### PR TITLE
i401 Add OrderAlready gem to all multi-valued metadata properties

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -149,4 +149,4 @@ gem 'pronto-rails_best_practices', require: false
 gem 'pronto-rails_schema', require: false
 gem 'pronto-rubocop', require: false
 
-gem "order_already", "~> 0.2.1"
+gem "order_already", "~> 0.3.0"

--- a/Gemfile
+++ b/Gemfile
@@ -148,3 +148,5 @@ gem 'pronto-flay', require: false
 gem 'pronto-rails_best_practices', require: false
 gem 'pronto-rails_schema', require: false
 gem 'pronto-rubocop', require: false
+
+gem "order_already", "~> 0.2.1"

--- a/Gemfile
+++ b/Gemfile
@@ -149,4 +149,4 @@ gem 'pronto-rails_best_practices', require: false
 gem 'pronto-rails_schema', require: false
 gem 'pronto-rubocop', require: false
 
-gem "order_already", "~> 0.3.0"
+gem "order_already", "~> 0.3.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -790,7 +790,7 @@ GEM
       rails (> 3.2.0)
     optimist (3.0.1)
     options (2.3.2)
-    order_already (0.2.1)
+    order_already (0.3.0)
       rails-html-sanitizer (~> 1.4)
     orm_adapter (0.5.0)
     os (1.1.4)
@@ -1284,7 +1284,7 @@ DEPENDENCIES
   mods (~> 2.4)
   negative_captcha
   okcomputer
-  order_already (~> 0.2.1)
+  order_already (~> 0.3.0)
   parser (~> 2.5.3)
   pg
   postrank-uri (>= 1.0.24)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -790,6 +790,8 @@ GEM
       rails (> 3.2.0)
     optimist (3.0.1)
     options (2.3.2)
+    order_already (0.2.1)
+      rails-html-sanitizer (~> 1.4)
     orm_adapter (0.5.0)
     os (1.1.4)
     parallel (1.22.1)
@@ -1282,6 +1284,7 @@ DEPENDENCIES
   mods (~> 2.4)
   negative_captcha
   okcomputer
+  order_already (~> 0.2.1)
   parser (~> 2.5.3)
   pg
   postrank-uri (>= 1.0.24)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -790,7 +790,7 @@ GEM
       rails (> 3.2.0)
     optimist (3.0.1)
     options (2.3.2)
-    order_already (0.3.0)
+    order_already (0.3.1)
       rails-html-sanitizer (~> 1.4)
     orm_adapter (0.5.0)
     os (1.1.4)
@@ -1284,7 +1284,7 @@ DEPENDENCIES
   mods (~> 2.4)
   negative_captcha
   okcomputer
-  order_already (~> 0.3.0)
+  order_already (~> 0.3.1)
   parser (~> 2.5.3)
   pg
   postrank-uri (>= 1.0.24)

--- a/app/models/active_fedora/base_decorator.rb
+++ b/app/models/active_fedora/base_decorator.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module ActiveFedora
+  module BaseDecorator
+    def multi_valued_properties_for_ordering
+      properties.collect do |prop_name, node_config|
+        next if %w[head tail].include?(prop_name)
+
+        prop_name.to_sym if node_config.instance_variable_get(:@opts)&.dig(:multiple)
+      end.compact
+    end
+  end
+end
+
+ActiveFedora::Base.extend(ActiveFedora::BaseDecorator)

--- a/app/models/concerns/order_metadata_values.rb
+++ b/app/models/concerns/order_metadata_values.rb
@@ -6,6 +6,7 @@ module OrderMetadataValues
   included do
     def self.multi_valued_properties_for_ordering
       properties.collect do |prop_name, node_config|
+        # Only concerned with properties displayed to end users
         next if %w[head tail].include?(prop_name)
 
         prop_name.to_sym if node_config.instance_variable_get(:@opts)&.dig(:multiple)

