### PR TITLE
try using a post request to solr to increase query size

### DIFF
--- a/app/services/hyrax/solr_query_service_decorator.rb
+++ b/app/services/hyrax/solr_query_service_decorator.rb
@@ -1,0 +1,12 @@
+# OVERRIDE: Hyrax 3.4.1 changes GET request to POST to allow for larger query size
+
+# frozen_string_literal: true
+module Hyrax
+  module SolrQueryServiceDecorator
+    def get
+      solr_service.post(build)
+    end
+  end
+end
+
+Hyrax::SolrQueryService.prepend(Hyrax::SolrQueryServiceDecorator)

--- a/app/services/hyrax/solr_query_service_decorator.rb
+++ b/app/services/hyrax/solr_query_service_decorator.rb
@@ -1,6 +1,7 @@
 # OVERRIDE: Hyrax 3.4.1 changes GET request to POST to allow for larger query size
 
 # frozen_string_literal: true
+
 module Hyrax
   module SolrQueryServiceDecorator
     def get


### PR DESCRIPTION
# Summary
ref: #334 
Error occurs when visiting the review submissions section of admin dashboard: `RSolr::Error::Http - 414 Request-URI Too Long
Error: reason: URI Too Long`
This MR changes the get request to a post request. Post requests to solr allow for 2MB while get requests 8192 bytes. Using the post request should make no difference to solr.

# Expected Behavior
When there are a lot of items on the review submissions tab, you should not receive an error that the query request is too long.
# Notes

This error only occurs when there are a lot of items to display on the review submissions tab
