### PR TITLE
i405-admin-notes

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -41,7 +41,7 @@ class CatalogController < ApplicationController
     config.default_solr_params = {
       qt: "search",
       rows: 10,
-      qf: "title_tesim alternative_title_tesim description_tesim creator_tesim contributor_tesim related_url_tesim learning_resource_type_tesim education_level_tesim audience_tesim degree_name_tesim degree_discipline_tesim degree_grantor_tesim date_tesim table_of_contents_tesim rights_statement_tesim license_tesim rights_holder_tesim additional_information_tesim oer_size_tesim publisher_tesim identifier_tesim keyword_tesim subject_tesim language_tesim resource_type_tesim date_created_tesim date_uploaded_tesim date_modified_tesim accessibility_feature_tesim accessibility_hazard_tesim accessibility_summary_tesim format_tesim extent_tesim all_text_timv"
+      qf: "admin_note_tesim title_tesim alternative_title_tesim description_tesim creator_tesim contributor_tesim related_url_tesim learning_resource_type_tesim education_level_tesim audience_tesim degree_name_tesim degree_discipline_tesim degree_grantor_tesim date_tesim table_of_contents_tesim rights_statement_tesim license_tesim rights_holder_tesim additional_information_tesim oer_size_tesim publisher_tesim identifier_tesim keyword_tesim subject_tesim language_tesim resource_type_tesim date_created_tesim date_uploaded_tesim date_modified_tesim accessibility_feature_tesim accessibility_hazard_tesim accessibility_summary_tesim format_tesim extent_tesim all_text_timv"
     }
 
     # Specify which field to use in the tag cloud on the homepage.
@@ -113,6 +113,7 @@ class CatalogController < ApplicationController
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
     config.add_show_field solr_name("title", :stored_searchable)
+    config.add_show_field solr_name('admin_note', :stored_searchable), label: "Administrative Notes"
     config.add_show_field solr_name("alternative_title", :stored_searchable), label: "Alternative title"
     config.add_show_field solr_name("creator", :stored_searchable)
     config.add_show_field solr_name("contributor", :stored_searchable)

--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -7,6 +7,7 @@ module Hyrax
     self.model_class = ::Etd
     include HydraEditor::Form::Permissions
 
