### PR TITLE
add-email-from

### DIFF
--- a/ops/demo-deploy.tmpl.yaml
+++ b/ops/demo-deploy.tmpl.yaml
@@ -109,7 +109,7 @@ extraEnvVars: &envVars
   - name: HYKU_BULKRAX_ENABLED
     value: "true"
   - name: HYKU_CONTACT_EMAIL
-    value: support@notch8.com
+    value: info@commons-archive.org
   - name: HYKU_DEFAULT_HOST
     value: "%{tenant}.commons-archive.org"
   - name: HYKU_FILE_ACL

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -109,7 +109,7 @@ extraEnvVars: &envVars
   - name: HYKU_BULKRAX_ENABLED
     value: "true"
   - name: HYKU_CONTACT_EMAIL
-    value: support@notch8.com
+    value: info@hykucommons.org
   - name: HYKU_DEFAULT_HOST
     value: "%{tenant}.hykucommons.org"
   - name: HYKU_FILE_ACL


### PR DESCRIPTION
 `HYKU_CONTACT_EMAIL` needed to be set with an email from the approved domain set in AWS SES. 