### PR TITLE
408-return-google-prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,39 +149,51 @@ Note: Google has announced they will stop processing data using the Universal An
 
 Analytics tracking and reporting features will be turned off by default. To enable them within Hyku, please follow the directions below.
 
-### Create the account
-#### Google
+
+### Google
+#### Create the account
+<!-- TODO: check for updates when we've moved to GA4 -->
 - Create an Analytics account: https://support.google.com/analytics/answer/10269537?hl=en
 - Enable the "Google Analytics API": https://developers.google.com/identity/protocols/oauth2/web-server#enable-apis
 - Create a Service Account:
   - https://developers.google.com/identity/protocols/oauth2/service-account#creatinganaccount
   - Please select the p12 format when making your service account key.
-  - Note the private key secret so we can add as an env variable in the subsequent steps below.
+  - Note the private key secret so we can add it to the tenant settings.
 - Configure OAuth 2.0 consent screen: https://support.google.com/cloud/answer/10311615?hl=en&ref_topic=3473162
 - Create an OAuth 2.0 Client ID: https://developers.google.com/identity/protocols/oauth2/web-server#creatingcred
 
-#### Matomo
-<!-- TODO -->
-
-### Set the Account Settings
+#### Set the Account Settings
 This applies to each of your environments: development/staging/production/etc.
 Dashboard >> Settings >> Account
 
 | Name | Description |
 | ------------- | ------------- |
-| ANALYTICS_ID | The Analytics account id. |
-| ANALYTICS_OAUTH_APP_NAME | The name of the application. |
-| ANALYTICS_OAUTH_APP_VERSION | The version of application. |
-| ANALYTICS_OAUTH_PRIVATE_KEY_SECRET | The secret provided when you created the key. |
-| ANALYTICS_OAUTH_PRIVATE_KEY_PATH | The full path to your p12, key file. |
-| ANALYTICS_OAUTH_PRIVATE_KEY_VALUE | The value of the p12 file with base64 encryption. |
-| ANALYTICS_OAUTH_CLIENT_EMAIL | OAuth Client email address. |
+| GOOGLE_ANALYTICS_ID | The ID of your Google Analytics account. |
+| GOOGLE_OAUTH_APP_NAME | The name of the Google application in the Google API console. |
+| GOOGLE_OAUTH_APP_VERSION | The version of the Google application in the Google API console. |
+| GOOGLE_OAUTH_PRIVATE_KEY_VALUE | The value of the p12 file with base64 encryption. |
+| GOOGLE_OAUTH_PRIVATE_KEY_PATH | The full path to your p12, key file. |
+| GOOGLE_OAUTH_PRIVATE_KEY_SECRET | The secret provided when you created the p12 key. |
+| GOOGLE_OAUTH_CLIENT_EMAIL | OAuth Client email address. |
 
-- To get the `ANALYTICS_OAUTH_PRIVATE_KEY_VALUE` value, you need the path to the p12 file you got from setting up your Service Account and run the following in your console locally.
+- To get the `GOOGLE_OAUTH_PRIVATE_KEY_VALUE` value, you need the path to the p12 file you got from setting up your Service Account and run the following in your console locally.
   - `base64 -i path/to/file.p12 | pbcopy`
   - Once you run this script the value is on your local computers clipboard. You will need to paste this into the corresponding account setting.
-- You can use the `ANALYTICS_OAUTH_PRIVATE_KEY_VALUE` OR `ANALYTICS_OAUTH_PRIVATE_KEY_PATH` value. VALUE takes precedence.
+- You can use the `GOOGLE_OAUTH_PRIVATE_KEY_VALUE` OR `GOOGLE_OAUTH_PRIVATE_KEY_PATH` value. VALUE takes precedence.
 
+### Matomo
+#### Create the account
+<!-- TODO -->
+
+#### Set the Account Settings
+This applies to each of your environments: development/staging/production/etc.
+Dashboard >> Settings >> Account
+
+| Name | Description |
+| ------------- | ------------- |
+| MATOMO_BASE_URL | |
+| MATOMO_SITE_ID | |
+| MATOMO_AUTH_TOKEN | |
 
 ## Environment Variables
 

--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -15,13 +15,13 @@ module AccountSettings
     end
 
     setting :allow_signup, type: 'boolean', default: true
-    setting :analytics_id, type: 'string'
-    setting :analytics_oauth_app_name, type: 'string'
-    setting :analytics_oauth_app_version, type: 'string'
-    setting :analytics_oauth_private_key_secret, type: 'string'
-    setting :analytics_oauth_private_key_path, type: 'string'
-    setting :analytics_oauth_private_key_value, type: 'string'
-    setting :analytics_oauth_client_email, type: 'string'
+    setting :google_analytics_id, type: 'string'
+    setting :google_oauth_app_name, type: 'string'
+    setting :google_oauth_app_version, type: 'string'
+    setting :google_oauth_private_key_value, type: 'string'
+    setting :google_oauth_private_key_path, type: 'string'
+    setting :google_oauth_private_key_secret, type: 'string'
+    setting :google_oauth_client_email, type: 'string'
     setting :bulkrax_validations, type: 'boolean', disabled: true
     setting :cache_api, type: 'boolean', default: false
     setting :contact_email, type: 'string', default: 'consortial-ir@palci.org'
