### PR TITLE
Controlled vocab for contributing library

### DIFF
--- a/app/services/hyrax/contributing_library_service.rb
+++ b/app/services/hyrax/contributing_library_service.rb
@@ -1,0 +1,20 @@
+module Hyrax
+  # Provide select options for the types field
+  class ContributingLibraryService < QaSelectService
+    mattr_accessor :authority
+    self.authority = Qa::Authorities::Local.subauthority_for('contributing_libraries')
+    def initialize(_authority_name = nil)
+      super('contributing_libraries')
+    end
+
+    def self.select_options
+      authority.all.map do |element|
+        [element[:label], element[:id]]
+      end
+    end
+
+    def self.label(id)
+      authority.find(id).fetch('term')
+    end
+  end
+end

--- a/app/views/records/edit_fields/_contributing_library.html.erb
+++ b/app/views/records/edit_fields/_contributing_library.html.erb
@@ -1,0 +1,5 @@
+<%# CUSTOM: app/views/records/edit_fields/_format.html.erb  %>
+<%= f.input :contributing_library, as: :select,
+  collection: Hyrax::ContributingLibraryService.select_options,
+  input_html: { class: 'form-control', multiple: true }
+%>

--- a/config/authorities/contributing_libraries.yml
+++ b/config/authorities/contributing_libraries.yml
@@ -1,0 +1,7 @@
+terms:
+  - id: 123
+    term: Contributing Library 1
+  - id: 234
+    term: Contributing Library 2
+  - id: 345
+    term: Contributing Library 3


### PR DESCRIPTION
# Story
Makes contributing library into a controlled vocab

# Related
- #495

# Expected Behavior Before Changes
Contributing library was a regular field

# Expected Behavior After Changes
Contributing library is a controlled vocab, with 3 options - Contributing Library 1, Contributing Library 2, & Contributing Library 3

# Video

https://share.getcloudapp.com/12ukBJ9W

# Notes
- ids/terms of contributing libraries will need to be filled in: ticket for that below
- https://github.com/scientist-softserv/palni-palci/issues/511