### PR TITLE
use POST to increase request size limit

### DIFF
--- a/lib/oai/provider/metadata_format/hyku_dublin_core.rb
+++ b/lib/oai/provider/metadata_format/hyku_dublin_core.rb
@@ -54,6 +54,7 @@ module OAI
             "has_model_ssim:FileSet AND " \
             "visibility_ssi:#{Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC}",
             fl: ["id"],
+            method: :post, # higher request size limit than :get
             rows: 1024 # maximum
           )
           return if public_fs_ids.blank?


### PR DESCRIPTION
# Story

Avoids `414 Request-URI Too Long` errors when works have many file sets

Refs #423 #440 

# Expected Behavior Before Changes

Works with many file sets cause OAI pages to throw errors 

# Expected Behavior After Changes

Works with many file sets (<= 1024) do not cause OAI pages to throw errors 

# Notes

Works that have more than 1024 could still throw errors 