### PR TITLE
sort homepage by cname

### DIFF
--- a/app/controllers/splash_controller.rb
+++ b/app/controllers/splash_controller.rb
@@ -2,7 +2,7 @@
 
 class SplashController < ProprietorController
   def index
-    @accounts = Account.where('is_public = ?', true).order(name: :asc)
+    @accounts = Account.where('is_public = ?', true).order(cname: :asc)
     @images = []
     @alt_text = []
     @accounts.map do |account|


### PR DESCRIPTION
# Summary
references #291 
Accounts on homepage are sorting by name. Client would like the images on the homepage to sort by cname. There are tenants where the name is different from the cname and it is causing confusion

# Screenshots / Video

# Expected Behavior
tenant images on the homepage sort alphabetically


