### PR TITLE
i359-devise-emails-not-sending

### DIFF
--- a/app/controllers/hyku/invitations_controller.rb
+++ b/app/controllers/hyku/invitations_controller.rb
@@ -15,7 +15,7 @@ module Hyku
       self.resource = User.find_by(email: params[:user][:email]) || invite_resource
       resource_invited = resource.errors.empty?
 
-            # Set roles, whether they are a new user or not
+      # Set roles, whether they are a new user or not
       # safe because adding the same role twice is a noop
       site = Site.instance
       if params[:user][:roles].present?
@@ -37,7 +37,7 @@ module Hyku
           respond_with resource, location: after_invite_path_for(current_inviter, resource)
         end
       else
-        respond_with_navigational(resource) { render :new }
+        respond_with resource, location: after_invite_path_for(current_inviter, resource)
       end
     end
 

--- a/app/controllers/hyku/invitations_controller.rb
+++ b/app/controllers/hyku/invitations_controller.rb
@@ -28,17 +28,18 @@ module Hyku
       yield resource if block_given?
 
       if resource_invited
-        if is_flashing_format? && self.resource.invitation_sent_at
-          set_flash_message :notice, :send_instructions, email: self.resource.email
+        # Override destination as this was a success either way
+        if is_flashing_format? && resource.invitation_sent_at
+          set_flash_message :notice, :send_instructions, email: resource.email
         end
-        if self.method(:after_invite_path_for).arity == 1
+        if method(:after_invite_path_for).arity == 1
           respond_with resource, location: after_invite_path_for(current_inviter)
-        else
-          respond_with resource, location: after_invite_path_for(current_inviter, resource)
         end
       else
         respond_with resource, location: after_invite_path_for(current_inviter, resource)
       end
+
+      super
     end
 
     protected

--- a/app/mailers/hyku_mailer.rb
+++ b/app/mailers/hyku_mailer.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
+# https://github.com/heartcombo/devise/wiki/How-To:-Use-custom-mailer
 # Provides a default host for the current tenant
-class HykuMailer < ActionMailer::Base
+class HykuMailer < Devise::Mailer
   def default_url_options
     { host: host_for_tenant }
   end

--- a/app/views/devise/invitations/edit.html.erb
+++ b/app/views/devise/invitations/edit.html.erb
@@ -1,0 +1,11 @@
+<h2><%= t 'devise.invitations.edit.header' %></h2>
+
+<%= simple_form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :put } do |f| %>
+  <%= devise_error_messages! %>
+  <%= f.hidden_field :invitation_token %>
+
+  <%= f.input :password %>
+  <%= f.input :password_confirmation %>
+
+  <%= f.button :submit, t("devise.invitations.edit.submit_button") %>
+<% end %>

--- a/app/views/devise/invitations/new.html.erb
+++ b/app/views/devise/invitations/new.html.erb
@@ -1,0 +1,11 @@
+<h2><%= t "devise.invitations.new.header" %></h2>
+
+<%= simple_form_for resource, as: resource_name, url: invitation_path(resource_name), html: { method: :post} do |f| %>
+  <%= devise_error_messages! %>
+
+<% resource.class.invite_key_fields.each do |field| -%>
+  <%= f.input field %>
+<% end -%>
+
+<%= f.button :submit, t("devise.invitations.new.submit_button") %>
+<% end %>

--- a/app/views/devise/mailer/invitation_instructions.html.erb
+++ b/app/views/devise/mailer/invitation_instructions.html.erb
@@ -1,0 +1,11 @@
+<p><%= t("devise.mailer.invitation_instructions.hello", email: @resource.email) %></p>
+
+<p><%= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url) %></p>
+
+<p><%= link_to t("devise.mailer.invitation_instructions.accept"), accept_invitation_url(@resource, :invitation_token => @token) %></p>
+
+<% if @resource.invitation_due_at %>
+  <p><%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %></p>
+<% end %>
+
+<p><%= t("devise.mailer.invitation_instructions.ignore") %></p>

