### PR TITLE
workflow actions header color

### DIFF
--- a/app/assets/stylesheets/themes/cultural_repository.scss
+++ b/app/assets/stylesheets/themes/cultural_repository.scss
@@ -194,6 +194,11 @@
     }
   }
 
+  // prevent cultural repository theme override to the workflow actions header background
+  .panel-default .panel-workflow .panel-heading {
+    background-color: #e6ab5f !important;
+  }
+
   // Note: copied over to override /* line 7, /usr/local/bundle/gems/bootstrap-sass-3.4.1/assets/stylesheets/bootstrap/_panels.scss */
   .panel {
     background-color: #fff !important;


### PR DESCRIPTION
# Summary
ref: #337 

When cultural repo is selected, the panel header color overrides the workflow actions panel. This adds CSS to the cultural repository them to prevent that override.

# Expected Behavior
When cultural repo is selected, the workflow actions panel has a gold background color

# Screenshot
![image](https://user-images.githubusercontent.com/18175797/205997241-70dfff00-dd54-40ba-9c05-3e655b001958.png)
