### PR TITLE
reorder required fields in generic work and image

### DIFF
--- a/app/forms/hyrax/generic_work_form.rb
+++ b/app/forms/hyrax/generic_work_form.rb
@@ -9,6 +9,6 @@ module Hyrax
     include HydraEditor::Form::Permissions
     self.terms += %i[resource_type additional_information bibliographic_citation]
     self.terms -=%i[based_near]
-    self.required_fields += %i[keyword]
+    self.required_fields = %i[title creator keyword rights_statement]
   end
 end

--- a/app/forms/hyrax/image_form.rb
+++ b/app/forms/hyrax/image_form.rb
@@ -8,6 +8,6 @@ module Hyrax
     self.model_class = ::Image
     self.terms += %i[resource_type extent additional_information bibliographic_citation]
     self.terms -=%i[based_near]
-    self.required_fields += %i[keyword]
+    self.required_fields = %i[title creator keyword rights_statement]
   end
 end


### PR DESCRIPTION
# Summary
references: #294 

Places keyword before rights_statement on the GenericWork and Image forms


![image](https://user-images.githubusercontent.com/18175797/202055630-a62a7112-8a45-4d23-87d7-a7695051ae98.png)
![image](https://user-images.githubusercontent.com/18175797/202055675-44919e91-299f-45f9-aa34-6752a064cc84.png)