--- a/app/models/concerns/order_metadata_values.rb
+++ b/app/models/concerns/order_metadata_values.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 
-module ActiveFedora
-  module BaseDecorator
-    def multi_valued_properties_for_ordering
+module OrderMetadataValues
+  extend ActiveSupport::Concern
+
+  included do
+    def self.multi_valued_properties_for_ordering
       properties.collect do |prop_name, node_config|
         next if %w[head tail].include?(prop_name)
-
+        
         prop_name.to_sym if node_config.instance_variable_get(:@opts)&.dig(:multiple)
       end.compact
     end
+
+    prepend OrderAlready.for(*multi_valued_properties_for_ordering)
   end
 end
-
-ActiveFedora::Base.extend(ActiveFedora::BaseDecorator)

--- a/app/models/concerns/order_metadata_values.rb
+++ b/app/models/concerns/order_metadata_values.rb
@@ -7,7 +7,7 @@ module OrderMetadataValues
     def self.multi_valued_properties_for_ordering
       properties.collect do |prop_name, node_config|
         next if %w[head tail].include?(prop_name)
-        
+
         prop_name.to_sym if node_config.instance_variable_get(:@opts)&.dig(:multiple)
       end.compact
     end

--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -57,6 +57,6 @@ class Etd < ActiveFedora::Base
   include ::Hyrax::BasicMetadata
   # This line must be kept below all others that set up properties,
   # including `include ::Hyrax::BasicMetadata`. All properties must
-  # be declared before they can be sorted.
+  # be declared before their values can be ordered.
   include OrderMetadataValues
 end

--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -55,4 +55,8 @@ class Etd < ActiveFedora::Base
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata
+  # This line must be kept below all others that set up properties,
+  # including `include ::Hyrax::BasicMetadata`. All properties must
+  # be declared before they can be sorted.
+  prepend OrderAlready.for(*multi_valued_properties_for_ordering)
 end

--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -58,5 +58,5 @@ class Etd < ActiveFedora::Base
   # This line must be kept below all others that set up properties,
   # including `include ::Hyrax::BasicMetadata`. All properties must
   # be declared before they can be sorted.
-  prepend OrderAlready.for(*multi_valued_properties_for_ordering)
+  include OrderMetadataValues
 end

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -19,4 +19,11 @@ class GenericWork < ActiveFedora::Base
 
   include ::Hyrax::BasicMetadata
   self.indexer = GenericWorkIndexer
+
+  MULTI_VALUED_PROPERTIES = properties.collect do |prop_name, node_config|
+    next if %w[head tail].include?(prop_name)
+    prop_name.to_sym if node_config.instance_variable_get(:@opts)&.dig(:multiple)
+  end.compact.freeze
+
+  prepend OrderAlready.for(*MULTI_VALUED_PROPERTIES)
 end

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -21,7 +21,7 @@ class GenericWork < ActiveFedora::Base
   # This line must be kept below all others that set up properties,
   # including `include ::Hyrax::BasicMetadata`. All properties must
   # be declared before they can be sorted.
-  prepend OrderAlready.for(*multi_valued_properties_for_ordering)
+  include OrderMetadataValues
 
   self.indexer = GenericWorkIndexer
 end

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -18,12 +18,10 @@ class GenericWork < ActiveFedora::Base
   end
 
   include ::Hyrax::BasicMetadata
+  # This line must be kept below all others that set up properties,
+  # including `include ::Hyrax::BasicMetadata`. All properties must
+  # be declared before they can be sorted.
+  prepend OrderAlready.for(*multi_valued_properties_for_ordering)
+
   self.indexer = GenericWorkIndexer
-
-  MULTI_VALUED_PROPERTIES = properties.collect do |prop_name, node_config|
-    next if %w[head tail].include?(prop_name)
-    prop_name.to_sym if node_config.instance_variable_get(:@opts)&.dig(:multiple)
-  end.compact.freeze
-
-  prepend OrderAlready.for(*MULTI_VALUED_PROPERTIES)
 end

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -20,7 +20,7 @@ class GenericWork < ActiveFedora::Base
   include ::Hyrax::BasicMetadata
   # This line must be kept below all others that set up properties,
   # including `include ::Hyrax::BasicMetadata`. All properties must
