### PR TITLE
449 color labels

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -433,6 +433,10 @@ a.restore-default-color {
   margin-bottom: 2em;
 }
 
+a.btn.btn-default.restore-default-color.with-color-hint {
+  margin-top: 4em;
+}
+
 .defaultable-colors div[class$="_color"] {
   margin-bottom: 0.75em;
 }

--- a/app/forms/hyrax/forms/admin/appearance.rb
+++ b/app/forms/hyrax/forms/admin/appearance.rb
@@ -24,17 +24,17 @@ module Hyrax
         }.freeze
 
         DEFAULT_COLORS = {
-          'header_background_color'          => '#3c3c3c',
-          'header_text_color'                => '#dcdcdc',
-          'searchbar_background_color'       => '#000000',
-          'searchbar_background_hover_color' => '#ffffff',
-          'searchbar_text_color'             => '#eeeeee',
-          'searchbar_text_hover_color'       => '#eeeeee',
+          'header_and_footer_background_color'          => '#3c3c3c',
+          'header_and_footer_text_color'                => '#dcdcdc',
+          'navbar_background_color'       => '#000000',
+          'navbar_link_background_hover_color' => '#ffffff',
+          'navbar_link_text_color'             => '#eeeeee',
+          'navbar_link_text_hover_color'       => '#eeeeee',
           'link_color'                       => '#2e74b2',
           'link_hover_color'                 => '#215480',
           'footer_link_color'                => '#ffebcd',
           'footer_link_hover_color'          => '#ffffff',
-          'primary_button_background_color'  => '#286090',
+          'primary_button_hover_color'  => '#286090',
           'default_button_background_color'  => '#ffffff',
           'default_button_border_color'      => '#cccccc',
           'default_button_text_color'        => '#333333',
@@ -112,42 +112,42 @@ module Hyrax
         end
 
         # The color for the background of the header and footer bars
-        def header_background_color
-          block_for('header_background_color')
+        def header_and_footer_background_color
+          block_for('header_and_footer_background_color')
         end
 
         # The color for the text in the header bar
-        def header_text_color
-          block_for('header_text_color')
+        def header_and_footer_text_color
+          block_for('header_and_footer_text_color')
         end
 
         # The color for the background of the search navbar
-        def searchbar_background_color
-          block_for('searchbar_background_color')
+        def navbar_background_color
+          block_for('navbar_background_color')
         end
 
-        def searchbar_background_color_alpha
-          convert_to_rgba(searchbar_background_color, 0.4)
+        def navbar_background_color_alpha
+          convert_to_rgba(navbar_background_color, 0.4)
         end
 
-        def searchbar_background_color_active
-          darken_color(searchbar_background_color, 0.35)
+        def navbar_background_color_active
+          darken_color(navbar_background_color, 0.35)
         end
 
-        def searchbar_background_hover_color
-          block_for('searchbar_background_hover_color')
+        def navbar_link_background_hover_color
+          block_for('navbar_link_background_hover_color')
         end
 
-        def searchbar_background_hover_color_alpha
-          convert_to_rgba(searchbar_background_hover_color, 0.15)
+        def navbar_link_background_hover_color_alpha
+          convert_to_rgba(navbar_link_background_hover_color, 0.15)
         end
 
-        def searchbar_text_color
-          block_for('searchbar_text_color')
+        def navbar_link_text_color
+          block_for('navbar_link_text_color')
         end
 
-        def searchbar_text_hover_color
-          block_for('searchbar_text_hover_color')
+        def navbar_link_text_hover_color
+          block_for('navbar_link_text_hover_color')
         end
 
         # The color links
@@ -172,18 +172,18 @@ module Hyrax
 
         # PRIMARY BUTTON COLORS
         # The background color for "primary" buttons
-        def primary_button_background_color
-          block_for('primary_button_background_color')
+        def primary_button_hover_color
+          block_for('primary_button_hover_color')
         end
 
         # The border color for "primary" buttons
         def primary_button_border_color
-          @primary_button_border ||= darken_color(primary_button_background_color, 0.05)
+          @primary_button_border ||= darken_color(primary_button_hover_color, 0.05)
         end
 
         # The mouse over color for "primary" buttons
         def primary_button_hover_background_color
-          darken_color(primary_button_background_color, 0.1)
+          darken_color(primary_button_hover_color, 0.1)
         end
 
         # The mouse over color for the border of "primary" buttons
@@ -193,7 +193,7 @@ module Hyrax
 
         # The color for the background of active "primary" buttons
         def primary_button_active_background_color
-          darken_color(primary_button_background_color, 0.1)
+          darken_color(primary_button_hover_color, 0.1)
         end
 
         # The color for the border of active "primary" buttons
@@ -203,7 +203,7 @@ module Hyrax
 
         # The color for the background of focused "primary" buttons
         def primary_button_focus_background_color
-          darken_color(primary_button_background_color, 0.1)
+          darken_color(primary_button_hover_color, 0.1)
         end
 
         # The color for the border of focused "primary" buttons
@@ -264,6 +264,7 @@ module Hyrax
           darken_color(default_button_border_color, 0.25)
         end
 
+        # ???
         # The color for the background of the home page nav-pills tab with active class
         def active_tabs_background_color
           block_for('active_tabs_background_color')
@@ -271,7 +272,7 @@ module Hyrax
 
         # The color for the border of navbar-inverse
         def header_background_border_color
-          darken_color(header_background_color, 0.25)
+          darken_color(header_and_footer_background_color, 0.25)
         end
 
         # The color for the facet panel header background color
@@ -363,23 +364,23 @@ module Hyrax
           %i[
             body_font
             headline_font
-            header_background_color
-            header_text_color
+            header_and_footer_background_color
+            header_and_footer_text_color
             link_color
             link_hover_color
             footer_link_color
             footer_link_hover_color
-            primary_button_background_color
+            primary_button_hover_color
             default_button_background_color
             default_button_border_color
             default_button_text_color
             active_tabs_background_color
             facet_panel_background_color
             facet_panel_text_color
-            searchbar_background_color
-            searchbar_background_hover_color
-            searchbar_text_color
-            searchbar_text_hover_color
+            navbar_background_color
+            navbar_link_background_hover_color
+            navbar_link_text_color
+            navbar_link_text_hover_color
             custom_css_block
             logo_image_text
             banner_image_text

--- a/app/forms/hyrax/forms/admin/appearance.rb
+++ b/app/forms/hyrax/forms/admin/appearance.rb
@@ -38,7 +38,7 @@ module Hyrax
           'default_button_background_color'  => '#ffffff',
           'default_button_border_color'      => '#cccccc',
           'default_button_text_color'        => '#333333',
-          'active_tabs_background_color'     => '#337ab7',
+          # 'active_tabs_background_color'     => '#337ab7',
           'facet_panel_background_color'     => '#f5f5f5',
           'facet_panel_text_color'           => '#333333'
         }.freeze
@@ -171,7 +171,7 @@ module Hyrax
         end
 
         # PRIMARY BUTTON COLORS
-        # The background color for "primary" buttons
+        # The background hover color for "primary" buttons
         def primary_button_hover_color
           block_for('primary_button_hover_color')
         end
@@ -264,7 +264,6 @@ module Hyrax
           darken_color(default_button_border_color, 0.25)
         end
 
-        # ???
         # The color for the background of the home page nav-pills tab with active class
         def active_tabs_background_color
           block_for('active_tabs_background_color')

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,7 +12,7 @@ module ApplicationHelper
   def hint_for(term:, record_class: nil)
     hint = locale_for(type: 'hints', term: term, record_class: record_class)
 
-    return hint unless hint.include?('translation missing')
+    return hint unless missing_translation(hint)
   end
 
   def locale_for(type:, term:, record_class:)
@@ -22,9 +22,13 @@ module ApplicationHelper
     default_locale     = t("simple_form.#{type}.#{work_or_collection}.#{@term}").html_safe
     locale             = t("hyrax.#{@record_class}.#{type}.#{@term}").html_safe
 
-    return default_locale if locale.include?('translation missing')
+    return default_locale if missing_translation(locale)
 
     locale
+  end
+
+  def missing_translation(value)
+    value.include?('translation missing')
   end
 
   def markdown(text)

--- a/app/views/hyrax/admin/appearances/_color_input.html.erb
+++ b/app/views/hyrax/admin/appearances/_color_input.html.erb
@@ -1,7 +1,6 @@
 <div class='row'>
   <div class='col-lg-10'>
-  <% hint = t("hyrax.admin.appearances.show.forms.#{color_name}.hint") %>
-
+    <% hint = t("hyrax.admin.appearances.show.forms.#{color_name}.hint") %>
     <%= f.input color_name,
         required: false,
         input_html: { type: 'color', data: { default_value: hex } },
@@ -10,7 +9,7 @@
   <div class='col-lg-2'>
     <%= link_to 'Restore Default',
         '#color',
-        class: 'btn btn-default restore-default-color',
+        class: "btn btn-default restore-default-color #{'with-color-hint' if !missing_translation(hint)}",
         data: { default_target: color_name } %>
   </div>
 </div>

--- a/app/views/hyrax/admin/appearances/_color_input.html.erb
+++ b/app/views/hyrax/admin/appearances/_color_input.html.erb
@@ -1,8 +1,16 @@
 <div class='row'>
   <div class='col-lg-10'>
-    <%= f.input color_name, required: false, input_html: { type: 'color', data: { default_value: hex } } %>
+  <% hint = t("hyrax.admin.appearances.show.forms.#{color_name}.hint") %>
+
+    <%= f.input color_name,
+        required: false,
+        input_html: { type: 'color', data: { default_value: hex } },
+        hint: !missing_translation(hint) && hint %>
   </div>
   <div class='col-lg-2'>
-    <%= link_to 'Restore Default', '#color', class: 'btn btn-default restore-default-color', data: { default_target: color_name } %>
+    <%= link_to 'Restore Default',
+        '#color',
+        class: 'btn btn-default restore-default-color',
+        data: { default_target: color_name } %>
   </div>
 </div>

--- a/app/views/shared/_appearance_styles.html.erb
+++ b/app/views/shared/_appearance_styles.html.erb
@@ -26,31 +26,31 @@ body.public-facing #per_page-dropdown .dropdown-toggle { color: <%= appearance.l
 /* MAIN NAV */
 body.public-facing .navbar-inverse .navbar-link { color: <%= appearance.footer_link_color %>; }
 body.public-facing .navbar-inverse .navbar-link:hover { color: <%= appearance.footer_link_hover_color %> }
-body.public-facing .navbar-inverse { background-color: <%= appearance.header_background_color %>; }
+body.public-facing .navbar-inverse { background-color: <%= appearance.header_and_footer_background_color %>; }
 body.public-facing .navbar-inverse .navbar-nav > .open > a,
 body.public-facing .navbar-inverse .navbar-nav > .open > a:hover,
-body.public-facing .navbar-inverse .navbar-nav > .open > a:focus { background-color: <%= appearance.header_background_color %>; }
+body.public-facing .navbar-inverse .navbar-nav > .open > a:focus { background-color: <%= appearance.header_and_footer_background_color %>; }
 body.public-facing .navbar-inverse .navbar-nav > li > a,
 body.public-facing .navbar-inverse .navbar-text,
-body.public-facing .navbar-inverse .navbar-brand { color: <%= appearance.header_text_color %>; }
+body.public-facing .navbar-inverse .navbar-brand { color: <%= appearance.header_and_footer_text_color %>; }
 body.public-facing .navbar-inverse { border-color: <%= appearance.header_background_border_color %>; }
 
 /* HOME PAGE SEARCH BAR NAV */
-body.public-facing .image-masthead .navbar { background-color: <%= appearance.searchbar_background_color_alpha %>; }
+body.public-facing .image-masthead .navbar { background-color: <%= appearance.navbar_background_color_alpha %>; }
 body.public-facing .image-masthead .navbar .active > a,
 body.public-facing .image-masthead .navbar .active > a:hover,
 body.public-facing .image-masthead .navbar .active > a:focus {
-    background-color: <%= appearance.searchbar_background_color_active %>;
-    color: <%= appearance.searchbar_text_color %>;
+    background-color: <%= appearance.navbar_background_color_active %>;
+    color: <%= appearance.navbar_link_text_color %>;
 }
 body.public-facing .image-masthead .navbar .navbar-nav a {
-    color: <%= appearance.searchbar_text_color %>;
+    color: <%= appearance.navbar_link_text_color %>;
 }
 
 body.public-facing .image-masthead .navbar .navbar-nav a:hover,
 body.public-facing .image-masthead .navbar .navbar-nav a:focus {
-    background-color: <%= appearance.searchbar_background_hover_color_alpha %>;
-    color: <%= appearance.searchbar_text_hover_color %>;
+    background-color: <%= appearance.navbar_link_background_hover_color_alpha %>;
+    color: <%= appearance.navbar_link_text_hover_color %>;
 }
 
 /* HOME PAGE NAV-PILL TABS */
@@ -62,7 +62,7 @@ body.public-facing .nav-pills > li.active > a:focus {
 
 /* PRIMARY BUTTON STYLES */
 body.public-facing .btn-primary {
-  background-color: <%= appearance.primary_button_background_color %>;
+  background-color: <%= appearance.primary_button_hover_color %>;
   border-color: <%= appearance.primary_button_border_color %>;
 }
 body.public-facing .btn-primary:focus,
@@ -76,7 +76,7 @@ body.public-facing .btn-primary:hover {
 }
 body.public-facing .btn-primary:active,
 body.public-facing .btn-primary.active {
-  background-color: <%= appearance.primary_button_background_color %>;
+  background-color: <%= appearance.primary_button_hover_color %>;
   border-color: <%= appearance.primary_button_border_color %>;
 }
 body.public-facing .btn-primary:active:hover,
@@ -85,7 +85,7 @@ body.public-facing .btn-primary:active.focus,
 body.public-facing .btn-primary.active:hover,
 body.public-facing .btn-primary.active:focus,
 body.public-facing .btn-primary.active.focus{
-  background-color: <%= appearance.primary_button_background_color %>;
+  background-color: <%= appearance.primary_button_hover_color %>;
   border-color: <%= appearance.primary_button_border_color %>;
 }
 body.public-facing .btn-primary.disabled:hover,
@@ -94,7 +94,7 @@ body.public-facing .btn-primary.disabled.focus,
 body.public-facing .btn-primary[disabled]:hover,
 body.public-facing .btn-primary[disabled]:focus,
 body.public-facing .btn-primary[disabled].focus {
-  background-color: <%= appearance.primary_button_background_color %>;
+  background-color: <%= appearance.primary_button_hover_color %>;
   border-color: <%= appearance.primary_button_border_color %>;
 }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -193,6 +193,20 @@ en:
               confirm: "If your theme doesn't appear to be applying correctly, verify that it isn't being overwritten by Custom CSS."
             favicon:
               hint: "Favicons need to be png files and must be square. The max size used is 228px x 228px."
+            navbar_background_color:
+              hint: 'At 40% opacity.'
+            navbar_link_background_hover_color:
+              hint: 'Applies to the Home, About, Contact and Help buttons on those specific pages only (at 15% opacity).'
+            link_color:
+              hint: 'Affects links on the home and work pages including: breadcrumbs, tabs, titles and terms of service.'
+            primary_button_hover_color:
+              hint: 'Share, search and collection interaction (edit, feature, etc.) buttons. The border of these buttons will also be this color.'
+            default_button_background_color:
+              hint: 'Work interaction (edit, feature, etc.) buttons; work views on collection page and search filter button.'
+            facet_panel_background_color:
+              hint: 'Applies to facets and additional section headers on the work pages in some themes.'
+            facet_panel_text_color:
+              hint: 'Also applies to the color of the caret next to the text and the work title on some themes.'
           tabs:
             banner_image: "Banner Image"
             directory_image: "Directory Image"

--- a/spec/views/hyrax/admin/appearances/show.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/appearances/show.html.erb_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "hyrax/admin/appearances/show", type: :view do
       # default work image
       assert_select "input#admin_appearance_default_work_image[name=?]", "admin_appearance[default_work_image]"
       # colors
-      assert_select "input#admin_appearance_primary_button_background_color[type=?]", "color"
+      assert_select "input#admin_appearance_primary_button_hover_color[type=?]", "color"
       # fonts
       assert_select "input#admin_appearance_body_font[name=?]", "admin_appearance[body_font]"
       # custom css


### PR DESCRIPTION
# Story
- Refs #449 

# Expected Behavior Before Changes
<details>
<summary> color form BEFORE</summary>

![Screenshot 2023-05-09 at 3 18 57 PM](https://github.com/scientist-softserv/palni-palci/assets/29032869/8507161a-d019-4b92-ae99-3a4af946dab0)
![Screenshot 2023-05-09 at 3 19 16 PM](https://github.com/scientist-softserv/palni-palci/assets/29032869/e0e43d5d-ad5b-488a-9fc9-e43a04c5f717)

</details>

# Expected Behavior After Changes
- better named color labels
- help text where useful

# Screenshots / Video

<details>
<summary>color form AFTER</summary>

![image](https://github.com/scientist-softserv/palni-palci/assets/29032869/24efa57d-7d32-4ca8-a801-f898c56a3283)
![image](https://github.com/scientist-softserv/palni-palci/assets/29032869/42a5bd56-0b38-4cc8-bbdf-879ccd39852c)
</details>

# Notes
<details>
<summary> fuller notes </summary>

# COLORS
color changes only apply to the public page, not the admin dashboard

## Header background color >> header_and_footer_background_color
- header and footer background color on every public page

## Header text color >> header_and_footer_text_color
- text color of all text/links in the header
- notification bell
- user icon
- color of all non linked text in the footer

## Searchbar background color >> navbar_background_color
- nav bar background (40% opacity of the color chosen)
- active link background on the navbar color ONLY. darker version of the chosen color. it's a hex and not an rgba so I can't figure out how it's set
- does not affect the bg color of the other navbar links. those are blue unless overridden with css

## Searchbar background hover color >> navbar_link_background_hover_color
- bg color of nav links on hover at 15% opacity

## Searchbar text color >> searchbar_text_color
- text color of the navbar links

## Searchbar text hover color
- text color of the navbar links on hover

## Link color
- dashboard: works/collections tab colors and titles of the works/collections in each tab, terms of use
- work show page: breadcrumbs, metadata text (but not the metadata labels), title of files
- "browse by" link colors on cultural theme home page

## Link hover color
- hover for the above selections

## Footer link color
- color of all linked text in the footer

## Footer link hover color
- hover color of all linked text in the footer

## Primary button background color (looks more like a border, changes to full color on hover) >> primary_button_hover_color
- share button
- search button
- edit, add to collection, feature - collection buttons
- contact form "send" button

## Default button background color
- edit, add to collection, attach child, feature, citations, actions - work buttons
- refresh or change view of works on collection page
- filter by button next to nav bar search icon

## Default button border color
- border color of the above

## Default button text color
- text color of the above

## Active tabs background color
- ??

## Facet panel background color
- facet bg color
- work show page additional sections (facets?) bg color

## Facet panel text color
- text color of the above
- color of caret next to facet title
- title color of work on show page in cultural theme
</details>