### PR TITLE
I268 worktype labels

### DIFF
--- a/app/presenters/hyku/work_show_presenter.rb
+++ b/app/presenters/hyku/work_show_presenter.rb
@@ -33,6 +33,14 @@ module Hyku
       def list_of_item_ids_to_display
         paginated_item_list(page_array: members)
       end
+
+      def page_title
+        if human_readable_type == "Generic Work"
+          "#{title.first} | ID: #{id} | #{I18n.t('hyrax.product_name')}"
+        else
+          "#{human_readable_type} | #{title.first} | ID: #{id} | #{I18n.t('hyrax.product_name')}"
+        end 
+      end
     end
 
     # OVERRIDE here for featured collection methods

--- a/app/presenters/hyrax/etd_presenter.rb
+++ b/app/presenters/hyrax/etd_presenter.rb
@@ -12,5 +12,9 @@ module Hyrax
              :department,
              :abstract,
              to: :solr_document
+
+    def human_readable_type
+      Etd.model_name.i18n_key.upcase
+    end
   end
 end

--- a/app/presenters/hyrax/oer_presenter.rb
+++ b/app/presenters/hyrax/oer_presenter.rb
@@ -25,6 +25,10 @@ module Hyrax
       paginated_item_list(page_array: authorized_related_items)
     end
 
+    def human_readable_type
+      Oer.model_name.i18n_key.upcase
+    end
+
     private
 
       # gets list of ids for previous versions

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -10,7 +10,7 @@
 <%= render 'shared/additional_citations' %>
 <div class="row work-type">
   <div class="col-sm-12">
-    <%= render 'work_type', presenter: @presenter %>
+    <%= render 'work_type', presenter: @presenter unless @presenter.human_readable_type == "Generic Work" %>
   </div>
   <div itemscope itemtype="http://schema.org/CreativeWork" class="col-xs-12">
     <%= render 'work_title', presenter: @presenter %>


### PR DESCRIPTION
# Summary
ref: #268 
This PR does a few things:
- remove "Generic Work" from the page titles (so it will not show in the browser tab, search results)
- remove "Generic Work" for the work show page
- Upcases OER and ETD on page titles (browser tab, search results)

# Screenshots / Video
![image](https://user-images.githubusercontent.com/18175797/203167987-4c6485cf-e923-4f20-8698-1030d87b5868.png)

# Expected Behavior
Browser tab and search results will show updated text as per client