### PR TITLE
show favicon tab

### DIFF
--- a/app/views/hyrax/admin/appearances/show.html.erb
+++ b/app/views/hyrax/admin/appearances/show.html.erb
@@ -9,8 +9,7 @@
         <li class="active">
           <a href="#logo_image" role="tab" data-toggle="tab"><%= t('.tabs.logo') %></a>
         </li>
-        <!-- Hide FAVICON until https://github.com/scientist-softserv/palni-palci/issues/149 is solved -->
-        <li class="hidden">
+        <li>
           <a href="#favicon" role="tab" data-toggle="tab"><%= t('.tabs.favicon') %></a>
         </li>
         <li>


### PR DESCRIPTION
# Summary
ref: #149 
Needed to run migrations on staging in order to get the favicons to save. This mr unhides the favicon tab
