### PR TITLE
408-three-fold-approach

### DIFF
--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -15,6 +15,13 @@ module AccountSettings
     end
 
     setting :allow_signup, type: 'boolean', default: true
+    setting :analytics_id, type: 'string'
+    setting :analytics_oauth_app_name, type: 'string'
+    setting :analytics_oauth_app_version, type: 'string'
+    setting :analytics_oauth_private_key_secret, type: 'string'
+    setting :analytics_oauth_private_key_path, type: 'string'
+    setting :analytics_oauth_private_key_value, type: 'string'
+    setting :analytics_oauth_client_email, type: 'string'
     setting :bulkrax_validations, type: 'boolean', disabled: true
     setting :cache_api, type: 'boolean', default: false
     setting :contact_email, type: 'string', default: 'consortial-ir@palci.org'
@@ -29,13 +36,6 @@ module AccountSettings
     setting :google_scholarly_work_types, type: 'array', disabled: true
     setting :geonames_username, type: 'string', default: ''
     setting :gtm_id, type: 'string'
-    setting :analytics_id, type: 'string'
-    setting :analytics_oauth_app_name, type: 'string'
-    setting :analytics_oauth_app_version, type: 'string'
-    setting :analytics_oauth_private_key_secret, type: 'string'
-    setting :analytics_oauth_private_key_path, type: 'string'
-    setting :analytics_oauth_private_key_value, type: 'string'
-    setting :analytics_oauth_client_email, type: 'string'
     setting :locale_name, type: 'string', disabled: true
     setting :monthly_email_list, type: 'array', disabled: true
     setting :oai_admin_email, type: 'string', default: 'changeme@example.com'
@@ -192,6 +192,23 @@ module AccountSettings
     end
 
     def reload_analytics
+      # fall back to the default values if they aren't set in the tenant
+      unless analytics_id.present? &&
+        analytics_oauth_app_name.present? &&
+        analytics_oauth_app_version.present? &&
+        analytics_oauth_private_key_secret.present? &&
+        analytics_oauth_client_email.present? &&
+        (analytics_oauth_private_key_value.present? || analytics_oauth_private_key_path.present?)
+
+        config = Hyrax::Analytics::Config.load_from_yaml
+        analytics_id ||= config.analytics_id
+        analytics_oauth_app_name ||= config.app_name
+        analytics_oauth_app_version ||= config.app_version
+        analytics_oauth_private_key_secret ||= config.privkey_secret
+        analytics_oauth_private_key_value ||= config.privkey_value
+        analytics_oauth_client_email ||= config.client_email
+      end
+
       # require the analytics to be set per tenant
       Hyrax::Analytics.config.analytics_id = analytics_id
       Hyrax::Analytics.config.app_name = analytics_oauth_app_name

--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -194,11 +194,11 @@ module AccountSettings
     def reload_analytics
       # fall back to the default values if they aren't set in the tenant
       unless analytics_id.present? &&
-        analytics_oauth_app_name.present? &&
-        analytics_oauth_app_version.present? &&
-        analytics_oauth_private_key_secret.present? &&
-        analytics_oauth_client_email.present? &&
-        (analytics_oauth_private_key_value.present? || analytics_oauth_private_key_path.present?)
+             analytics_oauth_app_name.present? &&
+             analytics_oauth_app_version.present? &&
+             analytics_oauth_private_key_secret.present? &&
+             analytics_oauth_client_email.present? &&
+             (analytics_oauth_private_key_value.present? || analytics_oauth_private_key_path.present?)
 
         config = Hyrax::Analytics::Config.load_from_yaml
         analytics_id ||= config.analytics_id

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -1,12 +1,12 @@
 #
 # To integrate your app with Google Analytics, uncomment the lines below and add your API key information.
 #
-# analytics:
-#   google:
-#     analytics_id: <%= ENV['GOOGLE_ANALYTICS_ID'] %>
-#     app_name: <%= ENV['GOOGLE_OAUTH_APP_NAME'] %>
-#     app_version: <%= ENV['GOOGLE_OAUTH_APP_VERSION'] %>
-#     privkey_value: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_VALUE'] %>
-#     # OR privkey_path: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_PATH'] %>
-#     privkey_secret: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_SECRET'] %>
-#     client_email: <%= ENV['GOOGLE_OAUTH_CLIENT_EMAIL'] %>
+analytics:
+  google:
+    analytics_id: <%= ENV['GOOGLE_ANALYTICS_ID'] %>
+    app_name: <%= ENV['GOOGLE_OAUTH_APP_NAME'] %>
+    app_version: <%= ENV['GOOGLE_OAUTH_APP_VERSION'] %>
+    privkey_value: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_VALUE'] %>
+    # OR privkey_path: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_PATH'] %>
+    privkey_secret: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_SECRET'] %>
+    client_email: <%= ENV['GOOGLE_OAUTH_CLIENT_EMAIL'] %>


### PR DESCRIPTION
# Story
`HYRAX_ANALYTICS=true` is still set in the staging and prod environments so that the client doesn't miss any tracking. therefore, all the analytics partials still try to load. although the [config](https://github.com/scientist-softserv/palni-palci/blob/main/app/services/hyrax/analytics/google.rb#L28) got set initially, once we went through the hyku account settings, each config property [was set to an empty string](https://github.com/scientist-softserv/palni-palci/blob/main/app/models/concerns/account_settings.rb#L75-L80). so when the dashboard tried to load the user graph, the config was [invalid](https://github.com/scientist-softserv/palni-palci/blob/main/app/services/hyrax/analytics/google.rb#L113).

we need for the app to still be able to read from the env variables, (old way) while also setting some defaults in the account settings. (new way) (e.g., adding fallbacks in #reload_analytics). the values won't show up in the ui though, so the client can still set them individually. the changes in this pr will be removed in #487 so that we are only using the "per tenant" approach.

as background: this change was also necessary because of the changes made to [Hyrax::Analytics::Google#valid?](https://github.com/scientist-softserv/palni-palci/blob/main/app/services/hyrax/analytics/google.rb#L59-L65). the method changes are better because we _should_ be checking for the presence of values, not just keys. however, that's what caused us to need a fallback for our new settings fields.

Refs: 
- #408
- #479 

# Expected Behavior Before Changes
- the dashboard wouldn't load on staging because the analytics config was invalid

# Expected Behavior After Changes
- leave the default analytics settings until the customer has updated the tenant settings in each environment