### PR TITLE
408 ldp gone

### DIFF
--- a/app/controllers/hyrax/admin/analytics/collection_reports_controller_decorator.rb
+++ b/app/controllers/hyrax/admin/analytics/collection_reports_controller_decorator.rb
@@ -31,7 +31,7 @@ module Hyrax
             all_top_collections.select do |col|
               begin
                 Collection.find(col[0]).present?
-              rescue
+              rescue StandardError
                 # account for errors such as ActiveFedora::ObjectNotFoundError, Ldp::Gone, etc.
                 next
               end

--- a/app/controllers/hyrax/admin/analytics/collection_reports_controller_decorator.rb
+++ b/app/controllers/hyrax/admin/analytics/collection_reports_controller_decorator.rb
@@ -26,16 +26,17 @@ module Hyrax
 
         private
 
-        def present_collections(all_top_collections)
-          # filter out collections that have been deleted or are otherwise not present
-          all_top_collections.select do |col|
-            begin
-              Collection.find(col[0]).present?
-            rescue ActiveFedora::ObjectNotFoundError
-              next
+          def present_collections(all_top_collections)
+            # filter out collections that have been deleted or are otherwise not present
+            all_top_collections.select do |col|
+              begin
+                Collection.find(col[0]).present?
+              rescue
+                # account for errors such as ActiveFedora::ObjectNotFoundError, Ldp::Gone, etc.
+                next
+              end
             end
           end
-        end
       end
     end
   end


### PR DESCRIPTION
# Story
while diem was testing this feature on staging, she deleted a collection and [received a 500 error](https://assaydepot.slack.com/archives/G0311DNF3MG/p1684188070243439) on the collections analytics page. according to the rancher logs and sentry, we were getting an "ldp gone" error.

- Refs #408

# Expected Behavior Before Changes
- we were accounting only for an "object not found" error when looking up collections

# Expected Behavior After Changes
- account for all errors that can happen if a collection can't be found for some reason

# Screenshots / Video

<details>
<summary>proof of concept in terminal</summary>

![image](https://github.com/scientist-softserv/palni-palci/assets/29032869/25a199b7-6a69-4c34-a60c-1ece8dca70a9)
</details>