### PR TITLE
444-show-depositors-not-creators-under-depositor-column-review-tab

### DIFF
--- a/app/views/hyrax/admin/workflows/index.html.erb
+++ b/app/views/hyrax/admin/workflows/index.html.erb
@@ -1,0 +1,95 @@
+<%# OVERRIDE: Hyrax v3.5.0 to show the user/depositor's display_name if available %>
+<% provide :page_header do %>
+  <h1><span class="fa fa-check-circle"></span> <%= t('.header') %></h1>
+<% end %>
+
+<div class="row">
+  <div class="col-md-12">
+    <div class="card tabs">
+      <ul class="nav nav-tabs" role="tablist">
+        <li class="nav-item active">
+          <a class="nav-link" href="#under-review" role="tab" data-toggle="tab"><%= t('.tabs.under_review') %></a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="#published" role="tab" data-toggle="tab"><%= t('.tabs.published') %></a>
+        </li>
+      </ul>
+      <div class="tab-content">
+        <div id="under-review" class="tab-pane active">
+          <div class="card labels">
+            <div class="card-body">
+              <div class="table-responsive">
+                <table class="table table-sm table-striped datatable">
+                  <thead>
+                    <tr>
+                      <th width="40%">Work</th>
+                      <th width="20%">Depositor</th>
+                      <th width="20%">Submission Date</th>
+                      <th width="20%">Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                  <% @status_list.each do |document| %>
+                      <tr>
+                        <td>
+                          <%= link_to document, [main_app, document] %>
+                        </td>
+                        <td>
+                          <%# OVERRIDE: show the user/depositor's display_name if available %>
+                          <% user = User.find_by(email: document.depositor) %>
+                          <%= user&.display_name.presence || document.depositor %>
+                        </td>
+                        <td>
+                          <%= document.date_modified %>
+                        </td>
+                        <td>
+                          <span class="state state-pending"><%= document.workflow_state %></span>
+                        </td>
+                      </tr>
+                    <% end %>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div id="published" class="tab-pane">
+          <div class="card labels">
+            <div class="card-body">
+              <div class="table-responsive">
+                <table class="table table-sm table-striped datatable">
+                  <thead>
+                    <tr>
+                      <th width="40%">Work</th>
+                      <th width="20%">Depositor</th>
+                      <th width="20%">Submission Date</th>
+                      <th width="20%">Status</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                  <% @published_list.each do |document| %>
+                    <div><%# = document %></div>
+                      <tr>
+                        <td>
+                          <%= link_to document, [main_app, document] %>
+                        </td>
+                        <td>
+                        <%= safe_join(document.creator, tag(:br)) %>
+                        <td>
+                          <%= document.date_modified %>
+                        </td>
+                        <td>
+                          <span class="state state-pending"><%= document.workflow_state %></span>
+                        </td>
+                      </tr>
+                    <% end %>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/hyrax/admin/workflows/index.html.erb
+++ b/app/views/hyrax/admin/workflows/index.html.erb
@@ -68,7 +68,6 @@
                   </thead>
                   <tbody>
                   <% @published_list.each do |document| %>
-                    <div><%# = document %></div>
                       <tr>
                         <td>
                           <%= link_to document, [main_app, document] %>

--- a/app/views/hyrax/admin/workflows/index.html.erb
+++ b/app/views/hyrax/admin/workflows/index.html.erb
@@ -37,7 +37,7 @@
                         <td>
                           <%# OVERRIDE: show the user/depositor's display_name if available %>
                           <% user = User.find_by(email: document.depositor) %>
-                          <%= user&.display_name.presence || document.depositor %>
+                          <%= user&.display_name.presence %>
                         </td>
                         <td>
                           <%= document.date_modified %>


### PR DESCRIPTION
Show the user that is the depositor by their display name if there is one, or leave blank.

# Story

Refs #444 

# Expected Behavior Before Changes
The Workflow Review page at app/views/admin/workflows/index.html.erb display's the works' creators metadata
# Expected Behavior After Changes
The Workflow Review page at app/views/admin/workflows/index.html.erb display's the depositors display name if there is one, leave blank.
# Screenshots / Video

<details>
<summary>CLICK FOR SCREENSHOTS OF WORK IN LOCAL DEV</summary>
Work:
<img width="1331" alt="Screenshot 2023-05-18 at 19 17 15" src="https://github.com/scientist-softserv/palni-palci/assets/63515648/e3009548-f632-4fd6-b6b4-3754c1c708e6">

Before:
<img width="1329" alt="Screenshot 2023-05-18 at 19 19 17" src="https://github.com/scientist-softserv/palni-palci/assets/63515648/3e825264-36be-4c2e-afeb-bbe5e3beddca">

After with display_name:
<img width="1330" alt="Screenshot 2023-05-18 at 19 08 14" src="https://github.com/scientist-softserv/palni-palci/assets/63515648/7137c20d-7984-4bd3-8cf6-087ce070aded">

After no display_name:
<img width="1330" alt="Screenshot 2023-05-18 at 19 20 15" src="https://github.com/scientist-softserv/palni-palci/assets/63515648/3949ef84-2468-487a-9c87-77ad88553d89">
</details>

# Notes