### PR TITLE
remove-form-validations-as-they-conflict-with-negative-captcha

### DIFF
--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   build:
-    uses: scientist-softserv/actions/.github/workflows/build.yaml@v0.0.5
+    uses: scientist-softserv/actions/.github/workflows/build.yaml@v005-but-on-github-runners
     secrets: inherit
     with:
       target: hyku-base
@@ -24,11 +24,11 @@ jobs:
       workerTarget: hyku-worker
   test:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.5
+    uses: scientist-softserv/actions/.github/workflows/test.yaml@v005-but-on-github-runners
     with:
       worker: true
   lint:
     needs: build
-    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.5
+    uses: scientist-softserv/actions/.github/workflows/lint.yaml@v005-but-on-github-runners
     with:
       worker: true

--- a/app/controllers/hyrax/contact_form_controller.rb
+++ b/app/controllers/hyrax/contact_form_controller.rb
@@ -52,7 +52,7 @@ module Hyrax
     end
 
     def create
-      # not spam and a valid form
+      # not spam, form is valid, and captcha is valid
       if @contact_form.valid? && @captcha.valid?
         ContactMailer.contact(@contact_form).deliver_now
         flash.now[:notice] = 'Thank you for your message!'
@@ -60,7 +60,8 @@ module Hyrax
         @contact_form = model_class.new
       else
         flash.now[:error] = 'Sorry, this message was not sent successfully. ' +
-                            @contact_form.errors.full_messages.map(&:to_s).join(", ")
+                            @contact_form.errors.full_messages.map(&:to_s).join(", ") + '' +
+                            @captcha.error if @captcha.error
       end
       render :new
     rescue RuntimeError => exception
@@ -130,6 +131,6 @@ module Hyrax
           css: "display: none",
           params: params
         )
-      end  
+      end
   end
 end

--- a/app/controllers/hyrax/contact_form_controller.rb
+++ b/app/controllers/hyrax/contact_form_controller.rb
@@ -60,8 +60,8 @@ module Hyrax
         @contact_form = model_class.new
       else
         flash.now[:error] = 'Sorry, this message was not sent successfully. ' +
-                            @contact_form.errors.full_messages.map(&:to_s).join(", ") + '' +
-                            @captcha.error if @captcha.error
+                            @contact_form.errors.full_messages.map(&:to_s).join(", ") + 
+                            "" + @captcha.error
       end
       render :new
     rescue RuntimeError => exception

--- a/app/models/hyrax/contact_form.rb
+++ b/app/models/hyrax/contact_form.rb
@@ -5,7 +5,6 @@ module Hyrax
   class ContactForm
     include ActiveModel::Model
     attr_accessor :contact_method, :category, :name, :email, :subject, :message
-    validates :email, :category, :name, :subject, :message, presence: true
     validates :email, format: /\A([\w\.%\+\-]+)@([\w\-]+\.)+([\w]{2,})\z/i, allow_blank: true
 
     # - can't use this without ActiveRecord::Base


### PR DESCRIPTION
Ref Ticket: https://github.com/scientist-softserv/palni-palci/issues/279

We have html required: true on each form field.
Removing the validations from the controller allows the user to submit their fields while robot fields left unfilled will not give the user a validation error.

But when the robot fills out the negative captcha form fields that are not visible to the user will not be able to submit the form and an error will appear with the captcha error.