### PR TITLE
408-for-the-last-time

### DIFF
--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -202,13 +202,13 @@ module AccountSettings
              self.google_oauth_client_email.present?
 
         config = Hyrax::Analytics::Config.load_from_yaml
-        self.google_analytics_id ||= config.analytics_id
-        self.google_oauth_app_name ||= config.app_name
-        self.google_oauth_app_version ||= config.app_version
-        self.google_oauth_private_key_value ||= config.privkey_value
-        self.google_oauth_private_key_path ||= config.privkey_path
-        self.google_oauth_private_key_secret ||= config.privkey_secret
-        self.google_oauth_client_email ||= config.client_email
+        self.google_analytics_id = self.google_analytics_id.presence || config.analytics_id
+        self.google_oauth_app_name = self.google_oauth_app_name.presence || config.app_name
+        self.google_oauth_app_version = self.google_oauth_app_version.presence || config.app_version
+        self.google_oauth_private_key_value = self.google_oauth_private_key_value.presence || config.privkey_value
+        self.google_oauth_private_key_path = self.google_oauth_private_key_path.presence || config.privkey_path
+        self.google_oauth_private_key_secret = self.google_oauth_private_key_secret.presence || config.privkey_secret
+        self.google_oauth_client_email = self.google_oauth_client_email.presence || config.client_email
       end
 
       # require the analytics to be set per tenant

--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -192,6 +192,7 @@ module AccountSettings
     end
 
     def reload_analytics
+      # rubocop:disable Style/RedundantSelf
       # fall back to the default values if they aren't set in the tenant
       unless self.google_analytics_id.present? &&
              self.google_oauth_app_name.present? &&
@@ -221,5 +222,6 @@ module AccountSettings
 
       # only show analytics partials if analytics are set on the tenant
       Hyrax.config.analytics = Hyrax::Analytics.config.valid?
+      # rubocop:enable Style/RedundantSelf
     end
 end

--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -15,13 +15,6 @@ module AccountSettings
     end
 
     setting :allow_signup, type: 'boolean', default: true
-    setting :google_analytics_id, type: 'string'
-    setting :google_oauth_app_name, type: 'string'
-    setting :google_oauth_app_version, type: 'string'
-    setting :google_oauth_private_key_value, type: 'string'
-    setting :google_oauth_private_key_path, type: 'string'
-    setting :google_oauth_private_key_secret, type: 'string'
-    setting :google_oauth_client_email, type: 'string'
     setting :bulkrax_validations, type: 'boolean', disabled: true
     setting :cache_api, type: 'boolean', default: false
     setting :contact_email, type: 'string', default: 'consortial-ir@palci.org'
@@ -36,6 +29,13 @@ module AccountSettings
     setting :google_scholarly_work_types, type: 'array', disabled: true
     setting :geonames_username, type: 'string', default: ''
     setting :gtm_id, type: 'string'
+    setting :google_analytics_id, type: 'string'
+    setting :google_oauth_app_name, type: 'string'
+    setting :google_oauth_app_version, type: 'string'
+    setting :google_oauth_private_key_value, type: 'string'
+    setting :google_oauth_private_key_path, type: 'string'
+    setting :google_oauth_private_key_secret, type: 'string'
+    setting :google_oauth_client_email, type: 'string'
     setting :locale_name, type: 'string', disabled: true
     setting :monthly_email_list, type: 'array', disabled: true
     setting :oai_admin_email, type: 'string', default: 'changeme@example.com'
@@ -193,30 +193,31 @@ module AccountSettings
 
     def reload_analytics
       # fall back to the default values if they aren't set in the tenant
-      unless google_analytics_id.present? &&
-             google_oauth_app_name.present? &&
-             google_oauth_app_version.present? &&
-             google_oauth_private_key_secret.present? &&
-             google_oauth_client_email.present? &&
-             (google_oauth_private_key_value.present? || google_oauth_private_key_path.present?)
+      unless self.google_analytics_id.present? &&
+             self.google_oauth_app_name.present? &&
+             self.google_oauth_app_version.present? &&
+             (self.google_oauth_private_key_value.present? || self.google_oauth_private_key_path.present?) &&
+             self.google_oauth_private_key_secret.present? &&
+             self.google_oauth_client_email.present?
 
         config = Hyrax::Analytics::Config.load_from_yaml
