### PR TITLE
add the feature flipper

### DIFF
--- a/app/presenters/hyku/menu_presenter.rb
+++ b/app/presenters/hyku/menu_presenter.rb
@@ -37,6 +37,10 @@ module Hyku
         can?(:manage, Hyrax::Group)
     end
 
+    def display_workflow_roles_menu_item_in_admin_dashboard_sidebar?
+      Flipflop.show_workflow_roles_menu_item_in_admin_dashboard_sidebar?
+    end
+
     # Returns true if we ought to show the user Admin-only areas of the menu
     def show_admin_menu_items?
       can?(:read, :admin_dashboard)

--- a/app/views/hyrax/dashboard/sidebar/_configuration.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_configuration.html.erb
@@ -40,7 +40,7 @@
         <% end %>
     </li>
   <% end %>
-  <% if can?(:manage, Sipity::WorkflowResponsibility) %>
+  <% if Flipflop.show_workflow_roles_menu_item_in_admin_dashboard_sidebar? && can?(:manage, Sipity::WorkflowResponsibility) %>
     <%= menu.nav_link(hyrax.admin_workflow_roles_path) do %>
        <span class="fa fa-users" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.workflow_roles') %></span>
     <% end %>

--- a/config/features.rb
+++ b/config/features.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 Flipflop.configure do
+  feature :show_workflow_roles_menu_item_in_admin_dashboard_sidebar,
+          default: false,
+          description: "Shows the Workflow Roles menu item in the admin dashboard sidebar."
+
   feature :show_featured_researcher,
           default: true,
           description: "Shows the Featured Researcher tab on the homepage."


### PR DESCRIPTION
Refs #447 

# Expected Behavior Before Changes
- in the admin dashboard on the sidebar the workflow roles displays
# Expected Behavior After Changes
- in the admin dashboard sidebar under the configuration section of the sidebar, in settings > features, you see a feature flipper to flip the feature of displaying the workflow roles menu item on the admin dashboard sidebar on/off
- in the admin dashboard on the sidebar the workflow roles menu item displays the menu item if the feature flipper is set to on
- in the admin dashboard on the sidebar the workflow roles menu item does not display if the feature flipper is set to off
# Screenshots / Video

<details>
<summary>CLICK ME FOR SCREENSHOTS OF IMPLEMENTATION</summary>

<img width="991" alt="Screenshot 2023-05-17 at 10 50 51" src="https://github.com/scientist-softserv/palni-palci/assets/63515648/9dc80c55-8f07-4577-91cf-12ab815dabd8">

<img width="988" alt="Screenshot 2023-05-17 at 10 50 10" src="https://github.com/scientist-softserv/palni-palci/assets/63515648/f0521e78-8347-4c93-a137-87203f554b43">

</details>
