### PR TITLE
fix random dash on hover

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -87,6 +87,11 @@
   }
 
   .product-features {
+    .accounts-row {
+      a:hover, a:focus {
+        text-decoration: none;
+      }
+    }
     img {
       height: 120px;
       width: auto;


### PR DESCRIPTION
# Summary
references #289 
CSS class that adds underlines to links when hovered was causing a unwanted dash after the repository images. This MR removes the CSS class that adds the underlines to these specific linked images

# Screenshots / Video

# Expected Behavior
hovering over tenant images on the homepage will not add a small dash between images

# Notes

