### PR TITLE
fix-build-issue-arm-vs-amd

### DIFF
--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -36,12 +36,12 @@ jobs:
     with:
       target: hyku-worker
   test:
-    needs: build-web
+    needs: [build-web, build-worker]
     uses: scientist-softserv/actions/.github/workflows/test.yaml@v0.0.5
     with:
       worker: true
   lint:
-    needs: build-web
+    needs: [build-web, build-worker]
     uses: scientist-softserv/actions/.github/workflows/lint.yaml@v0.0.5
     with:
       worker: true

--- a/.github/workflows/build-test-lint.yaml
+++ b/.github/workflows/build-test-lint.yaml
@@ -16,22 +16,22 @@ on:
 
 jobs:
   build-web:
-    uses: scientist-softserv/actions/.github/workflows/build-web.yaml@arm-wrestle
+    uses: scientist-softserv/actions/.github/workflows/build-web.yaml@fix-build-issue-arm-vs-amd
     secrets: inherit
     with:
       target: hyku-base
   build-web-arm64:
-    uses: scientist-softserv/actions/.github/workflows/build-web-arm64.yaml@arm-wrestle
+    uses: scientist-softserv/actions/.github/workflows/build-web-arm64.yaml@fix-build-issue-arm-vs-amd
     secrets: inherit
     with:
       target: hyku-base
   build-worker:
-    uses: scientist-softserv/actions/.github/workflows/build-worker.yaml@arm-wrestle
+    uses: scientist-softserv/actions/.github/workflows/build-worker.yaml@fix-build-issue-arm-vs-amd
     secrets: inherit
     with:
       target: hyku-worker
   build-worker-arm64:
-    uses: scientist-softserv/actions/.github/workflows/build-worker-arm64.yaml@arm-wrestle
+    uses: scientist-softserv/actions/.github/workflows/build-worker-arm64.yaml@fix-build-issue-arm-vs-amd
     secrets: inherit
     with:
       target: hyku-worker


### PR DESCRIPTION
Ref Action Branch: https://github.com/scientist-softserv/actions/pull/19/files

Updates to the actions branch fix-build-issue-arm-vs-amd to test out a solution for the issue we are experiencing with having deployments fail sporadically with the image we expect to be amd64 but after the arm64 image was getting built and pushed would overwrite the amd64 image needed for deployments.