### PR TITLE
update-500-public-img-to-src

### DIFF
--- a/public/500.html
+++ b/public/500.html
@@ -180,14 +180,5 @@
         <div class="bar"></div>
       </div>
     </div>
-    <script src="https://code.jquery.com/jquery-1.10.2.js"></script>
-    <script src="js/main.js" type="text/javascript"></script>
-    <script>
-      $(function() {
-        setTimeout(function(){
-          $('body').removeClass('loading');
-        }, 1000);
-      });
-    </script>
   </body>
 </html>

--- a/public/500.html
+++ b/public/500.html
@@ -8,14 +8,8 @@
         color: #2e74b2;
       }
       .splash-logo {
-        background: url("Hyku_Commons_Logo.png") no-repeat;
-        background-size: contain;
-        height: 120px;
-        width: 310px;
-        margin-top: 100px;
-        margin-bottom: 50px;
-        margin-left: auto;
-        margin-right: auto;
+        text-align: center;
+        margin: 100px auto 50px;
       }
       /**/
       :root {
@@ -165,6 +159,7 @@
   <link href="https://fonts.googleapis.com/css?family=Encode+Sans+Semi+Condensed:100,200,300,400" rel="stylesheet">
   <body class="loading">
     <div class="splash-logo">
+      <img src="Hyku_Commons_Logo.png" height="120" alt="Hyku Commons Logo" />
     </div>
     <h1>500</h1>
     <h2>An unexpected error occurred. </br>Please <a class="public" href="mailto:help@hykuforconsortia.org">email us</a> if you continue to experience this error.</h2>

--- a/public/500.html
+++ b/public/500.html
@@ -159,7 +159,7 @@
   <link href="https://fonts.googleapis.com/css?family=Encode+Sans+Semi+Condensed:100,200,300,400" rel="stylesheet">
   <body class="loading">
     <div class="splash-logo">
-      <img src="Hyku_Commons_Logo.png" height="120" alt="Hyku Commons Logo" />
+      <img src="/Hyku_Commons_Logo.png" height="120" alt="Hyku Commons Logo" />
     </div>
     <h1>500</h1>
     <h2>An unexpected error occurred. </br>Please <a class="public" href="mailto:help@hykuforconsortia.org">email us</a> if you continue to experience this error.</h2>


### PR DESCRIPTION
Seeing error on demo when hitting a 500 error and being able to have the logo render inside a tenant 500 error since the image in in the public dir, each tenant is looking in their public dir. To solve this I am setting the image as an html img src tag

Error:
```
olr query: get select {:qt=>"document", :id=>"Hyku_Commons_Logo"}
D, [2022-12-20T22:22:33.159534 #1] DEBUG -- : [7b6309264628a35b70dfb88f70ac2e05] Solr fetch (11.0ms)
I, [2022-12-20T22:22:33.159929 #1]  INFO -- : [7b6309264628a35b70dfb88f70ac2e05] Completed 404 Not Found in 202ms (ActiveRecord: 65.3ms)
D, [2022-12-20T22:22:33.161318 #1] DEBUG -- : [7b6309264628a35b70dfb88f70ac2e05]   [1m[36mAccount Load (0.3ms)[0m  [1m[34mSELECT  "public"."accounts".* FROM "public"."accounts" WHERE "public"."accounts"."tenant" = $1 LIMIT $2[0m  [["tenant", "public"], ["LIMIT", 1]]
I, [2022-12-20T22:22:33.175917 #1]  INFO -- : [7b6309264628a35b70dfb88f70ac2e05] Sending event aa5430e27d794adb965288ad6e3ba6fb to Sentry
F, [2022-12-20T22:22:33.275277 #1] FATAL -- : [7b6309264628a35b70dfb88f70ac2e05]   
F, [2022-12-20T22:22:33.275345 #1] FATAL -- : [7b6309264628a35b70dfb88f70ac2e05] Blacklight::Exceptions::RecordNotFound (Blacklight::Exceptions::RecordNotFound):
F, [2022-12-20T22:22:33.275369 #1] FATAL -- : [7b6309264628a35b70dfb88f70ac2e05]   
F, [2022-12-20T22:22:33.275397 #1] FATAL -- : [7b6309264628a35b70dfb88f70ac2e05] app/controllers/concerns/hyrax/works_controller_behavior.rb:296:in `search_result_document'
[7b6309264628a35b70dfb88f70ac2e05] app/controllers/concerns/hyrax/works_controller_behavior.rb:227:in `presenter'
[7b6309264628a35b70dfb88f70ac2e05] app/controllers/concerns/hyrax/works_controller_behavior.rb:512:in `inject_show_theme_views'
[7b6309264628a35b70dfb88f70ac2e05] app/middleware/no_cache_middleware.rb:13:in `call'
10.0.4.231, 10.0.5.221 - - [20/Dec/2022:22:22:33 +0000] "GET /404 HTTP/1.0" 404 1564 0.3810

```
https://dev.commons-archive.org/concern/images/fe135de6-06e4-440e-9818-86e4560ed31a?locale=en
<img width="1728" alt="Screenshot 2022-12-20 at 17 25 41" src="https://user-images.githubusercontent.com/63515648/208798772-e6c40440-7f0f-4a40-ab55-38075caed9d0.png">

