### PR TITLE
Restrict downloads

### DIFF
--- a/app/views/hyrax/file_sets/_actions.html.erb
+++ b/app/views/hyrax/file_sets/_actions.html.erb
@@ -1,0 +1,57 @@
+<%# Overridden from Hyrax 3.5.0 - To add extra download restrictions %>
+<% if (can?(:download, file_set.id) || can?(:destroy, file_set.id) || can?(:edit, file_set.id)) && !workflow_restriction?(@parent) %>
+  <% if can?(:download, file_set.id) && !(can?(:edit, file_set.id) || can?(:destroy, file_set.id)) %>
+    <% if Site.account.settings[:allow_downloads].nil? || Site.account.settings[:allow_downloads].to_i.nonzero? %>
+      <%= link_to t('.download'),
+                  hyrax.download_path(file_set),
+                  class: 'btn btn-default btn-sm',
+                  title: t('.download_title', file_set: file_set),
+                  target: "_blank",
+                  id: "file_download",
+                  data: { label: file_set.id, work_id: @presenter.id, collection_ids: @presenter.member_of_collection_ids } %>
+    <% end %>
+  <% else %>
+  <div class="btn-group">
+    <button class="btn btn-default dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= file_set.id %>" aria-haspopup="true" aria-expanded="false">
+      <span class="sr-only"><%= t('.press_to') %> </span>
+      <%= t('.header') %>
+      <span class="caret" aria-hidden="true"></span>
+    </button>
+
+    <ul role="menu" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= file_set.id %>">
+    <% if can?(:edit, file_set.id) %>
+      <li role="menuitem" tabindex="-1">
+        <%= link_to t('.edit'), edit_polymorphic_path([main_app, file_set]),
+          { title: t('.edit_title', file_set: file_set) } %>
+      </li>
+
+      <li role="menuitem" tabindex="-1">
+        <%= link_to t('.versions'),  edit_polymorphic_path([main_app, file_set], anchor: 'versioning_display'),
+          { title: t('.versions_title') } %>
+      </li>
+    <% end %>
+
+    <% if can?(:destroy, file_set.id) %>
+      <li role="menuitem" tabindex="-1">
+        <%= link_to t('.delete'), polymorphic_path([main_app, file_set]),
+          method: :delete, title: t('.delete_title', file_set: file_set),
+          data: { confirm: t('.delete_confirm', file_set: file_set, application_name: application_name) } %>
+      </li>
+    <% end %>
+
+    <% if can?(:download, file_set.id) && (Site.account.settings[:allow_downloads].nil? || Site.account.settings[:allow_downloads].to_i.nonzero?) %>
+      <li role="menuitem" tabindex="-1">
+        <%= link_to t('.download'),
+                    hyrax.download_path(file_set),
+                    title: t('.download_title', file_set: file_set),
+                    target: "_blank",
+                    id: "file_download",
+                    class: "download",
+                    data: { label: file_set.id, work_id: @presenter.id, collection_ids: @presenter.member_of_collection_ids } %>
+      </li>
+    <% end %>
+
+    </ul>
+  </div>
+  <% end %>
+<% end %>

--- a/app/views/hyrax/file_sets/media_display/_audio.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_audio.html.erb
@@ -1,0 +1,26 @@
+<%# Overridden from Hyrax 3.5.0 - To add extra download restrictions %>
+<% if display_media_download_link?(file_set: file_set) %>
+  <div>
+      <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
+      <audio controls="controls" class="audiojs" style="width:100%" controlsList="nodownload" preload="auto">
+        <source src="<%= hyrax.download_path(file_set, file: 'ogg') %>" type="audio/ogg" />
+        <source src="<%= hyrax.download_path(file_set, file: 'mp3') %>" type="audio/mpeg" />
+        <%= t('hyrax.file_set.show.downloadable_content.audio_tag_not_supported') %>
+      </audio>
+    <% if Site.account.settings[:allow_downloads].nil? || Site.account.settings[:allow_downloads].to_i.nonzero? %>
+      <%= link_to t('hyrax.file_set.show.downloadable_content.audio_link'),
+                  hyrax.download_path(file_set),
+                  data: { label: file_set.id },
+                  target: :_blank,
+                  id: "file_download" %>
+    <% end %>
+    </div>
+<% else %>
+    <div>
+      <audio controls="controls" class="audiojs" style="width:100%" controlsList="nodownload" preload="auto">
+        <source src="<%= hyrax.download_path(file_set, file: 'ogg') %>" type="audio/ogg" />
+        <source src="<%= hyrax.download_path(file_set, file: 'mp3') %>" type="audio/mpeg" />
+        <%= t('hyrax.file_set.show.downloadable_content.audio_tag_not_supported') %>
+      </audio>
+    </div>
+<% end %>