-  # be declared before they can be sorted.
+  # be declared before their values can be ordered.
   include OrderMetadataValues
 
   self.indexer = GenericWorkIndexer

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -24,6 +24,10 @@ class Image < ActiveFedora::Base
   # This must come after the properties because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata
+  # This line must be kept below all others that set up properties,
+  # including `include ::Hyrax::BasicMetadata`. All properties must
+  # be declared before they can be sorted.
+  prepend OrderAlready.for(*multi_valued_properties_for_ordering)
 
   self.indexer = ImageIndexer
   # Change this to restrict which works can be added as a child.

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -16,7 +16,7 @@ class Image < ActiveFedora::Base
   property :bibliographic_citation, predicate: ::RDF::Vocab::DC.bibliographicCitation do |index|
     index.as :stored_searchable
   end
-  
+
   property :bulkrax_identifier, predicate: ::RDF::URI("https://hykucommons.org/terms/bulkrax_identifier"), multiple: false do |index|
     index.as :stored_searchable, :facetable
   end
@@ -26,7 +26,7 @@ class Image < ActiveFedora::Base
   include ::Hyrax::BasicMetadata
   # This line must be kept below all others that set up properties,
   # including `include ::Hyrax::BasicMetadata`. All properties must
-  # be declared before they can be sorted.
+  # be declared before their values can be ordered.
   include OrderMetadataValues
 
   self.indexer = ImageIndexer

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -27,7 +27,7 @@ class Image < ActiveFedora::Base
   # This line must be kept below all others that set up properties,
   # including `include ::Hyrax::BasicMetadata`. All properties must
   # be declared before they can be sorted.
-  prepend OrderAlready.for(*multi_valued_properties_for_ordering)
+  include OrderMetadataValues
 
   self.indexer = ImageIndexer
   # Change this to restrict which works can be added as a child.

--- a/app/models/oer.rb
+++ b/app/models/oer.rb
@@ -94,7 +94,7 @@ class Oer < ActiveFedora::Base
   include ::Hyrax::BasicMetadata
   # This line must be kept below all others that set up properties,
   # including `include ::Hyrax::BasicMetadata`. All properties must
-  # be declared before they can be sorted.
+  # be declared before their values can be ordered.
   include OrderMetadataValues
 
   def previous_version

--- a/app/models/oer.rb
+++ b/app/models/oer.rb
@@ -95,7 +95,7 @@ class Oer < ActiveFedora::Base
   # This line must be kept below all others that set up properties,
   # including `include ::Hyrax::BasicMetadata`. All properties must
   # be declared before they can be sorted.
-  prepend OrderAlready.for(*multi_valued_properties_for_ordering)
+  include OrderMetadataValues
 
   def previous_version
     @previous_version ||= Oer.where(id: previous_version_id) if previous_version_id

--- a/app/models/oer.rb
+++ b/app/models/oer.rb
@@ -92,6 +92,10 @@ class Oer < ActiveFedora::Base
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata
+  # This line must be kept below all others that set up properties,
+  # including `include ::Hyrax::BasicMetadata`. All properties must
+  # be declared before they can be sorted.
+  prepend OrderAlready.for(*multi_valued_properties_for_ordering)
 
   def previous_version
     @previous_version ||= Oer.where(id: previous_version_id) if previous_version_id

--- a/spec/models/concerns/order_metadata_values_spec.rb
+++ b/spec/models/concerns/order_metadata_values_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe OrderMetadataValues do
 
   before do
     multiple_property_config = OpenStruct.new
-    multiple_property_config.instance_variable_set(:@opts, { multiple: true })
+    multiple_property_config.instance_variable_set(:@opts, multiple: true)
 
     singular_property_config = OpenStruct.new
     singular_property_config.instance_variable_set(:@opts, {})
@@ -64,12 +64,12 @@ RSpec.describe OrderMetadataValues do
 
     it 'return properties that allow multiple values' do
       expect(base_model.multi_valued_properties_for_ordering)
-        .to include(*%i[prop_one_multi prop_three_multi])
+        .to include(:prop_one_multi, :prop_three_multi)
     end
 
     it 'does not return properties that only allow one value' do
       expect(base_model.multi_valued_properties_for_ordering)
