### PR TITLE
reverting commit

### DIFF
--- a/app/models/solr_endpoint.rb
+++ b/app/models/solr_endpoint.rb
@@ -10,7 +10,7 @@ class SolrEndpoint < Endpoint
 
   # @return [Hash] options for the RSolr connection.
   def connection_options
-    bl_defaults = Blacklight.blacklight_yml[::Rails.env].symbolize_keys
+    bl_defaults = Blacklight.connection_config
     af_defaults = ActiveFedora::SolrService.instance.conn.options
     switchable_options.reverse_merge(bl_defaults).reverse_merge(af_defaults)
   end


### PR DESCRIPTION
- Seeing errors when trying to create an adminset
- As a superadmin after creating a tenant I click "Edit" on that tenant and scroll down to solr endpoint url form field, and notice `Solr not initialized`
Reverting this commit till we can investigate more