@@ -193,30 +193,30 @@ module AccountSettings
 
     def reload_analytics
       # fall back to the default values if they aren't set in the tenant
-      unless analytics_id.present? &&
-             analytics_oauth_app_name.present? &&
-             analytics_oauth_app_version.present? &&
-             analytics_oauth_private_key_secret.present? &&
-             analytics_oauth_client_email.present? &&
-             (analytics_oauth_private_key_value.present? || analytics_oauth_private_key_path.present?)
+      unless google_analytics_id.present? &&
+             google_oauth_app_name.present? &&
+             google_oauth_app_version.present? &&
+             google_oauth_private_key_secret.present? &&
+             google_oauth_client_email.present? &&
+             (google_oauth_private_key_value.present? || google_oauth_private_key_path.present?)
 
         config = Hyrax::Analytics::Config.load_from_yaml
-        analytics_id ||= config.analytics_id
-        analytics_oauth_app_name ||= config.app_name
-        analytics_oauth_app_version ||= config.app_version
-        analytics_oauth_private_key_secret ||= config.privkey_secret
-        analytics_oauth_private_key_value ||= config.privkey_value
-        analytics_oauth_client_email ||= config.client_email
+        google_analytics_id ||= config.analytics_id
+        google_oauth_app_name ||= config.app_name
+        google_oauth_app_version ||= config.app_version
+        google_oauth_private_key_secret ||= config.privkey_secret
+        google_oauth_private_key_value ||= config.privkey_value
+        google_oauth_client_email ||= config.client_email
       end
 
       # require the analytics to be set per tenant
-      Hyrax::Analytics.config.analytics_id = analytics_id
-      Hyrax::Analytics.config.app_name = analytics_oauth_app_name
-      Hyrax::Analytics.config.app_version = analytics_oauth_app_version
-      Hyrax::Analytics.config.privkey_secret = analytics_oauth_private_key_secret
-      Hyrax::Analytics.config.privkey_path = analytics_oauth_private_key_path
-      Hyrax::Analytics.config.privkey_value = analytics_oauth_private_key_value
-      Hyrax::Analytics.config.client_email = analytics_oauth_client_email
+      Hyrax::Analytics.config.analytics_id = google_analytics_id
+      Hyrax::Analytics.config.app_name = google_oauth_app_name
+      Hyrax::Analytics.config.app_version = google_oauth_app_version
+      Hyrax::Analytics.config.privkey_value = google_oauth_private_key_value
+      Hyrax::Analytics.config.privkey_path = google_oauth_private_key_path
+      Hyrax::Analytics.config.privkey_secret = google_oauth_private_key_secret
+      Hyrax::Analytics.config.client_email = google_oauth_client_email
 
       # only show analytics partials if analytics are set on the tenant
       Hyrax.config.analytics = Hyrax::Analytics.config.valid?

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -13,13 +13,13 @@ en:
           url: Fedora URL should not end with a slash
         name: A single or hyphenated name used for technical aspects of the repository (e.g., "acme" or "acme-library").
         gtm_id: The ID of your Google Tag Manager account
-        analytics_id: The ID of your Analytics account
-        analytics_oauth_app_name: The name of the application
-        analytics_oauth_app_version: The version of application
-        analytics_oauth_private_key_secret: The secret provided when you created the key
-        analytics_oauth_private_key_path: The full path to your p12, key file
-        analytics_oauth_private_key_value: The value of the p12 file with base64 encryption
-        analytics_oauth_client_email: OAuth Client email address
+        google_analytics_id: The ID of your Google Analytics account
+        google_oauth_app_name: The name of the Google application in the Google API console
+        google_oauth_app_version: The version of the Google application in the Google API console
+        google_oauth_private_key_value: The value of the p12 file with base64 encryption
+        google_oauth_private_key_path: The full path to your p12, key file
+        google_oauth_private_key_secret: The secret provided when you created the p12 key
+        google_oauth_client_email: OAuth Client email address
         contact_email: Email recipient of messages sent via the contact form
         weekly_email_list: List of email addresses to email the weekly report. Leave a single space between each email
         monthly_email_list: List of email addresses to email the monthly report. Leave a single space between each email


### PR DESCRIPTION
# Story
I thought that the google and matomo variable names were the same, so I made all of the google analytics variables be generic. looking at the [hyrax analytics config](https://github.com/samvera/hyrax/blob/main/.dassie/config/analytics.yml) shows this not to be the case.

Refs:
- #408 
- #409 

# Expected Behavior Before Changes
- google analytics variable names were generic

# Expected Behavior After Changes
- return the "google" prefix to the google only analytics variable names
- update related form hints

# Screenshots / Video
![image](https://github.com/scientist-softserv/palni-palci/assets/29032869/8bf2b1b9-8e26-4904-bef9-7a48ac0f67f3)