-        .not_to include(*%i[prop_two_singular prop_four_singular])
+        .not_to include(:prop_two_singular, :prop_four_singular)
     end
   end
 end

--- a/spec/models/concerns/order_metadata_values_spec.rb
+++ b/spec/models/concerns/order_metadata_values_spec.rb
@@ -1,0 +1,75 @@
+require 'rails_helper'
+
+RSpec.describe OrderMetadataValues do
+  let(:base_model) do
+    TestWork = Struct.new(
+      :prop_one_multi,
+      :prop_two_singular,
+      :prop_three_multi,
+      :prop_four_singular
+    )
+  end
+
+  before do
+    multiple_property_config = OpenStruct.new
+    multiple_property_config.instance_variable_set(:@opts, { multiple: true })
+
+    singular_property_config = OpenStruct.new
+    singular_property_config.instance_variable_set(:@opts, {})
+
+    base_model.define_singleton_method(:properties) do
+      {
+        'prop_one_multi' => multiple_property_config,
+        'prop_two_singular' => singular_property_config,
+        'prop_three_multi' => multiple_property_config,
+        'prop_four_singular' => singular_property_config
+      }
+    end
+  end
+
+  after do
+    Object.send(:remove_const, :TestWork)
+  end
+
+  it 'defines the #multi_valued_properties_for_ordering class method' do
+    expect { base_model.method(:multi_valued_properties_for_ordering) }.to raise_error(NameError)
+
+    base_model.include(OrderMetadataValues)
+
+    expect(base_model.method(:multi_valued_properties_for_ordering)).to be_a(Method)
+  end
+
+  it 'prepends OrderAlready for all multi-valued properties' do
+    # `OrderAlready.for` initializes a new Module, which we call `prepend` on.
+    # @see https://github.com/samvera-labs/order_already/blob/1a9bb51a5052257bf9870ee2892bb84b1ab72ffb/lib/order_already.rb#L45
+    expect(base_model).to receive(:prepend).with(an_instance_of(Module))
+
+    base_model.include(OrderMetadataValues)
+  end
+
+  it 'orders multi-valued properties' do
+    base_model.include(OrderMetadataValues)
+    work = base_model.new
+
+    expect(work.attribute_is_ordered_already?(:prop_one_multi)).to eq(true)
+    expect(work.attribute_is_ordered_already?(:prop_two_singular)).to eq(false)
+    expect(work.attribute_is_ordered_already?(:prop_three_multi)).to eq(true)
+    expect(work.attribute_is_ordered_already?(:prop_four_singular)).to eq(false)
+  end
+
+  describe '#multi_valued_properties_for_ordering' do
+    before do
+      base_model.include(OrderMetadataValues)
+    end
+
+    it 'return properties that allow multiple values' do
+      expect(base_model.multi_valued_properties_for_ordering)
+        .to include(*%i[prop_one_multi prop_three_multi])
+    end
+
+    it 'does not return properties that only allow one value' do
+      expect(base_model.multi_valued_properties_for_ordering)
+        .not_to include(*%i[prop_two_singular prop_four_singular])
+    end
+  end
+end

--- a/spec/models/concerns/order_metadata_values_spec.rb
+++ b/spec/models/concerns/order_metadata_values_spec.rb
@@ -11,12 +11,14 @@ RSpec.describe OrderMetadataValues do
   end
 
   before do
+    # Mock the structure of a ActiveTriples::NodeConfig, which holds the
+    # information for whether a property allows multiple values or not
     multiple_property_config = OpenStruct.new
     multiple_property_config.instance_variable_set(:@opts, multiple: true)
-
     singular_property_config = OpenStruct.new
     singular_property_config.instance_variable_set(:@opts, {})
 