-        google_analytics_id ||= config.analytics_id
-        google_oauth_app_name ||= config.app_name
-        google_oauth_app_version ||= config.app_version
-        google_oauth_private_key_secret ||= config.privkey_secret
-        google_oauth_private_key_value ||= config.privkey_value
-        google_oauth_client_email ||= config.client_email
+        self.google_analytics_id ||= config.analytics_id
+        self.google_oauth_app_name ||= config.app_name
+        self.google_oauth_app_version ||= config.app_version
+        self.google_oauth_private_key_value ||= config.privkey_value
+        self.google_oauth_private_key_path ||= config.privkey_path
+        self.google_oauth_private_key_secret ||= config.privkey_secret
+        self.google_oauth_client_email ||= config.client_email
       end
 
       # require the analytics to be set per tenant
-      Hyrax::Analytics.config.analytics_id = google_analytics_id
-      Hyrax::Analytics.config.app_name = google_oauth_app_name
-      Hyrax::Analytics.config.app_version = google_oauth_app_version
-      Hyrax::Analytics.config.privkey_value = google_oauth_private_key_value
-      Hyrax::Analytics.config.privkey_path = google_oauth_private_key_path
-      Hyrax::Analytics.config.privkey_secret = google_oauth_private_key_secret
-      Hyrax::Analytics.config.client_email = google_oauth_client_email
+      Hyrax::Analytics.config.analytics_id = self.google_analytics_id
+      Hyrax::Analytics.config.app_name = self.google_oauth_app_name
+      Hyrax::Analytics.config.app_version = self.google_oauth_app_version
+      Hyrax::Analytics.config.privkey_value = self.google_oauth_private_key_value
+      Hyrax::Analytics.config.privkey_path = self.google_oauth_private_key_path
+      Hyrax::Analytics.config.privkey_secret = self.google_oauth_private_key_secret
+      Hyrax::Analytics.config.client_email = self.google_oauth_client_email
 
       # only show analytics partials if analytics are set on the tenant
       Hyrax.config.analytics = Hyrax::Analytics.config.valid?

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -7,6 +7,6 @@ analytics:
     app_name: <%= ENV['GOOGLE_OAUTH_APP_NAME'] %>
     app_version: <%= ENV['GOOGLE_OAUTH_APP_VERSION'] %>
     privkey_value: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_VALUE'] %>
-    # OR privkey_path: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_PATH'] %>
+    privkey_path: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_PATH'] %>
     privkey_secret: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_SECRET'] %>
     client_email: <%= ENV['GOOGLE_OAUTH_CLIENT_EMAIL'] %>

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -16,8 +16,8 @@ en:
         google_analytics_id: The ID of your Google Analytics account
         google_oauth_app_name: The name of the Google application in the Google API console
         google_oauth_app_version: The version of the Google application in the Google API console
-        google_oauth_private_key_value: The value of the p12 file with base64 encryption
-        google_oauth_private_key_path: The full path to your p12, key file
+        google_oauth_private_key_value: The value of the p12 file with base64 encryption. (You can use the private key value OR path; value takes precedence)
+        google_oauth_private_key_path: The full path to your p12, key file. (You can use the private key value OR path; value takes precedence)
         google_oauth_private_key_secret: The secret provided when you created the p12 key
         google_oauth_client_email: OAuth Client email address
         contact_email: Email recipient of messages sent via the contact form


### PR DESCRIPTION
# Story

Refs
- #408 
- #409 

# Expected Behavior Before Changes
- without setting tenant level account settings, the dashboard would load fine
- after adding and saving the account settings, the dashboard would err
  - this is because the user graph needs the correct [profile](https://github.com/scientist-softserv/palni-palci/blob/main/app/services/hyrax/analytics/google.rb#L112-L119). `Hyrax::Analytics.config.valid?` would return false however. while `Hyrax.config.analytics` would be true. (this may be a side effect of trying to have a fallback only, since `HYRAX_ANALYTICS=true` is set in the ENV variables)
  - either way, the correct settings would be set on the `Account.settings` object. 

# Expected Behavior After Changes
- usw `self` to make sure that everything gets set properly when reloading the analytics properties
- a user is able to see analytics related partials after tenant level analytics have been applied

# Screenshots / Video

![image](https://github.com/scientist-softserv/palni-palci/assets/29032869/66bf7387-c683-4747-a8f6-14e256f0bc34)