--- a/app/views/devise/mailer/invitation_instructions.text.erb
+++ b/app/views/devise/mailer/invitation_instructions.text.erb
@@ -1,0 +1,11 @@
+<%= t("devise.mailer.invitation_instructions.hello", email: @resource.email) %>
+
+<%= t("devise.mailer.invitation_instructions.someone_invited_you", url: root_url) %>
+
+<%= accept_invitation_url(@resource, :invitation_token => @token) %>
+
+<% if @resource.invitation_due_at %>
+  <%= t("devise.mailer.invitation_instructions.accept_until", due_date: l(@resource.invitation_due_at, format: :'devise.mailer.invitation_instructions.accept_until_format')) %>
+<% end %>
+
+<%= t("devise.mailer.invitation_instructions.ignore") %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -15,10 +15,11 @@ Devise.setup do |config|
   config.mailer_sender = ENV.fetch('HYKU_CONTACT_EMAIL', 'changeme@example.com')
 
   # Configure the class responsible to send e-mails.
-  # config.mailer = 'Devise::Mailer'
+  config.mailer = 'HykuMailer'
 
-  # Configure the parent class responsible to send e-mails.
-  config.parent_mailer = 'HykuMailer'
+  # Configure the parent class responsible to send e-mails, this class
+  # will be prepended to the Devise::Mailer class to inherit from.
+  config.parent_mailer = 'ActionMailer::Base'
 
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and


### PR DESCRIPTION
Ref Ticket: https://github.com/scientist-softserv/palni-palci/issues/359

# Summary
- Updates the create method to have a wrapper that checks for errors before displaying the Green Banner with the saying you have successfully created a user. 
- Updates the HykuMailer to inherit from Devise::Mailer class, setting the HykuMailer class and the email sender and added ActiveRecord::Base as the parent because devise prepends that class onto the back of their mailer to inherit from to make it easy to inherit from another class.

# Documentation
- https://github.com/heartcombo/devise/wiki/How-To:-Use-custom-mailer
- https://github.com/scambra/devise_invitable/blob/v1.7.5/app/controllers/devise/invitations_controller.rb#L18-L36
- https://www.rubyinrails.com/2019/09/16/override-devise-mailer-in-rails/
- https://github.com/scambra/devise_invitable#label-Send+an+invitation

# Testing Instructions
**Use Case One**: As a superadmin user I create a new user and the new user is not receiving the confirmation email.
- Go to the Proprietor page, login as a superadmin
- Go up to Users (next to Accounts) in the upper left hand corner of the page
- Click the blue "Create New" blue button in the upper right hand of the page
- Add Email address (Note: youremail@scientist.com can also be youremail+whateveryouwant@scientist.com)
- Add a password for the new user you are creating
- Optional: If you want a superadmin user check that box
- Click save and check your inbox (may take some time, up to ~10 mins?)

**Use case Two-Alpha**: As any user when I go to the proprietor login page and click "Forgot Password" and enter my email and click "Send me reset password instructions", I never receive the reset password instructions email.
- Go to the proprietor page click on "Admin" and navigate to the [sign_in page](https://commons-archive.org/users/sign_in?locale=en) 
- After getting to the login page click the "Forgot password" link
- Enter your email, click "Send me reset password instructions", and check your inbox (may take some time, up to ~10 mins?)

**Use case Two-Bravo**: As any user of a tenant when I go to the tenant login page and click "Forgot Password" and enter my email and click "Send me reset password instructions", I never receive the reset password instructions email.
- Go to any tenant page and click on "Login" and navigate to the [sign_in page](https://dev.commons-archive.org/users/sign_in?) 
- After getting to the login page click the "Forgot password" link
- Enter your email, click "Send me reset password instructions", and check your inbox (may take some time, up to ~10 mins?)