### PR TITLE
hiding favicon tab until it works

### DIFF
--- a/app/helpers/hyrax_helper.rb
+++ b/app/helpers/hyrax_helper.rb
@@ -21,6 +21,10 @@ module HyraxHelper
     Site.instance.banner_image? ? Site.instance.banner_image.url : super
   end
 
+  def favicon
+    Site.instance.favicon? ? Site.instance.favicon.url : super
+  end
+
   def logo_image
     Site.instance.logo_image? ? Site.instance.logo_image.url : false
   end

--- a/app/views/hyrax/admin/appearances/show.html.erb
+++ b/app/views/hyrax/admin/appearances/show.html.erb
@@ -9,7 +9,8 @@
         <li class="active">
           <a href="#logo_image" role="tab" data-toggle="tab"><%= t('.tabs.logo') %></a>
         </li>
-        <li>
+        <!-- Hide FAVICON until https://github.com/scientist-softserv/palni-palci/issues/149 is solved -->
+        <li class="hidden">
           <a href="#favicon" role="tab" data-toggle="tab"><%= t('.tabs.favicon') %></a>
         </li>
         <li>


### PR DESCRIPTION
# Summary
ref: #149 
Favicon is erroring in staging. This MR hides the favicon tab for users, while allowing us to debug in staging. 

This will allow a deploy to production without removing all of the favicon code.