+    # Mock ActiveFedora::Base.properties for our TestWork Struct
     base_model.define_singleton_method(:properties) do
       {
         'prop_one_multi' => multiple_property_config,

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Etd do
+  include_examples('includes OrderMetadataValues')
+
   describe 'indexer' do
     subject { described_class.indexer }
 

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -1,6 +1,7 @@
 # Generated via
 #  `rails generate hyrax:work Etd`
 require 'rails_helper'
+require 'order_already/spec_helper'
 
 RSpec.describe Etd do
   include_examples('includes OrderMetadataValues')
@@ -10,6 +11,8 @@ RSpec.describe Etd do
 
     it { is_expected.to eq EtdIndexer }
   end
+
+  it { is_expected.to have_already_ordered_attributes(*described_class.multi_valued_properties_for_ordering) }
 
   describe 'metadata properties' do
     it { is_expected.to have_property(:bulkrax_identifier).with_predicate("https://hykucommons.org/terms/bulkrax_identifier") }

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -1,6 +1,7 @@
 # Generated via
 #  `rails generate hyrax:work GenericWork`
 require 'rails_helper'
+require 'order_already/spec_helper'
 
 RSpec.describe GenericWork do
   include_examples('includes OrderMetadataValues')
@@ -8,4 +9,6 @@ RSpec.describe GenericWork do
   describe "metadata" do
     it { is_expected.to have_property(:bulkrax_identifier).with_predicate("https://hykucommons.org/terms/bulkrax_identifier") }
   end
+
+  it { is_expected.to have_already_ordered_attributes(*described_class.multi_valued_properties_for_ordering) }
 end

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe GenericWork do
+  include_examples('includes OrderMetadataValues')
+
   describe "metadata" do
     it { is_expected.to have_property(:bulkrax_identifier).with_predicate("https://hykucommons.org/terms/bulkrax_identifier") }
   end

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -4,6 +4,8 @@
 #  `rails generate hyrax:work Image`
 
 RSpec.describe Image do
+  include_examples('includes OrderMetadataValues')
+
   describe 'indexer' do
     subject { described_class.indexer }
 

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -2,6 +2,8 @@
 
 # Generated via
 #  `rails generate hyrax:work Image`
+require 'rails_helper'
+require 'order_already/spec_helper'
 
 RSpec.describe Image do
   include_examples('includes OrderMetadataValues')
@@ -15,4 +17,6 @@ RSpec.describe Image do
   describe "metadata" do
     it { is_expected.to have_property(:bulkrax_identifier).with_predicate("https://hykucommons.org/terms/bulkrax_identifier") }
   end
+
+  it { is_expected.to have_already_ordered_attributes(*described_class.multi_valued_properties_for_ordering) }
 end

--- a/spec/models/oer_spec.rb
+++ b/spec/models/oer_spec.rb
@@ -1,6 +1,7 @@
 # Generated via
 #  `rails generate hyrax:work Oer`
 require 'rails_helper'
+require 'order_already/spec_helper'
 
 RSpec.describe Oer do
   include_examples('includes OrderMetadataValues')
@@ -10,6 +11,8 @@ RSpec.describe Oer do
 
     it { is_expected.to eq OerIndexer }
   end
+
+  it { is_expected.to have_already_ordered_attributes(*described_class.multi_valued_properties_for_ordering) }
 
   it 'has a title' do
     subject.title = ['new oer work']

--- a/spec/models/oer_spec.rb
+++ b/spec/models/oer_spec.rb
@@ -3,6 +3,8 @@
 require 'rails_helper'
 
 RSpec.describe Oer do
+  include_examples('includes OrderMetadataValues')
+
   describe 'indexer' do
     subject { described_class.indexer }
 

--- a/spec/support/shared_examples.rb
+++ b/spec/support/shared_examples.rb
@@ -7,3 +7,9 @@ RSpec.shared_examples "work_form" do
     end
   end
 end
+
+RSpec.shared_examples 'includes OrderMetadataValues' do
+  it 'includes the OrderMetadataValues concern' do
+    described_class.include?(OrderMetadataValues)
+  end
+end


### PR DESCRIPTION
Ref https://github.com/scientist-softserv/palni-palci/issues/401

# Summary

Apply `OrderAlready` gem to all multi-valued properties in all work types 

# Expected Behavior

All properties that allow multiple values will display those values in the same order that they were inputted in the form 