### PR TITLE
uses f.object.model in form partial

### DIFF
--- a/app/views/records/edit_fields/_default.html.erb
+++ b/app/views/records/edit_fields/_default.html.erb
@@ -1,0 +1,18 @@
+<%# OVERRIDE: HydraEditor 5.0.5 support dynamic labels and hints for custom worktypes %>
+<%# Avoid NoMethod error when rendering partial in Collection or batch edit form %>
+
+  <% record = f.object.model %>
+  <% if f.object.multiple? key %>
+    <%= f.input key,
+        as: :multi_value,
+        label: label_for(term: key, record_class: record.class),
+        hint: hint_for(term: key, record_class: record.class),
+        input_html: { class: 'form-control' },
+        required: f.object.required?(key) %>
+  <% else %>
+    <%= f.input key,
+        label: label_for(term: key, record_class: record.class),
+        hint: hint_for(term: key, record_class: record.class),
+        required: f.object.required?(key) %>
+  <% end %>
+


### PR DESCRIPTION
# Summary
fixes #185 rework
-Uses f.object.model instead of `@collection || curation_concern` as neither of those existed with batch edits. This allows for custom labels for different worktypes that use the same property. 
-Updated the code comment for override to use the correct location of the original partial

# Expected Behavior
Selecting multiple works and choosing edit from the admin dashboard should not throw error.

