### PR TITLE
I507 show page error

### DIFF
--- a/app/presenters/hyku/work_show_presenter.rb
+++ b/app/presenters/hyku/work_show_presenter.rb
@@ -98,6 +98,5 @@ module Hyku
         end
         ref
       end
-
   end
 end

--- a/app/presenters/hyku/work_show_presenter.rb
+++ b/app/presenters/hyku/work_show_presenter.rb
@@ -31,13 +31,8 @@ module Hyku
     end
 
     # OVERRIDE FILE from Hyrax v2.9.0
-    # @return [Array] list to display with Kaminari pagination
-    # paginating on members so we can filter out derived status
+    # @return [String] title update for GenericWork
     Hyrax::WorkShowPresenter.class_eval do
-      def list_of_item_ids_to_display
-        paginated_item_list(page_array: members)
-      end
-
       def page_title
         if human_readable_type == "Generic Work"
           "#{title.first} | ID: #{id} | #{I18n.t('hyrax.product_name')}"
@@ -104,19 +99,5 @@ module Hyku
         ref
       end
 
-      # OVERRIDE FILE from Hyrax v2.9.0
-      # Gets the member id's for pagination, filter out derived files
-      Hyrax::WorkShowPresenter.class_eval do
-        def members
-          members = member_presenters_for(authorized_item_ids)
-          filtered_members =
-            if current_ability.admin?
-              members
-            else
-              members.reject { |m| m.solr_document['is_derived_ssi'] == 'true' }
-            end
-          filtered_members.collect(&:id)
-        end
-      end
   end
 end

--- a/app/views/hyrax/base/_items.html.erb
+++ b/app/views/hyrax/base/_items.html.erb
@@ -1,11 +1,6 @@
 <h2><%= t('.header') %></h2>
 <%  array_of_ids = presenter.list_of_item_ids_to_display %>
 <%  members = presenter.member_presenters_for(array_of_ids) %>
-<% 
-  if !current_user || !current_user.has_role?(:admin, Site.instance)
-    members = members.reject { |m| m.solr_document['is_derived_bsi'] == true }
-  end
-%>
 
 <% if members.present? %>
   <table class="table table-striped related-files">

--- a/lib/oai/provider/model_decorator.rb
+++ b/lib/oai/provider/model_decorator.rb
@@ -55,7 +55,7 @@ module OAI
           source: :source,
           subject: :subject,
           table_of_contents: :table_of_contents,
-          title: :title,
+          title: :title
         }
       end
       # rubocop:enable Metrics/MethodLength


### PR DESCRIPTION
# Story
Show page was getting an error 
```
private method `solr_document' called for #<Hyrax::IiifAv::IiifFileSetPresenter:0x0000ffff99dab0f8>
Did you mean?  solr_document=
```

Refs #507 

This was hitting old code from our previous attempt at splitting PDFs that was partially removed. This removes old code referencing "is_derived" files.

# Expected Behavior Before Changes
Show page hits error
# Expected Behavior After Changes
Show page does not error

# Notes
This was found on staging when a user is logged out.