--- a/app/views/hyrax/file_sets/media_display/_default.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_default.html.erb
@@ -1,0 +1,13 @@
+<%# Overridden from Hyrax 3.5.0 - To add extra download restrictions %>
+<div class="no-preview">
+  <%= t('hyrax.works.show.no_preview') %>
+  <% if Site.account.settings[:allow_downloads].nil? || Site.account.settings[:allow_downloads].to_i.nonzero? %>
+    <% if display_media_download_link?(file_set: file_set) %>
+      <p /><%= link_to t('hyrax.file_set.show.download'),
+      hyrax.download_path(file_set),
+      id: "file_download",
+      data: { label: file_set.id },
+      target: "_new" %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/hyrax/file_sets/media_display/_image.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_image.html.erb
@@ -1,0 +1,22 @@
+<%# Overridden from Hyrax 3.5.0 - To add extra download restrictions %>
+<% if display_media_download_link?(file_set: file_set) && (Site.account.settings[:allow_downloads].nil? || Site.account.settings[:allow_downloads].to_i.nonzero?) %>
+    <div>
+      <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: "",
+                    role: "presentation" %>
+      <%= link_to t('hyrax.file_set.show.downloadable_content.image_link'),
+                  hyrax.download_path(file_set),
+                  data: { label: file_set.id },
+                  target: :_blank,
+                  id: "file_download" %>
+    </div>
+<% else %>
+    <div>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: "",
+                    role: "presentation" %>
+    </div>
+<% end %>

--- a/app/views/hyrax/file_sets/media_display/_office_document.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_office_document.html.erb
@@ -1,0 +1,22 @@
+<%# Overridden from Hyrax 3.5.0 - To add extra download restrictions %>
+<% if display_media_download_link?(file_set: file_set) && (Site.account.settings[:allow_downloads].nil? || Site.account.settings[:allow_downloads].to_i.nonzero?) %>
+  <div>
+      <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: "",
+                    role: "presentation" %>
+      <%= link_to t('hyrax.file_set.show.downloadable_content.office_link'),
+                  hyrax.download_path(file_set),
+                  target: :_blank,
+                  id: "file_download",
+                  data: { label: file_set.id } %>
+    </div>
+<% else %>
+    <div>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: "",
+                    role: "presentation" %>
+    </div>
+<% end %>

--- a/app/views/hyrax/file_sets/media_display/_pdf.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_pdf.html.erb
@@ -1,0 +1,22 @@
+<%# Overridden from Hyrax 3.5.0 - To add extra download restrictions %>
+<% if display_media_download_link?(file_set: file_set) && (Site.account.settings[:allow_downloads].nil? || Site.account.settings[:allow_downloads].to_i.nonzero?) %>
+  <div>
+      <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: "",
+                    role: "presentation" %>
+      <%= link_to t('hyrax.file_set.show.downloadable_content.pdf_link'),
+                  hyrax.download_path(file_set),
+                  target: :_blank,
+                  id: "file_download",
+                  data: { label: file_set.id } %>
+    </div>
+<% else %>
+    <div>
+      <%= image_tag thumbnail_url(file_set),
+                    class: "representative-media",
+                    alt: "",
+                    role: "presentation" %>
+    </div>
+<% end %>

--- a/app/views/hyrax/file_sets/media_display/_video.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_video.html.erb
@@ -1,0 +1,24 @@
+<%# Overridden from Hyrax 3.5.0 - To add extra download restrictions %>
+<% if display_media_download_link?(file_set: file_set) && (Site.account.settings[:allow_downloads].nil? || Site.account.settings[:allow_downloads].to_i.nonzero?) %>
+  <div>
+      <h2 class="sr-only"><%= t('hyrax.file_set.show.downloadable_content.heading') %></h2>
+      <video controls="controls" class="video-js vjs-default-skin" style="width:100%" data-setup="{}" controlsList="nodownload" preload="auto">
+        <source src="<%= hyrax.download_path(file_set, file: 'webm') %>" type="video/webm" />
+        <source src="<%= hyrax.download_path(file_set, file: 'mp4') %>" type="video/mp4" />
+        <%= t('hyrax.file_set.show.downloadable_content.video_tag_not_supported') %>
+      </video>
+      <%= link_to t('hyrax.file_set.show.downloadable_content.video_link'),
+                  hyrax.download_path(file_set),
+                  data: { label: file_set.id },
+                  target: :_blank,
+                  id: "file_download" %>
+    </div>
+<% else %>
+    <div>
+      <video controls="controls" class="video-js vjs-default-skin" style="width:100%" data-setup="{}" controlsList="nodownload" preload="auto">
+        <source src="<%= hyrax.download_path(file_set, file: 'webm') %>" type="video/webm" />
+        <source src="<%= hyrax.download_path(file_set, file: 'mp4') %>" type="video/mp4" />
+        <%= t('hyrax.file_set.show.downloadable_content.video_tag_not_supported') %>
+      </video>
+    </div>
+<% end %>


### PR DESCRIPTION
wraps download links in an `if` statement that checks if `allow_downloads` is disabled