### PR TITLE
408-disable-analytics-defaults-prod

### DIFF
--- a/bin/web
+++ b/bin/web
@@ -1,6 +1,2 @@
 #!/usr/local/bin/ruby
-if ENV['GOOGLE_OAUTH_PRIVATE_KEY_VALUE'] && !ENV['GOOGLE_OAUTH_PRIVATE_KEY_VALUE'].empty?
-  %x{echo "$GOOGLE_OAUTH_PRIVATE_KEY_VALUE" | base64 -d > prod-cred.p12}
-end
-
 exec "bundle exec puma -v -b tcp://0.0.0.0:3000"

--- a/bin/worker
+++ b/bin/worker
@@ -1,8 +1,4 @@
 #!/usr/local/bin/ruby
-if ENV['GOOGLE_OAUTH_PRIVATE_KEY_VALUE'] && !ENV['GOOGLE_OAUTH_PRIVATE_KEY_VALUE'].empty?
-  %x{echo "$GOOGLE_OAUTH_PRIVATE_KEY_VALUE" | base64 -d > prod-cred.p12}
-end
-
 if ENV['DB_URL'] && !ENV['DB_URL'].empty?
   ENV['DB_URL'] = ENV['DB_URL'].gsub('pool=5', 'pool=30')
 else

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -84,20 +84,6 @@ extraEnvVars: &envVars
     value: http://palsfcrepo:8080/rest
   - name: GOOGLE_FONTS_KEY
     value: $GOOGLE_FONTS_KEY
-  - name: GOOGLE_ANALYTICS_ID
-    value: $GOOGLE_ANALYTICS_ID
-  - name: GOOGLE_OAUTH_APP_NAME
-    value: palni-palci-production 
-  - name: GOOGLE_OAUTH_APP_VERSION
-    value: '1.0'
-  - name: GOOGLE_OAUTH_PRIVATE_KEY_SECRET
-    value: $GOOGLE_OAUTH_PRIVATE_KEY_SECRET
-  - name: GOOGLE_OAUTH_PRIVATE_KEY_PATH
-    value: prod-cred.p12
-  - name: GOOGLE_OAUTH_PRIVATE_KEY_VALUE
-    value: $GOOGLE_OAUTH_PRIVATE_KEY_VALUE
-  - name: GOOGLE_OAUTH_CLIENT_EMAIL
-    value: hyku-analytics@hyku-analytics-362617.iam.gserviceaccount.com
   - name: HYKU_ACTIVE_JOB_QUEUE_URL
     value: sidekiq
   - name: HYKU_ADMIN_HOST
@@ -120,8 +106,6 @@ extraEnvVars: &envVars
     value: hykucommons.org
   - name: HYRAX_ACTIVE_JOB_QUEUE
     value: sidekiq
-  - name: HYRAX_ANALYTICS
-    value: 'true'
   - name: HYRAX_FITS_PATH
     value: /app/fits/fits.sh
   - name: INITIAL_ADMIN_EMAIL


### PR DESCRIPTION
# Story
remove prod related default analytics settings. we need to wait until #479 has been deployed all the way through to production and the client has set up analytics settings on each applicable tenant before deploying this work.

otherwise, the client shouldn't see any change.

- related: #479 
- related: #472 

# Expected Behavior Before Changes
- default analytics values are still being set in production

# Expected Behavior After Changes
- tenants without analytics settings will no longer have any analytics features