### PR TITLE
fix-solr-bl-adapter-issue

### DIFF
--- a/app/models/solr_endpoint.rb
+++ b/app/models/solr_endpoint.rb
@@ -10,7 +10,7 @@ class SolrEndpoint < Endpoint
 
   # @return [Hash] options for the RSolr connection.
   def connection_options
-    bl_defaults = Blacklight.connection_config
+    bl_defaults = Blacklight.blacklight_yml[::Rails.env].symbolize_keys
     af_defaults = ActiveFedora::SolrService.instance.conn.options
     switchable_options.reverse_merge(bl_defaults).reverse_merge(af_defaults)
   end


### PR DESCRIPTION
Adds the connection to the blacklight.yml instead of using the cached values