### PR TITLE
set splash header font size to 15pts 22px

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -52,7 +52,7 @@
   h1 {
     font-family: $splash-font-family;
     color: $jumbotron-heading-color;
-    font-size: 30px;
+    font-size: 20px;
     font-weight: 400;
   }
 
@@ -62,12 +62,14 @@
     font-size: 1.6em;
     font-weight: 400;
     margin-bottom: 20px;
+    font-size: 18px;
   }
 
   h2 {
     font-family: $splash-font-family;
     color: $jumbotron-sub-heading-color;
     font-weight: 400;
+    font-size: 20px;
   }
 
   .navbar {


### PR DESCRIPTION
# Summary
references #292 

# Expected Behavior
Client asks for smaller headline size font on the splash page. Changed the fontsize to 22px to match BL font

