### PR TITLE
i406-create-work-no-files 

### DIFF
--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -103,7 +103,7 @@ Hyrax.config do |config|
   # Should work creation require file upload, or can a work be created first
   # and a file added at a later time?
   # The default is true.
-  # config.work_requires_files = true
+  config.work_requires_files = false
 
   # Should a button with "Share my work" show on the front page to all users (even those not logged in)?
   # config.display_share_button_when_not_logged_in = true


### PR DESCRIPTION
# Summary

set require files to false

refs #406 Pals wants to allow users to upload works without files.  Setting `config.work_requires_files = false` removes the `File` requirement on the `New Work Form` in the UI.

# Screenshots / Video

<details><summary>Before code changes:</summary>

![Image   Hyku Commons 2023-02-27 at 4 04 58 PM](https://user-images.githubusercontent.com/29311858/221721700-a89f7671-ee72-4658-8216-16a991a26df7.jpg)
![Image before code changes work must have file ID 8769b318-9437-4c22-8bc4-fd92897d6dde Hyku Commons 2023-02-27 at 4 30 04 PM](https://user-images.githubusercontent.com/29311858/221721708-73b408b1-985d-49a4-91ac-91208eb0f0af.jpg)</details>

<details><summary>After code changes:</summary>

![Image   Hyku Commons 2023-02-27 at 4 27 00 PM](https://user-images.githubusercontent.com/29311858/221721799-30a80cea-6ddb-4c26-ae75-68f43ae942cd.jpg)
![Image after code changes work does not require file ID 13c9beb8-55be-4405-a866-194c6be16a9d Hyku Commons 2023-02-27 at 4 30 19 PM](https://user-images.githubusercontent.com/29311858/221721804-6de30c52-615d-4838-b153-c2830d068adf.jpg)</details>

# Expected Behavior

- [x] Users are no longer required to upload a file for works through the UI's `New Work Form`