### PR TITLE
Allow downloads setting

### DIFF
--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -15,6 +15,7 @@ module AccountSettings
     end
 
     setting :allow_signup, type: 'boolean', default: true
+    setting :allow_downloads, type: 'boolean', default: true
     setting :bulkrax_validations, type: 'boolean', disabled: true
     setting :cache_api, type: 'boolean', default: false
     setting :contact_email, type: 'string', default: 'consortial-ir@palci.org'
@@ -58,7 +59,7 @@ module AccountSettings
   class_methods do
     def setting(name, args)
       known_type = ['array', 'boolean', 'hash', 'string'].include?(args[:type])
-      raise "Setting type #{args[:type]} is not supported. Can not laod." unless known_type
+      raise "Setting type #{args[:type]} is not supported. Can not load." unless known_type
 
       send("#{args[:type]}_settings") << name
       all_settings[name] = args


### PR DESCRIPTION
# Story
Adds only the setting for allowing downloads. the actual places where downloads can need to be turned on & off will be in the next pr. 

# Related
- #468 

# Screenshots
<details>
<summary>Setting in dashboard</summary>
<img width="483" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/73361970/8f1fe4d2-cdc9-4b06-96d6-621bc50adeb4">

</details>

<details>
<summary>Setting in proprietor area</summary>
<img width="614" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/73361970/03a34784-2553-4970-8af2-b6fccd9221fe">

</details>