### PR TITLE
Rework for markdown

### DIFF
--- a/app/renderers/hyrax/renderers/attribute_renderer_decorator.rb
+++ b/app/renderers/hyrax/renderers/attribute_renderer_decorator.rb
@@ -10,7 +10,9 @@ module Hyrax
       private
 
         def attribute_value_to_html(value)
-          if microdata_value_attributes(field).present?
+          if field.to_s === 'abstract'
+            markdown(value)
+          elsif microdata_value_attributes(field).present?
             "<span#{html_attributes(microdata_value_attributes(field))}>#{markdown(li_value(value))}</span>"
           else
             markdown(li_value(value))

--- a/app/renderers/hyrax/renderers/attribute_renderer_decorator.rb
+++ b/app/renderers/hyrax/renderers/attribute_renderer_decorator.rb
@@ -10,7 +10,7 @@ module Hyrax
       private
 
         def attribute_value_to_html(value)
-          if field.to_s === 'abstract'
+          if field.to_s == 'abstract'
             markdown(value)
           elsif microdata_value_attributes(field).present?
             "<span#{html_attributes(microdata_value_attributes(field))}>#{markdown(li_value(value))}</span>"

--- a/app/views/hyrax/base/_work_description.erb
+++ b/app/views/hyrax/base/_work_description.erb
@@ -1,5 +1,5 @@
-<%# OVERRIDE Hyrax 3.4.2 to enable markdown in the work description %>
+<%# OVERRIDE Hyrax 3.4.2 to enable markdown in the work description, and remove autolink to search in description on show page %>
 
 <% presenter.description.each do |description| %>
-    <p class="work_description"><%= markdown(iconify_auto_link(description)) %></p>
+    <p class="work_description"><%= markdown(description) %></p>
 <% end %>

--- a/app/views/hyrax/dashboard/collections/_collection_title.html.erb
+++ b/app/views/hyrax/dashboard/collections/_collection_title.html.erb
@@ -1,0 +1,25 @@
+<%# OVERRIDE Hyrax 3.5.0 to add markdown to collection titles in dashboard %>
+
+<% id = presenter.id %>
+
+<section class="collection-title-row-wrapper"
+  data-source="my"
+  data-id="<%= id %>"
+  data-colls-hash="<%= available_parent_collections_data(collection: presenter) %>"
+  data-post-url="<%= hyrax.dashboard_create_nest_collection_within_path(id) %>"
+  data-post-delete-url="<%= hyrax.dashboard_collection_path(id) %>">
+
+    <div class="collection-title-row-content">
+      <h2 class="collection-title">
+        <% # List multiple titles %>
+        <% presenter.title.each_with_index do |title, index| %>
+          <span><%= markdown(title) %></span>
+        <% end %>
+      </h2>
+      <%= presenter.permission_badge %>
+      <%= presenter.collection_type_badge %>
+    </div>
+    <div class="collection-title-row-content">
+      <%= render 'show_actions', presenter: presenter %>
+    </div>
+</section>


### PR DESCRIPTION
# Story

Fixes a few places where markdown was not rendering correctly

Refs #402 

# Expected Behavior Before Changes
- [ ] Hyperlinks in the description & abstract of works rendered strangely
- [ ] Dashboard titles for collections didn't render markdown

# Expected Behavior After Changes
- [ ] Hyperlinks in description of works link to the correct place
- [ ] Hyperlinks in abstract of works link to the correct place
- [ ] Dashboard titles for collections render markdown

# Screenshots / Video

<details>
<summary> Hyperlinks in description </summary>

<img width="592" alt="image" src="https://user-images.githubusercontent.com/73361970/229839044-0086915c-3828-423b-9927-96ea2507ba55.png">


</details>

<details>
<summary> Hyperlinks in abstracts </summary>

<img width="537" alt="image" src="https://user-images.githubusercontent.com/73361970/229886858-e1912314-1907-46d6-b5cf-3063c7fc9949.png">


</details>

<details>
<summary> Dashboard titles </summary>

<img width="1186" alt="image" src="https://user-images.githubusercontent.com/73361970/229891835-927a7fcf-6a71-482e-af9b-6c6033c7dc83.png">


</details>