+    self.terms.prepend(:admin_note).uniq!
     self.terms += [
       :resource_type,
       :format,

--- a/app/forms/hyrax/generic_work_form.rb
+++ b/app/forms/hyrax/generic_work_form.rb
@@ -7,6 +7,7 @@ module Hyrax
     include Hyrax::FormTerms
     self.model_class = ::GenericWork
     include HydraEditor::Form::Permissions
+    self.terms.prepend(:admin_note).uniq!
     self.terms += %i[resource_type additional_information bibliographic_citation]
     self.terms -=%i[based_near]
     self.required_fields = %i[title creator keyword rights_statement]

--- a/app/forms/hyrax/image_form.rb
+++ b/app/forms/hyrax/image_form.rb
@@ -6,6 +6,7 @@ module Hyrax
   class ImageForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::Image
+    self.terms.prepend(:admin_note).uniq!
     self.terms += %i[resource_type extent additional_information bibliographic_citation]
     self.terms -=%i[based_near]
     self.required_fields = %i[title creator keyword rights_statement]

--- a/app/forms/hyrax/oer_form.rb
+++ b/app/forms/hyrax/oer_form.rb
@@ -7,7 +7,7 @@ module Hyrax
     self.model_class = ::Oer
     include HydraEditor::Form::Permissions
 
-    self.terms = %i[title creator resource_type audience education_level learning_resource_type
+    self.terms = %i[admin_note title creator resource_type audience education_level learning_resource_type
                     discipline bibliographic_citation source rights_statement license rights_holder
                     rights_notes additional_information description subject language publisher oer_size
                     identifier table_of_contents alternative_title contributor related_url accessibility_feature

--- a/app/indexers/etd_indexer.rb
+++ b/app/indexers/etd_indexer.rb
@@ -16,6 +16,7 @@ class EtdIndexer < Hyrax::WorkIndexer
     super.tap do |solr_doc|
       solr_doc['bulkrax_identifier_tesim'] = object.bulkrax_identifier
       solr_doc['title_ssi'] = SortTitle.new(object.title.first).alphabetical
+      solr_doc['admin_note_tesim'] = object.admin_note
     end
   end
 end

--- a/app/indexers/generic_work_indexer.rb
+++ b/app/indexers/generic_work_indexer.rb
@@ -8,6 +8,7 @@ class GenericWorkIndexer < AppIndexer
     super.tap do |solr_doc|
       solr_doc['bulkrax_identifier_tesim'] = object.bulkrax_identifier
       solr_doc['title_ssi'] = SortTitle.new(object.title.first).alphabetical
+      solr_doc['admin_note_tesim'] = object.admin_note
     end
   end
 end

--- a/app/indexers/image_indexer.rb
+++ b/app/indexers/image_indexer.rb
@@ -8,6 +8,7 @@ class ImageIndexer < AppIndexer
     super.tap do |solr_doc|
       solr_doc['bulkrax_identifier_tesim'] = object.bulkrax_identifier
       solr_doc['title_ssi'] = SortTitle.new(object.title.first).alphabetical
+      solr_doc['admin_note_tesim'] = object.admin_note
     end
   end
 end

--- a/app/indexers/oer_indexer.rb
+++ b/app/indexers/oer_indexer.rb
@@ -16,6 +16,7 @@ class OerIndexer < Hyrax::WorkIndexer
     super.tap do |solr_doc|
       solr_doc['bulkrax_identifier_tesim'] = object.bulkrax_identifier
       solr_doc['title_ssi'] = SortTitle.new(object.title.first).alphabetical
+      solr_doc['admin_note_tesim'] = object.admin_note
     end
   end
 end

--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -52,6 +52,10 @@ class Etd < ActiveFedora::Base
     index.as :stored_searchable
   end
 
+  property :admin_note, predicate: ::RDF::Vocab::SCHEMA.positiveNotes, multiple: false do |index|
+    index.as :stored_searchable
+  end
+
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -17,6 +17,10 @@ class GenericWork < ActiveFedora::Base
     index.as :stored_searchable, :facetable
   end
 
+  property :admin_note, predicate: ::RDF::Vocab::SCHEMA.positiveNotes, multiple: false do |index|
+    index.as :stored_searchable
+  end
+
   include ::Hyrax::BasicMetadata
   self.indexer = GenericWorkIndexer
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -21,6 +21,10 @@ class Image < ActiveFedora::Base
     index.as :stored_searchable, :facetable
   end
 
+  property :admin_note, predicate: ::RDF::Vocab::SCHEMA.positiveNotes, multiple: false do |index|
+    index.as :stored_searchable
+  end
+
   # This must come after the properties because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata

--- a/app/models/oer.rb
+++ b/app/models/oer.rb
@@ -89,6 +89,10 @@ class Oer < ActiveFedora::Base
     index.as :stored_searchable
   end
 
+  property :admin_note, predicate: ::RDF::Vocab::SCHEMA.positiveNotes, multiple: false do |index|
+    index.as :stored_searchable
+  end
+
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -56,7 +56,8 @@ class SolrDocument
   attribute :title_ssi, Solr::Array, 'title_ssi_tesim'
   attribute :bibliographic_citation, Solr::String, 'bibliographic_citation_tesi'
   attribute :collection_subtitle, Solr::String, 'collection_subtitle_tesi'
-  
+  attribute :admin_note, Solr::String, 'admin_note_tesi'
+
   field_semantics.merge!(
     contributor: 'contributor_tesim',
     creator: 'creator_tesim',

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -56,7 +56,7 @@ class SolrDocument
   attribute :title_ssi, Solr::Array, 'title_ssi_tesim'
   attribute :bibliographic_citation, Solr::String, 'bibliographic_citation_tesi'
   attribute :collection_subtitle, Solr::String, 'collection_subtitle_tesi'
-  attribute :admin_note, Solr::String, 'admin_note_tesi'
+  attribute :admin_note, Solr::String, 'admin_note_tesim'
 
   field_semantics.merge!(
     contributor: 'contributor_tesim',

--- a/app/presenters/hyku/work_show_presenter.rb
+++ b/app/presenters/hyku/work_show_presenter.rb
@@ -6,7 +6,7 @@ module Hyku
   class WorkShowPresenter < Hyrax::WorkShowPresenter
     Hyrax::MemberPresenterFactory.file_presenter_class = Hyrax::FileSetPresenter
 
-    delegate :title_or_label, :extent, :additional_information, :source, :bibliographic_citation, to: :solr_document
+    delegate :title_or_label, :extent, :additional_information, :source, :bibliographic_citation, :admin_note, to: :solr_document
 
     # OVERRIDE Hyrax v2.9.0 here to make featured collections work
     delegate :collection_presenters, to: :member_presenter_factory

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -1,3 +1,4 @@
+<%= presenter.attribute_to_html(:admin_note, html_dl: true) %>
 <%= presenter.attribute_to_html(:alternative_title, html_dl: true) %>
 <%= presenter.attribute_to_html(:creator, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:contributor, render_as: :faceted, html_dl: true) %>

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -1,4 +1,4 @@
-<%= presenter.attribute_to_html(:admin_note, html_dl: true) %>
+<%= presenter.attribute_to_html(:admin_note, html_dl: true) if presenter.editor? %>
 <%= presenter.attribute_to_html(:alternative_title, html_dl: true) %>
 <%= presenter.attribute_to_html(:creator, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:contributor, render_as: :faceted, html_dl: true) %>

--- a/app/views/hyrax/etds/_attribute_rows.html.erb
+++ b/app/views/hyrax/etds/_attribute_rows.html.erb
@@ -1,4 +1,4 @@
-<%= presenter.attribute_to_html(:alternative_title, html_dl: true) %>
+<%= presenter.attribute_to_html(:admin_note, html_dl: true) if presenter.editor? %>
 <%= presenter.attribute_to_html(:creator, render_as: :faceted, label: label_for(term: :creator, record_class: Etd), html_dl: true) %>
 <%= presenter.attribute_to_html(:contributor, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:subject, render_as: :faceted, html_dl: true) %>

--- a/app/views/hyrax/oers/_attribute_rows.html.erb
+++ b/app/views/hyrax/oers/_attribute_rows.html.erb
@@ -1,3 +1,4 @@
+<%= presenter.attribute_to_html(:admin_note, html_dl: true) if presenter.editor? %>
 <%= presenter.attribute_to_html(:title, html_dl: true) %>
 <%= presenter.attribute_to_html(:alternative_title, html_dl: true) %>
 <%= presenter.attribute_to_html(:creator, render_as: :faceted, html_dl: true) %>

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -30,6 +30,7 @@ en:
           rights_tesim: Rights
           subject_tesim: Subject
         show:
+          admin_note: Administrative Note
           based_near_label_tesim: Location
           contributor_tesim: Contributor
           creator_tesim: Creator

--- a/config/locales/etd.en.yml
+++ b/config/locales/etd.en.yml
@@ -25,3 +25,4 @@ en:
         related_url: "Related URL"
         resource_type: "Type"
         rights_statement: "Rights"
+        admin_note: "Administrative Notes"

--- a/config/locales/generic_work.en.yml
+++ b/config/locales/generic_work.en.yml
@@ -7,3 +7,6 @@ en:
       generic_work:
         description: General purpose work type. Select this if the more specific work types below are not suited to the work you want to add.
         name: Generic Work
+    generic_work:
+      labels:
+        admin_note: "Administrative Notes"

--- a/config/locales/image.en.yml
+++ b/config/locales/image.en.yml
@@ -7,3 +7,6 @@ en:
       image:
         description: Single or multi-page image works.
         name: Image
+    image:
+      labels:
+        admin_note: "Administrative Notes"

--- a/config/locales/oer.en.yml
+++ b/config/locales/oer.en.yml
@@ -14,6 +14,7 @@ en:
       labels:
         resource_type: "Type"
         description: "Description"
+        admin_note: "Administrative Notes"
       show:
         related_items: "Related Versions and Items"
       works:

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -51,6 +51,8 @@ en:
         gtm_id: Google tag manager
       add_user_to_group:
         user_ids: User ID
+      defaults:
+        admin_note: Administrative Notes
       domain_names:
         cname: Domain Name
       group_search:


### PR DESCRIPTION
# Story
add admin note to all work types

refs #405. Pals wants to add a new field on the `new/edit work form` called `Administrative Note`. This should sit towards the top of the form, but below all the required fields. Only those with edit access should be able to see this field on the work show page.

# Acceptance Criteria:
- [x] A new field exists on all worktypes with a label of 'Administrative Notes' and a hyku database name of 'admin_note' (Nic and Amanda, please confirm or adjust what names you would like.  The database name is what is used as the header on CSV importer).
     - [x] Dev note: Admin note appears on `new/edit work form` and `work show pages` for those with edit access for all 4 work types
          - [x] Works with UV
          - [x] Works without UV
- [x] The field is scoped to only be available to view/edit for users with roles of ( Please add roles this should be available for)
     - [x] Nic: `Ideally, access to the notes should be scaled to anyone who has edit access to that work. This means depositors should have access to it on works they have uploaded or new works, work editors should have access to it on all works, and if a work has been shared with a specific individual or group they should have access to the field. The field should display on the work page for any user who has edit access for that work.` 
- [x] Put after required fields.
     - [x] Dev note: This is after the required fields. It sits at the top of `Additional fields`

# Screenshots / Video

<details><summary>Users with edit access can see "Administrative Note" on new/edit work form for all 4 work types. This field is at the top of the form, but below the required fields</summary>

![pair with lea ann Generic Work  9bff4d72-9057-43d2-9868-22c2e8b2cbd1  Hyku Commons 2023-03-03 at 12 26 56 PM](https://user-images.githubusercontent.com/29311858/222824998-3daaab53-7d1c-4f6f-afee-1663baeb6dff.jpg)
![image with lea ann Image  17bbd89d-874a-4e61-b3f7-bbc2e39b3918  Hyku Commons 2023-03-03 at 12 27 28 PM](https://user-images.githubusercontent.com/29311858/222825010-84489757-0c04-42c3-9292-9bec82645a31.jpg)
![image with lea ann Image  17bbd89d-874a-4e61-b3f7-bbc2e39b3918  Hyku Commons 2023-03-03 at 12 27 57 PM](https://user-images.githubusercontent.com/29311858/222825017-2fbd93c5-9c0b-40a7-bb0e-661612c9f09f.jpg)
![oer with lea ann Oer  0209d106-0bfb-44e6-b07a-97dce162f28e  Hyku Commons 2023-03-03 at 12 28 17 PM](https://user-images.githubusercontent.com/29311858/222825025-ae572347-d0c5-4722-8369-e7a026cd98ea.jpg)
</details>

<details><summary>With UV: Users with edit access can see "Administrative Note" on work show page</summary>

![Image Image with UV - does admin note show ID 24975a38-4050-4677-b2bc-3ed59b1fe161 Hyku Commons 2023-03-03 at 12 07 26 PM](https://user-images.githubusercontent.com/29311858/222825480-7affa65c-d9a4-438d-b5ed-7862b56362a5.jpg)
![generic work - admin note ID 45aa28a4-53c9-4aeb-8a54-19071df5b148 Hyku Commons 2023-03-03 at 12 07 37 PM](https://user-images.githubusercontent.com/29311858/222825485-33897b7f-b44a-4d42-aafd-fbe4f8fffe71.jpg)
![ETD ETD with UV - does admin note show ID de1a481e-d92e-4193-838c-c0dcdd8e49e3 Hyku Commons 2023-03-03 at 12 08 31 PM](https://user-images.githubusercontent.com/29311858/222825489-679a3c84-0d46-433f-867a-105a9d1be9e4.jpg)
![OER oer - admin note ID 31b54484-7b07-4b72-9512-f06d1b0249c9 Hyku Commons 2023-03-03 at 12 09 28 PM](https://user-images.githubusercontent.com/29311858/222825501-d9e6d510-5634-480c-bd42-fc30b61d28aa.jpg)

</details>

<details><summary>Without UV: Users with edit access can see "Administrative Note" on work show page</summary>

![pair with lea ann ID 9bff4d72-9057-43d2-9868-22c2e8b2cbd1 Hyku Commons 2023-03-03 at 12 10 12 PM](https://user-images.githubusercontent.com/29311858/222825679-add07448-1f45-4578-8cec-41806733cf9b.jpg)
![Image image with lea ann ID 17bbd89d-874a-4e61-b3f7-bbc2e39b3918 Hyku Commons 2023-03-03 at 12 10 20 PM](https://user-images.githubusercontent.com/29311858/222825693-07188e2b-a3aa-44ed-846c-d851c8a743c2.jpg)
![OER oer with lea ann ID 0209d106-0bfb-44e6-b07a-97dce162f28e Hyku Commons 2023-03-03 at 12 10 31 PM](https://user-images.githubusercontent.com/29311858/222825707-ab690d91-5c06-4a60-8a11-d56d3a958ed7.jpg)
![ETD etd with lea ann ID 929dedf2-a0b2-432d-b57a-75aff7fdfadb Hyku Commons 2023-03-03 at 12 10 42 PM](https://user-images.githubusercontent.com/29311858/222825715-671edca2-45cf-4e76-a0ba-770035571730.jpg)

</details>

<details><summary>Users without edit access cannot see "Administrative Note" on work show page</summary>


![OER oer with lea ann ID 0209d106-0bfb-44e6-b07a-97dce162f28e Hyku Commons 2023-03-03 at 12 12 17 PM](https://user-images.githubusercontent.com/29311858/222826239-d4dbab66-0161-4e67-9eda-ec7ecc03f320.jpg)
![ETD etd with lea ann ID 929dedf2-a0b2-432d-b57a-75aff7fdfadb Hyku Commons 2023-03-03 at 12 12 25 PM](https://user-images.githubusercontent.com/29311858/222826243-f660f0e6-696f-442c-8cee-d08d25e01c2a.jpg)
![Image image with lea ann ID 17bbd89d-874a-4e61-b3f7-bbc2e39b3918 Hyku Commons 2023-03-03 at 12 12 05 PM](https://user-images.githubusercontent.com/29311858/222826246-32a64500-c118-42f8-853c-bd9caca7b5b8.jpg)
![pair with lea ann ID 9bff4d72-9057-43d2-9868-22c2e8b2cbd1 Hyku Commons 2023-03-03 at 12 11 52 PM](https://user-images.githubusercontent.com/29311858/222826248-ec7e58b7-7225-4935-9823-7cd8698ed744.jpg)
![OER oer - admin note ID 31b54484-7b07-4b72-9512-f06d1b0249c9 Hyku Commons 2023-03-03 at 12 11 45 PM](https://user-images.githubusercontent.com/29311858/222826250-8b89ef42-1d97-4bc4-9077-303235d73b32.jpg)
![ETD ETD with UV - does admin note show ID de1a481e-d92e-4193-838c-c0dcdd8e49e3 Hyku Commons 2023-03-03 at 12 11 37 PM](https://user-images.githubusercontent.com/29311858/222826252-c9df0cb7-c377-4d68-a759-1c6e1c34caf9.jpg)
![generic work - admin note ID 45aa28a4-53c9-4aeb-8a54-19071df5b148 Hyku Commons 2023-03-03 at 12 11 28 PM](https://user-images.githubusercontent.com/29311858/222826254-a0c279b1-ba10-4db6-9fd1-fc0bfe83c184.jpg)
![Image Image with UV - does admin note show ID 24975a38-4050-4677-b2bc-3ed59b1fe161 Hyku Commons 2023-03-03 at 12 11 18 PM](https://user-images.githubusercontent.com/29311858/222826257-6008399b-fddf-4bb1-b0e6-5ed53b8fc598.jpg)
</details>

# Expected Behavior

- [x] `Administrative Note` is a new field on the `new/edit work form`
- [x] This should sit towards the top of the form, but below all the required fields.
- [x] Only those with edit access should be able to see this field on the work show page.