### PR TITLE
i455-run-translations

### DIFF
--- a/config/locales/blacklight.de.yml
+++ b/config/locales/blacklight.de.yml
@@ -31,6 +31,7 @@ de:
           rights_tesim: Rechte
           subject_tesim: Fach
         show:
+          admin_note: Verwaltungshinweis
           based_near_label_tesim: Ort
           contributor_tesim: Mitwirkender
           creator_tesim: Schöpfer

--- a/config/locales/blacklight.es.yml
+++ b/config/locales/blacklight.es.yml
@@ -31,6 +31,7 @@ es:
           rights_tesim: Derechos
           subject_tesim: Tema
         show:
+          admin_note: Nota Administrativa
           based_near_label_tesim: Ubicación
           contributor_tesim: Contribuidor
           creator_tesim: Creador

--- a/config/locales/blacklight.fr.yml
+++ b/config/locales/blacklight.fr.yml
@@ -31,6 +31,7 @@ fr:
           rights_tesim: Droits
           subject_tesim: Assujettir
         show:
+          admin_note: Note administrative
           based_near_label_tesim: Emplacement
           contributor_tesim: Donateur
           creator_tesim: Créateur

--- a/config/locales/blacklight.it.yml
+++ b/config/locales/blacklight.it.yml
@@ -31,6 +31,7 @@ it:
           rights_tesim: Diritti
           subject_tesim: Soggetto
         show:
+          admin_note: Nota amministrativa
           based_near_label_tesim: luogo
           contributor_tesim: Collaboratore
           creator_tesim: Creatore

--- a/config/locales/blacklight.pt-BR.yml
+++ b/config/locales/blacklight.pt-BR.yml
@@ -31,6 +31,7 @@ pt-BR:
           rights_tesim: Direitos
           subject_tesim: Sujeito
         show:
+          admin_note: Nota Administrativa
           based_near_label_tesim: Localização
           contributor_tesim: Contribuinte
           creator_tesim: O Criador

--- a/config/locales/blacklight.zh.yml
+++ b/config/locales/blacklight.zh.yml
@@ -31,6 +31,7 @@ zh:
           rights_tesim: 权
           subject_tesim: 学科
         show:
+          admin_note: 行政说明
           based_near_label_tesim: 位置
           contributor_tesim: 贡献者
           creator_tesim: 创造者

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -180,15 +180,29 @@ de:
             custom_css:
               confirm: Benutzerdefiniertes CSS überschreibt immer andere Themenauswahlen. Vorgehen?
               warning: Wenn Ihre Themenanpassungen nicht korrekt angewendet werden, stellen Sie sicher, dass sie nicht von benutzerdefiniertem CSS überschrieben werden.
+            default_button_background_color:
+              hint: Schaltflächen für die Arbeitsinteraktion (Bearbeiten, Funktionen usw.); Arbeitsansichten auf der Sammlungsseite und Suchfilterschaltfläche.
             default_images:
               alert: Bitte laden Sie vor dem Absenden mindestens eine Datei hoch.
               hint: Für Standardbilder sollten Sie ein Bild (JPG, GIF oder PNG) verwenden, das die gleichen Abmessungen für Höhe und Breite aufweist (100 Pixel breit und 100 Pixel hoch).
             directory_image:
               hint: Das Verzeichnisbild sollte ein Bild (JPG, GIF oder PNG) verwenden. Die Breite des Bildes sollte nicht größer als die doppelte Höhe sein.
+            facet_panel_background_color:
+              hint: Gilt für Facetten und zusätzliche Abschnittsüberschriften auf den Arbeitsseiten einiger Themen.
+            facet_panel_text_color:
+              hint: Gilt bei einigen Themen auch für die Farbe des Caretzeichens neben dem Text und den Werktitel.
             favicon:
               hint: Favicons müssen PNG-Dateien und quadratisch sein. Die maximal verwendete Größe beträgt 228 x 228 Pixel.
+            link_color:
+              hint: 'Betrifft Links auf der Startseite und der Arbeitsseite, einschließlich: Breadcrumbs, Tabs, Titel und Nutzungsbedingungen.'
             logo_image:
               hint: Um ein Bild als Logo zu verwenden, sollten Sie ein Bild (JPG, GIF oder PNG) verwenden, das nicht höher als der Header und nicht breiter als 400 Pixel ist.
+            navbar_background_color:
+              hint: Bei 40 % Deckkraft.
+            navbar_link_background_hover_color:
+              hint: Gilt nur für die Schaltflächen „Startseite“, „Info“, „Kontakt“ und „Hilfe“ auf diesen spezifischen Seiten (bei 15 % Deckkraft).
+            primary_button_hover_color:
+              hint: Schaltflächen zum Teilen, Suchen und Sammeln von Interaktionen (Bearbeiten, Funktionen usw.). Der Rand dieser Schaltflächen wird ebenfalls diese Farbe haben.
             themes:
               confirm: Wenn Ihr Thema nicht richtig angewendet wird, stellen Sie sicher, dass es nicht von benutzerdefiniertem CSS überschrieben wird.
           hints:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -181,15 +181,29 @@ es:
             custom_css:
               confirm: CSS personalizado siempre anulará otras selecciones de temas. ¿Continuar?
               warning: Si sus personalizaciones de temas no parecen aplicarse correctamente, verifique que CSS personalizado no las sobrescriba.
+            default_button_background_color:
+              hint: Botones de interacción de trabajo (editar, función, etc.); vistas de trabajo en la página de colección y botón de filtro de búsqueda.
             default_images:
               alert: Cargue al menos un archivo antes de enviarlo.
               hint: Para las imágenes predeterminadas, debe usar una imagen (JPG, GIF o PNG) que tenga las mismas dimensiones de alto y ancho (100 píxeles de ancho y 100 píxeles de alto)
             directory_image:
               hint: La imagen del directorio debe usar una imagen (JPG, GIF o PNG). El ancho de la imagen no debe ser más ancho que el doble de la altura.
+            facet_panel_background_color:
+              hint: Se aplica a facetas y encabezados de sección adicionales en las páginas de trabajo en algunos temas.
+            facet_panel_text_color:
+              hint: También se aplica al color del símbolo de intercalación junto al texto y al título de la obra en algunos temas.
             favicon:
               hint: Los favicons deben ser archivos png y deben ser cuadrados. El tamaño máximo utilizado es 228px x 228px.
+            link_color:
+              hint: 'Afecta a los enlaces en las páginas de inicio y trabajo, incluidos: migas de pan, pestañas, títulos y términos de servicio.'
             logo_image:
               hint: Para usar una imagen como logotipo, debe usar una imagen (JPG, GIF o PNG) que no sea más alta que el encabezado ni más ancha que 400 píxeles de ancho.
+            navbar_background_color:
+              hint: Al 40% de opacidad.
+            navbar_link_background_hover_color:
+              hint: Se aplica a los botones Inicio, Acerca de, Contacto y Ayuda solo en esas páginas específicas (al 15 % de opacidad).
+            primary_button_hover_color:
+              hint: Botones para compartir, buscar e interactuar con la colección (editar, presentar, etc.). El borde de estos botones también será de este color.
             themes:
               confirm: Si su tema no parece aplicarse correctamente, verifique que no esté siendo sobrescrito por CSS personalizado.
           hints:

--- a/config/locales/etd.de.yml
+++ b/config/locales/etd.de.yml
@@ -3,6 +3,7 @@ de:
   hyrax:
     etd:
       labels:
+        admin_note: Verwaltungshinweise
         committee_member: Ausschussmitglied
         creator: Autor
         date_created: Datum

--- a/config/locales/etd.es.yml
+++ b/config/locales/etd.es.yml
@@ -3,6 +3,7 @@ es:
   hyrax:
     etd:
       labels:
+        admin_note: Notas Administrativas
         committee_member: miembro del Comité
         creator: Autor
         date_created: Fecha

--- a/config/locales/etd.fr.yml
+++ b/config/locales/etd.fr.yml
@@ -3,6 +3,7 @@ fr:
   hyrax:
     etd:
       labels:
+        admin_note: Remarques administratives
         committee_member: membre du comité
         creator: Auteur
         date_created: Date

--- a/config/locales/etd.it.yml
+++ b/config/locales/etd.it.yml
@@ -3,6 +3,7 @@ it:
   hyrax:
     etd:
       labels:
+        admin_note: Note Amministrative
         committee_member: membro del Comitato
         creator: Autore
         date_created: Data

--- a/config/locales/etd.pt-BR.yml
+++ b/config/locales/etd.pt-BR.yml
@@ -3,6 +3,7 @@ pt-BR:
   hyrax:
     etd:
       labels:
+        admin_note: Notas Administrativas
         committee_member: membro do Comitê
         creator: Autor
         date_created: Encontro

--- a/config/locales/etd.zh.yml
+++ b/config/locales/etd.zh.yml
@@ -3,6 +3,7 @@ zh:
   hyrax:
     etd:
       labels:
+        admin_note: 行政笔记
         committee_member: 委员会成员
         creator: 作者
         date_created: 日期

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -181,15 +181,29 @@ fr:
             custom_css:
               confirm: Le CSS personnalisé remplacera toujours les autres sélections de thèmes. Procéder?
               warning: Si vos personnalisations de thème ne semblent pas s'appliquer correctement, vérifiez qu'elles ne sont pas écrasées par CSS personnalisé.
+            default_button_background_color:
+              hint: Boutons d'interaction de travail (édition, fonctionnalité, etc.) ; vues de travail sur la page de collection et le bouton de filtre de recherche.
             default_images:
               alert: Veuillez télécharger au moins un fichier avant de soumettre.
               hint: Pour les images par défaut, vous devez utiliser une image (JPG, GIF ou PNG) qui a des dimensions de hauteur et de largeur égales (100 pixels de large et 100 pixels de haut)
             directory_image:
               hint: L'image du répertoire doit utiliser une image (JPG, GIF ou PNG). La largeur de l'image ne doit pas être plus large que 2x la hauteur.
+            facet_panel_background_color:
+              hint: S'applique aux facettes et aux en-têtes de section supplémentaires sur les pages de travail dans certains thèmes.
+            facet_panel_text_color:
+              hint: S'applique également à la couleur du caret à côté du texte et du titre de l'ouvrage sur certains thèmes.
             favicon:
               hint: Les favicons doivent être des fichiers png et doivent être carrés. La taille maximale utilisée est de 228px x 228px.
+            link_color:
+              hint: 'Affecte les liens sur les pages d''accueil et de travail, notamment : les fils d''Ariane, les onglets, les titres et les conditions d''utilisation.'
             logo_image:
               hint: Pour utiliser une image comme logo, vous devez utiliser une image (JPG, GIF ou PNG) qui n'est pas plus haute que l'en-tête et pas plus large que 400 pixels de large.
+            navbar_background_color:
+              hint: À 40% d'opacité.
+            navbar_link_background_hover_color:
+              hint: S'applique aux boutons Accueil, À propos, Contact et Aide de ces pages spécifiques uniquement (à 15 % d'opacité).
+            primary_button_hover_color:
+              hint: Boutons de partage, de recherche et d'interaction de collecte (édition, fonctionnalité, etc.). La bordure de ces boutons sera également de cette couleur.
             themes:
               confirm: Si votre thème ne semble pas s'appliquer correctement, vérifiez qu'il n'est pas écrasé par le CSS personnalisé.
           hints:

--- a/config/locales/generic_work.de.yml
+++ b/config/locales/generic_work.de.yml
@@ -1,6 +1,9 @@
 ---
 de:
   hyrax:
+    generic_work:
+      labels:
+        admin_note: Verwaltungshinweise
     icons:
       generic_work: fa fa-file-text-o
     select_type:

--- a/config/locales/generic_work.es.yml
+++ b/config/locales/generic_work.es.yml
@@ -1,6 +1,9 @@
 ---
 es:
   hyrax:
+    generic_work:
+      labels:
+        admin_note: Notas Administrativas
     icons:
       generic_work: fa fa-file-text-o
     select_type:

--- a/config/locales/generic_work.fr.yml
+++ b/config/locales/generic_work.fr.yml
@@ -1,6 +1,9 @@
 ---
 fr:
   hyrax:
+    generic_work:
+      labels:
+        admin_note: Remarques administratives
     icons:
       generic_work: fa fa-file-text-o
     select_type:

--- a/config/locales/generic_work.it.yml
+++ b/config/locales/generic_work.it.yml
@@ -1,6 +1,9 @@
 ---
 it:
   hyrax:
+    generic_work:
+      labels:
+        admin_note: Note Amministrative
     icons:
       generic_work: fa fa-file-text-o
     select_type:

--- a/config/locales/generic_work.pt-BR.yml
+++ b/config/locales/generic_work.pt-BR.yml
@@ -1,6 +1,9 @@
 ---
 pt-BR:
   hyrax:
+    generic_work:
+      labels:
+        admin_note: Notas Administrativas
     icons:
       generic_work: fa fa-file-text-o
     select_type:

--- a/config/locales/generic_work.zh.yml
+++ b/config/locales/generic_work.zh.yml
@@ -1,6 +1,9 @@
 ---
 zh:
   hyrax:
+    generic_work:
+      labels:
+        admin_note: 行政笔记
     icons:
       generic_work: fa fa-file-text-o
     select_type:

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -6,8 +6,10 @@ de:
     active_consent_to_agreement: Ich habe die ... gelesen und stimme ihnen zu
     activefedora:
       models:
+        etd: ETD
         generic_work: Arbeit
         image: Bild
+        oer: OER
     admin:
       admin_sets:
         delete:
@@ -1161,14 +1163,30 @@ de:
         contributor: Mitwirkender
         creator: Schöpfer
         date_created: Datum erstellt
+        default_button_background_color: Standardhintergrundfarbe der Schaltfläche
+        default_button_border_color: Standardfarbe des Schaltflächenrahmens
+        default_button_text_color: Standardfarbe für den Schaltflächentext
         description: Zusammenfassung oder Zusammenfassung
         embargo_release_date: bis um
+        facet_panel_background_color: Hintergrundfarbe des Facettenfelds
+        facet_panel_text_color: Textfarbe des Facettenbereichs
         files: Eine Datei hochladen
+        footer_link_color: Farbe des Fußzeilenlinks
+        footer_link_hover_color: Hover-Farbe des Fußzeilen-Links
+        header_and_footer_background_color: Hintergrundfarbe für Kopf- und Fußzeile
+        header_and_footer_text_color: Textfarbe für Kopf- und Fußzeile
         identifier: Kennung
         keyword: Stichwort
         lease_expiration_date: bis um
         license: Lizenz
+        link_color: Verknüpfungsfarbe
+        link_hover_color: Link-Hover-Farbe
         member_of_collection_ids: Zur Sammlung hinzufügen
+        navbar_background_color: Hintergrundfarbe der Navigationsleiste
+        navbar_link_background_hover_color: Hintergrundfarbe des Navigationsleisten-Links
+        navbar_link_text_color: Textfarbe für Navigationsleisten-Links
+        navbar_link_text_hover_color: Hover-Farbe des Navigationsleisten-Linktextes
+        primary_button_hover_color: Hover-Farbe der primären Schaltfläche
         publisher: Verleger
         related_url: Verwandte URL
         rights_statement: Rechteerklärung

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1167,14 +1167,30 @@ en:
         contributor: Contributor
         creator: Creator
         date_created: Date Created
+        default_button_background_color: Default button background color
+        default_button_border_color: Default button border color
+        default_button_text_color: Default button text color
         description: Description
         embargo_release_date: until
+        facet_panel_background_color: Facet panel background color
+        facet_panel_text_color: Facet panel text color
         files: Upload a file
+        footer_link_color: Footer link color
+        footer_link_hover_color: Footer link hover color
+        header_and_footer_background_color: Header and footer background color
+        header_and_footer_text_color: Header and footer text color
         identifier: Identifier
         keyword: Keyword
         lease_expiration_date: until
         license: License
+        link_color: Link color
+        link_hover_color: Link hover color
         member_of_collection_ids: Add to collection
+        navbar_background_color: Navbar background color
+        navbar_link_background_hover_color: Navbar link background hover color
+        navbar_link_text_color: Navbar link text color
+        navbar_link_text_hover_color: Navbar link text hover color
+        primary_button_hover_color: Primary button hover color
         publisher: Publisher
         related_url: Related URL
         rights_statement: Rights statement

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -6,8 +6,10 @@ es:
     active_consent_to_agreement: he leído y estoy de acuerdo con
     activefedora:
       models:
+        etd: EDT
         generic_work: Trabajo
         image: Imagen
+        oer: REA
     admin:
       admin_sets:
         delete:
@@ -1162,14 +1164,30 @@ es:
         contributor: Contribuyente
         creator: Creador
         date_created: fecha de creacion
+        default_button_background_color: Color de fondo predeterminado del botón
+        default_button_border_color: Color predeterminado del borde del botón
+        default_button_text_color: Color de texto de botón predeterminado
         description: Resumen o resumen
         embargo_release_date: hasta
+        facet_panel_background_color: Color de fondo del panel de facetas
+        facet_panel_text_color: Color del texto del panel de facetas
         files: Cargar un archivo
+        footer_link_color: Color del enlace de pie de página
+        footer_link_hover_color: Color de desplazamiento del enlace de pie de página
+        header_and_footer_background_color: Color de fondo de encabezado y pie de página
+        header_and_footer_text_color: Color de texto de encabezado y pie de página
         identifier: Identificador
         keyword: Palabra clave
         lease_expiration_date: hasta
         license: Licencia
+        link_color: Color de enlace
+        link_hover_color: Color de desplazamiento del enlace
         member_of_collection_ids: Añadir a la colección
+        navbar_background_color: Color de fondo de la barra de navegación
+        navbar_link_background_hover_color: Color de desplazamiento del fondo del vínculo de la barra de navegación
+        navbar_link_text_color: Color del texto del enlace de la barra de navegación
+        navbar_link_text_hover_color: Color de desplazamiento del texto del vínculo de la barra de navegación
+        primary_button_hover_color: Color de desplazamiento del botón principal
         publisher: Editor
         related_url: URL relacionada
         rights_statement: Declaración de derechos

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -6,8 +6,10 @@ fr:
     active_consent_to_agreement: j'ai lu et accepté les
     activefedora:
       models:
+        etd: ETD
         generic_work: Travail
         image: Image
+        oer: REL
     admin:
       admin_sets:
         delete:
@@ -1160,14 +1162,30 @@ fr:
         contributor: Donateur
         creator: Créateur
         date_created: date créée
+        default_button_background_color: Couleur d'arrière-plan du bouton par défaut
+        default_button_border_color: Couleur de bordure de bouton par défaut
+        default_button_text_color: Couleur du texte du bouton par défaut
         description: Résumé ou résumé
         embargo_release_date: jusqu'à ce que
+        facet_panel_background_color: Couleur d'arrière-plan du panneau de facettes
+        facet_panel_text_color: Couleur du texte du panneau des facettes
         files: Télécharger un fichier
+        footer_link_color: Couleur du lien de pied de page
+        footer_link_hover_color: Couleur de survol du lien de pied de page
+        header_and_footer_background_color: Couleur d'arrière-plan de l'en-tête et du pied de page
+        header_and_footer_text_color: Couleur du texte de l'en-tête et du pied de page
         identifier: Identifiant
         keyword: Mot-clé
         lease_expiration_date: jusqu'à ce que
         license: Licence
+        link_color: Couleur du lien
+        link_hover_color: Couleur de survol du lien
         member_of_collection_ids: Ajouter à la collection
+        navbar_background_color: Couleur d'arrière-plan de la barre de navigation
+        navbar_link_background_hover_color: Couleur de survol de l'arrière-plan du lien de la barre de navigation
+        navbar_link_text_color: Couleur du texte du lien de la barre de navigation
+        navbar_link_text_hover_color: Couleur de survol du texte du lien de la barre de navigation
+        primary_button_hover_color: Couleur de survol du bouton principal
         publisher: Éditeur
         related_url: URL associée
         rights_statement: Déclaration des droits

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -6,8 +6,10 @@ it:
     active_consent_to_agreement: Ho letto e accetto la
     activefedora:
       models:
+        etd: ETD
         generic_work: Lavoro
         image: Immagine
+        oer: OER
     admin:
       admin_sets:
         delete:
@@ -1162,14 +1164,30 @@ it:
         contributor: Collaboratore
         creator: Creatore
         date_created: data di creazione
+        default_button_background_color: Colore di sfondo del pulsante predefinito
+        default_button_border_color: Colore predefinito del bordo del pulsante
+        default_button_text_color: Colore predefinito del testo del pulsante
         description: Riepilogo o Riepilogo
         embargo_release_date: fino a
+        facet_panel_background_color: Colore di sfondo del pannello facet
+        facet_panel_text_color: Colore del testo del pannello facet
         files: Caricare un file
+        footer_link_color: Colore del collegamento a piè di pagina
+        footer_link_hover_color: Colore al passaggio del mouse del collegamento a piè di pagina
+        header_and_footer_background_color: Colore di sfondo dell'intestazione e del piè di pagina
+        header_and_footer_text_color: Colore del testo dell'intestazione e del piè di pagina
         identifier: Identificatore
         keyword: Parola chiave
         lease_expiration_date: fino a
         license: Licenza
+        link_color: Colore del collegamento
+        link_hover_color: Colore del collegamento al passaggio del mouse
         member_of_collection_ids: Aggiungere alla collezione
+        navbar_background_color: Colore di sfondo della barra di navigazione
+        navbar_link_background_hover_color: Colore di sfondo del collegamento della barra di navigazione al passaggio del mouse
+        navbar_link_text_color: Colore del testo del collegamento alla barra di navigazione
+        navbar_link_text_hover_color: Colore al passaggio del mouse del testo del collegamento della barra di navigazione
+        primary_button_hover_color: Colore del pulsante principale al passaggio del mouse
         publisher: Editore
         related_url: URL correlato
         rights_statement: Dichiarazione dei diritti

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -6,8 +6,10 @@ pt-BR:
     active_consent_to_agreement: Eu li e concordo com o
     activefedora:
       models:
+        etd: ETD
         generic_work: Trabalhos
         image: Imagem
+        oer: REA
     admin:
       admin_sets:
         delete:
@@ -1162,14 +1164,30 @@ pt-BR:
         contributor: Contribuinte
         creator: O Criador
         date_created: Data Criada
+        default_button_background_color: Cor de fundo do botão padrão
+        default_button_border_color: Cor padrão da borda do botão
+        default_button_text_color: Cor padrão do texto do botão
         description: Resumo ou Resumo
         embargo_release_date: até
+        facet_panel_background_color: Cor de fundo do painel de facetas
+        facet_panel_text_color: Cor do texto do painel de facetas
         files: Enviar um arquivo
+        footer_link_color: Cor do link do rodapé
+        footer_link_hover_color: Cor do foco do link do rodapé
+        header_and_footer_background_color: Cor de fundo do cabeçalho e rodapé
+        header_and_footer_text_color: Cor do texto do cabeçalho e rodapé
         identifier: Identificador
         keyword: Palavra-chave
         lease_expiration_date: até
         license: Licença
+        link_color: Cor do link
+        link_hover_color: Cor do foco do link
         member_of_collection_ids: Adicionar a coleção
+        navbar_background_color: Cor de fundo da barra de navegação
+        navbar_link_background_hover_color: Cor de foco do plano de fundo do link da barra de navegação
+        navbar_link_text_color: Cor do texto do link da barra de navegação
+        navbar_link_text_hover_color: Cor do foco do texto do link da barra de navegação
+        primary_button_hover_color: Cor principal do foco do botão
         publisher: Editor
         related_url: URL relacionado
         rights_statement: Declaração de direitos

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -6,8 +6,10 @@ zh:
     active_consent_to_agreement: 我已经阅读并且同意
     activefedora:
       models:
+        etd: 预计到达时间
         generic_work: 工作
         image: 图片
+        oer: 开放教育资源
     admin:
       admin_sets:
         delete:
@@ -1162,14 +1164,30 @@ zh:
         contributor: 贡献者
         creator: 创作者
         date_created: 创建日期
+        default_button_background_color: 默认按钮背景颜色
+        default_button_border_color: 默认按钮边框颜色
+        default_button_text_color: 默认按钮文字颜色
         description: 摘要或摘要
         embargo_release_date: 直到
+        facet_panel_background_color: 分面面板背景色
+        facet_panel_text_color: 构面面板文本颜色
         files: 上传一个文件
+        footer_link_color: 页脚链接颜色
+        footer_link_hover_color: 页脚链接悬停颜色
+        header_and_footer_background_color: 页眉和页脚背景颜色
+        header_and_footer_text_color: 页眉和页脚文本颜色
         identifier: 识别码
         keyword: 关键词
         lease_expiration_date: 直到
         license: 执照
+        link_color: 链接颜色
+        link_hover_color: 链接悬停颜色
         member_of_collection_ids: 添加到收藏
+        navbar_background_color: 导航栏背景颜色
+        navbar_link_background_hover_color: 导航栏链接背景悬停颜色
+        navbar_link_text_color: 导航栏链接文字颜色
+        navbar_link_text_hover_color: 导航栏链接文本悬停颜色
+        primary_button_hover_color: 主按钮悬停颜色
         publisher: 发行人
         related_url: 相关网址
         rights_statement: 权利声明

--- a/config/locales/image.de.yml
+++ b/config/locales/image.de.yml
@@ -3,6 +3,9 @@ de:
   hyrax:
     icons:
       image: fa fa-picture-o
+    image:
+      labels:
+        admin_note: Verwaltungshinweise
     select_type:
       image:
         description: Einzel- oder mehrseitiges Bild funktioniert.

--- a/config/locales/image.es.yml
+++ b/config/locales/image.es.yml
@@ -3,6 +3,9 @@ es:
   hyrax:
     icons:
       image: fa fa-picture-o
+    image:
+      labels:
+        admin_note: Notas Administrativas
     select_type:
       image:
         description: La imagen de una o varias páginas funciona.

--- a/config/locales/image.fr.yml
+++ b/config/locales/image.fr.yml
@@ -3,6 +3,9 @@ fr:
   hyrax:
     icons:
       image: fa fa-picture-o
+    image:
+      labels:
+        admin_note: Remarques administratives
     select_type:
       image:
         description: L'image simple ou multi-page fonctionne.

--- a/config/locales/image.it.yml
+++ b/config/locales/image.it.yml
@@ -3,6 +3,9 @@ it:
   hyrax:
     icons:
       image: fa fa-picture-o
+    image:
+      labels:
+        admin_note: Note Amministrative
     select_type:
       image:
         description: L'immagine singola o multi-pagina funziona.

--- a/config/locales/image.pt-BR.yml
+++ b/config/locales/image.pt-BR.yml
@@ -3,6 +3,9 @@ pt-BR:
   hyrax:
     icons:
       image: fa fa-picture-o
+    image:
+      labels:
+        admin_note: Notas Administrativas
     select_type:
       image:
         description: A imagem de uma ou várias páginas funciona.

--- a/config/locales/image.zh.yml
+++ b/config/locales/image.zh.yml
@@ -3,6 +3,9 @@ zh:
   hyrax:
     icons:
       image: fa fa-picture-o
+    image:
+      labels:
+        admin_note: 行政笔记
     select_type:
       image:
         description: 单页或多页图像工作。

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -181,15 +181,29 @@ it:
             custom_css:
               confirm: I CSS personalizzati sostituiranno sempre altre selezioni di temi. Procedere?
               warning: Se le personalizzazioni dei temi non sembrano essere applicate correttamente, verifica che non vengano sovrascritte dal CSS personalizzato.
+            default_button_background_color:
+              hint: Pulsanti di interazione con il lavoro (modifica, funzionalità, ecc.); viste di lavoro sulla pagina di raccolta e sul pulsante del filtro di ricerca.
             default_images:
               alert: Carica almeno un file prima di inviarlo.
               hint: Per le immagini predefinite, è necessario utilizzare un'immagine (JPG, GIF o PNG) che abbia le stesse dimensioni in altezza e larghezza (100 pixel in larghezza e 100 pixel in altezza)
             directory_image:
               hint: L'immagine della directory deve utilizzare un'immagine (JPG, GIF o PNG). La larghezza dell'immagine non dovrebbe essere più ampia di 2 volte l'altezza.
+            facet_panel_background_color:
+              hint: Si applica ai facet e alle intestazioni di sezione aggiuntive nelle pagine di lavoro in alcuni temi.
+            facet_panel_text_color:
+              hint: Vale anche per il colore del cursore accanto al testo e al titolo dell'opera su alcuni temi.
             favicon:
               hint: Le favicon devono essere file png e devono essere quadrate. La dimensione massima utilizzata è 228px x 228px.
+            link_color:
+              hint: 'Influisce sui collegamenti nelle pagine di casa e di lavoro, inclusi: breadcrumb, schede, titoli e termini di servizio.'
             logo_image:
               hint: Per utilizzare un'immagine come logo, è necessario utilizzare un'immagine (JPG, GIF o PNG) non più alta dell'intestazione e non più larga di 400 pixel.
+            navbar_background_color:
+              hint: Al 40% di opacità.
+            navbar_link_background_hover_color:
+              hint: Si applica ai pulsanti Home, Informazioni, Contatti e Guida solo su quelle pagine specifiche (con un'opacità del 15%).
+            primary_button_hover_color:
+              hint: Pulsanti di interazione di condivisione, ricerca e raccolta (modifica, funzionalità, ecc.). Anche il bordo di questi pulsanti sarà di questo colore.
             themes:
               confirm: Se il tuo tema non sembra essere applicato correttamente, verifica che non venga sovrascritto dal CSS personalizzato.
           hints:

--- a/config/locales/oer.de.yml
+++ b/config/locales/oer.de.yml
@@ -9,6 +9,7 @@ de:
         resource_type: Vordefinierte Kategorien, um die Art des hochgeladenen Inhalts zu beschreiben. Es können mehr als ein Typ ausgewählt werden.
         table_of_contents: Inhaltsverzeichnis einer Arbeit.
       labels:
+        admin_note: Verwaltungshinweise
         description: Beschreibung
         resource_type: Art
       show:
@@ -26,7 +27,7 @@ de:
         confirm:
           actions: Aktion
           cancel: Stornieren
-          header: 
+          header:
           remove: Entfernen
           text: Durch das Entfernen dieser alternativen Version wird sie nicht aus dem Repository entfernt, sondern nur aus dieser Arbeit. Möchten Sie diese alternative Version wirklich entfernen?
           title: Arbeitstitel

--- a/config/locales/oer.es.yml
+++ b/config/locales/oer.es.yml
@@ -9,6 +9,7 @@ es:
         resource_type: Categorías predefinidas que describen el tipo de contenido que se ha subido. Se puede seleccionar más de un tipo.
         table_of_contents: Tabla de contenidos de una obra.
       labels:
+        admin_note: Notas administrativas
         description: Descripción
         resource_type: Tipo
       show:
@@ -25,7 +26,7 @@ es:
         confirm:
           actions: Acción
           cancel: Cancelar
-          header: 
+          header:
           remove: Eliminar
           text: Eliminar esta versión alternativa no la eliminará del repositorio, solo de este trabajo. ¿Seguro que quieres eliminar esta versión alternativa?
           title: Título de trabajo

--- a/config/locales/oer.fr.yml
+++ b/config/locales/oer.fr.yml
@@ -9,6 +9,7 @@ fr:
         resource_type: Des catégories prédéfinies pour décrire le type de contenu en cours de chargement. Plus d'un type peut être sélectionné.
         table_of_contents: Table des matières d'une oeuvre.
       labels:
+        admin_note: Remarques administratives
         description: La description
         resource_type: Type
       show:
@@ -25,7 +26,7 @@ fr:
         confirm:
           actions: Action
           cancel: Annuler
-          header: 
+          header:
           remove: Retirer
           text: La suppression de cette version alternative ne la supprimera pas du référentiel, uniquement de ce travail. Voulez-vous vraiment supprimer cette version alternative?
           title: Titre de l'oeuvre

--- a/config/locales/oer.it.yml
+++ b/config/locales/oer.it.yml
@@ -9,6 +9,7 @@ it:
         resource_type: Categorie predefinite per descrivere il tipo di contenuto che viene caricato. Possono essere selezionati più di un tipo.
         table_of_contents: Indice di un'opera.
       labels:
+        admin_note: Note Amministrative
         description: Descrizione
         resource_type: genere
       show:
@@ -25,7 +26,7 @@ it:
         confirm:
           actions: Azione
           cancel: Annulla
-          header: 
+          header:
           remove: Rimuovere
           text: La rimozione di questa versione alternativa non la rimuoverà dal repository, ma solo da questo lavoro. Sei sicuro di voler rimuovere questa versione alternativa?
           title: Titolo dell'opera

--- a/config/locales/oer.pt-BR.yml
+++ b/config/locales/oer.pt-BR.yml
@@ -9,6 +9,7 @@ pt-BR:
         resource_type: Categorias pré-definidas para descrever o tipo de conteúdo que está sendo carregado. Mais de um tipo pode ser selecionado.
         table_of_contents: Sumário de um trabalho.
       labels:
+        admin_note: Notas Administrativas
         description: Descrição
         resource_type: Tipo
       show:
@@ -25,7 +26,7 @@ pt-BR:
         confirm:
           actions: Açao
           cancel: Cancelar
-          header: 
+          header:
           remove: Retirar
           text: A remoção desta versão alternativa não a removerá do repositório, apenas deste trabalho. Tem certeza de que deseja remover esta versão alternativa?
           title: Título do trabalho

--- a/config/locales/oer.zh.yml
+++ b/config/locales/oer.zh.yml
@@ -9,6 +9,7 @@ zh:
         resource_type: 预定类型用于描述上传内容类型。可以选择多项类型。
         table_of_contents: 作品目录。
       labels:
+        admin_note: 行政笔记
         description: 描述
         resource_type: 类型
       show:
@@ -25,7 +26,7 @@ zh:
         confirm:
           actions: 行动
           cancel: 取消
-          header: 
+          header:
           remove: 去掉
           text: 刪除此替代版本不會將其從存儲庫中刪除，僅會從此工作中刪除。您確定要刪除此備用版本嗎？
           title: 作品名称

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -181,15 +181,29 @@ pt-BR:
             custom_css:
               confirm: CSS personalizado sempre substituirá outras seleções de temas. Continuar?
               warning: Se suas personalizações de temas não parecem estar sendo aplicadas corretamente, verifique se elas não estão sendo substituídas pelo CSS personalizado.
+            default_button_background_color:
+              hint: Botões de interação do trabalho (editar, recurso, etc.); exibições de trabalho na página de coleção e botão de filtro de pesquisa.
             default_images:
               alert: Faça upload de pelo menos um arquivo antes de enviar.
               hint: Para imagens padrão, você deve usar uma imagem (JPG, GIF ou PNG) que tenha dimensões iguais de altura e largura (100 pixels de largura e 100 pixels de altura)
             directory_image:
               hint: A imagem do diretório deve usar uma imagem (JPG, GIF ou PNG). A largura da imagem não deve ser maior que 2x a altura.
+            facet_panel_background_color:
+              hint: Aplica-se a facetas e cabeçalhos de seção adicionais nas páginas de trabalho em alguns temas.
+            facet_panel_text_color:
+              hint: Aplica-se também à cor do cursor ao lado do texto e ao título da obra em alguns temas.
             favicon:
               hint: Os favicons precisam ser arquivos png e devem ser quadrados. O tamanho máximo usado é 228px x 228px.
+            link_color:
+              hint: 'Afeta links nas páginas inicial e de trabalho, incluindo: breadcrumbs, guias, títulos e termos de serviço.'
             logo_image:
               hint: Para usar uma imagem como logotipo, use uma imagem (JPG, GIF ou PNG) que não seja mais alta que o cabeçalho e que não tenha mais que 400 pixels de largura.
+            navbar_background_color:
+              hint: Com 40% de opacidade.
+            navbar_link_background_hover_color:
+              hint: Aplica-se apenas aos botões Início, Sobre, Contato e Ajuda nessas páginas específicas (com 15% de opacidade).
+            primary_button_hover_color:
+              hint: Botões de compartilhamento, pesquisa e interação de coleção (editar, recurso, etc.). A borda desses botões também será dessa cor.
             themes:
               confirm: Se o seu tema não parece estar sendo aplicado corretamente, verifique se ele não está sendo substituído pelo CSS personalizado.
           hints:

--- a/config/locales/simple_form.de.yml
+++ b/config/locales/simple_form.de.yml
@@ -22,6 +22,13 @@ de:
         file_acl: Deaktivieren Sie diese Option, wenn Sie ein Dateisystem wie Samba oder NFS verwenden, das das Festlegen von Zugriffssteuerungslisten nicht unterstützt
         file_size_limit: Dieser sollte mindestens auf 536870912000 eingestellt sein
         geonames_username: Registrieren Sie sich unter http://www.geonames.org/manageaccount
+        google_analytics_id: Die ID Ihres Google Analytics-Kontos
+        google_oauth_app_name: Der Name der Google-Anwendung in der Google API-Konsole
+        google_oauth_app_version: Die Version der Google-Anwendung in der Google API-Konsole
+        google_oauth_client_email: E-Mail-Adresse des OAuth-Clients
+        google_oauth_private_key_path: Der vollständige Pfad zu Ihrer p12-Schlüsseldatei. (Sie können den privaten Schlüsselwert ODER den Pfad verwenden; der Wert hat Vorrang)
+        google_oauth_private_key_secret: Das Geheimnis, das Sie bei der Erstellung des p12-Schlüssels angegeben haben
+        google_oauth_private_key_value: Der Wert der p12-Datei mit Base64-Verschlüsselung. (Sie können den privaten Schlüsselwert ODER den Pfad verwenden; der Wert hat Vorrang)
         gtm_id: Die ID Ihres Google Tag Manager-Kontos
         is_public: Können Benutzer Ihre Website auf der Homepage entdecken oder ohne einen speziellen Benutzernamen / ein spezielles Passwort auf Ihre Seiten zugreifen?
         locale_name: 'Der Name des mandantenspezifischen Gebietsschema-Suffixes, das den locale.yml-Dateien hinzugefügt wurde. Es dürfen nur Buchstaben hinzugefügt werden, keine Symbole oder Zahlen, diese werden dann groß geschrieben.
@@ -52,6 +59,8 @@ de:
         tenant: Mandanten UUID
       add_user_to_group:
         user_ids: Benutzeridentifikation
+      defaults:
+        admin_note: Verwaltungshinweise
       domain_names:
         cname: Domänenname
       group_search:

--- a/config/locales/simple_form.es.yml
+++ b/config/locales/simple_form.es.yml
@@ -22,6 +22,13 @@ es:
         file_acl: Desactívelo si usa un sistema de archivos como samba o nfs que no admita la configuración de listas de control de acceso
         file_size_limit: Esto debe establecerse en al menos 536870912000
         geonames_username: Regístrese en http://www.geonames.org/manageaccount
+        google_analytics_id: El ID de su cuenta de Google Analytics
+        google_oauth_app_name: El nombre de la aplicación de Google en la consola API de Google
+        google_oauth_app_version: La versión de la aplicación de Google en la consola API de Google
+        google_oauth_client_email: Dirección de correo electrónico del cliente de OAuth
+        google_oauth_private_key_path: La ruta completa a su p12, archivo clave. (Puede usar el valor de la clave privada O la ruta; el valor tiene prioridad)
+        google_oauth_private_key_secret: El secreto proporcionado cuando creó la clave p12
+        google_oauth_private_key_value: El valor del archivo p12 con cifrado base64. (Puede usar el valor de la clave privada O la ruta; el valor tiene prioridad)
         gtm_id: El ID de su cuenta de Google Tag Manager
         is_public: "¿Los usuarios pueden descubrir su sitio en la página de inicio o acceder a sus páginas sin un nombre de usuario/contraseña especiales?"
         locale_name: 'El nombre del sufijo de configuración regional específico del arrendatario agregado a sus archivos locale.yml. Solo se deben agregar caracteres alfabéticos, sin símbolos ni números, estos se escribirán en mayúscula.
@@ -52,6 +59,8 @@ es:
         tenant: Inquilino UUID
       add_user_to_group:
         user_ids: Identidad de usuario
+      defaults:
+        admin_note: Notas administrativas
       domain_names:
         cname: Nombre de dominio
       group_search:

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -22,6 +22,13 @@ fr:
         file_acl: Désactiver si vous utilisez un système de fichiers comme samba ou nfs qui ne prend pas en charge la définition de listes de contrôle d'accès
         file_size_limit: Il doit être défini sur au moins 536870912000
         geonames_username: Inscrivez-vous sur http://www.geonames.org/manageaccount
+        google_analytics_id: L'identifiant de votre compte Google Analytics
+        google_oauth_app_name: Le nom de l'application Google dans la console de l'API Google
+        google_oauth_app_version: La version de l'application Google dans la console de l'API Google
+        google_oauth_client_email: Adresse e-mail du client OAuth
+        google_oauth_private_key_path: Le chemin complet vers votre p12, fichier clé. (Vous pouvez utiliser la valeur de la clé privée OU le chemin ; la valeur est prioritaire)
+        google_oauth_private_key_secret: Le secret fourni lors de la création de la clé p12
+        google_oauth_private_key_value: La valeur du fichier p12 avec le cryptage base64. (Vous pouvez utiliser la valeur de la clé privée OU le chemin ; la valeur est prioritaire)
         gtm_id: L'identifiant de votre compte Google Tag Manager
         is_public: Les utilisateurs peuvent-ils découvrir votre site sur la page d'accueil ou accéder à vos pages sans nom d'utilisateur/mot de passe particulier ?
         locale_name: 'Le nom du suffixe de paramètres régionaux spécifiques au locataire ajouté à leurs fichiers locale.yml. Seuls les caractères alphabétiques doivent être ajoutés, pas de symboles ni de chiffres, ceux-ci seront alors en majuscules.
@@ -52,6 +59,8 @@ fr:
         tenant: UUID du locataire
       add_user_to_group:
         user_ids: Identifiant d'utilisateur
+      defaults:
+        admin_note: Remarques administratives
       domain_names:
         cname: Nom de domaine
       group_search:

--- a/config/locales/simple_form.it.yml
+++ b/config/locales/simple_form.it.yml
@@ -22,6 +22,13 @@ it:
         file_acl: Disattivare se si utilizza un file system come samba o nfs che non supporta l'impostazione degli elenchi di controllo degli accessi
         file_size_limit: Questo dovrebbe essere impostato almeno su 536870912000
         geonames_username: Registrati su http://www.geonames.org/manageaccount
+        google_analytics_id: L'ID del tuo account Google Analytics
+        google_oauth_app_name: Il nome dell'applicazione Google nella console dell'API di Google
+        google_oauth_app_version: La versione dell'applicazione Google nella console dell'API di Google
+        google_oauth_client_email: Indirizzo e-mail del client OAuth
+        google_oauth_private_key_path: Il percorso completo del tuo file chiave p12. (Puoi utilizzare il valore della chiave privata OR path; il valore ha la precedenza)
+        google_oauth_private_key_secret: Il segreto fornito quando hai creato la chiave p12
+        google_oauth_private_key_value: Il valore del file p12 con crittografia base64. (Puoi utilizzare il valore della chiave privata OR path; il valore ha la precedenza)
         gtm_id: L'ID del tuo account Google Tag Manager
         is_public: Gli utenti possono scoprire il tuo sito sulla home page o accedere alle tue pagine senza un nome utente/password speciale?
         locale_name: 'Il nome del suffisso locale specifico del tenant aggiunto ai relativi file locale.yml. Dovrebbero essere aggiunti solo caratteri alfabetici, nessun simbolo o numero, questi saranno poi scritti in maiuscolo.
@@ -52,6 +59,8 @@ it:
         tenant: UUID tenant
       add_user_to_group:
         user_ids: ID utente
+      defaults:
+        admin_note: Note Amministrative
       domain_names:
         cname: Nome del dominio
       group_search:

--- a/config/locales/simple_form.pt-BR.yml
+++ b/config/locales/simple_form.pt-BR.yml
@@ -22,6 +22,13 @@ pt-BR:
         file_acl: Desligue se estiver usando um sistema de arquivos como samba ou nfs que não suporta a configuração de listas de controle de acesso
         file_size_limit: Isso deve ser definido para pelo menos 536870912000
         geonames_username: Registre-se em http://www.geonames.org/manageaccount
+        google_analytics_id: O ID da sua conta do Google Analytics
+        google_oauth_app_name: O nome do aplicativo do Google no console de API do Google
+        google_oauth_app_version: A versão do aplicativo do Google no console de API do Google
+        google_oauth_client_email: Endereço de e-mail do cliente OAuth
+        google_oauth_private_key_path: O caminho completo para o seu p12, arquivo de chave. (Você pode usar o valor OU caminho da chave privada; o valor tem precedência)
+        google_oauth_private_key_secret: O segredo fornecido quando você criou a chave p12
+        google_oauth_private_key_value: O valor do arquivo p12 com criptografia base64. (Você pode usar o valor OU caminho da chave privada; o valor tem precedência)
         gtm_id: O ID da sua conta do Gerenciador de tags do Google
         is_public: Os usuários podem descobrir seu site na página inicial ou acessar suas páginas sem um nome de usuário/senha especial?
         locale_name: 'O nome do sufixo de localidade específico do locatário incluído em seus arquivos locale.yml. Apenas caracteres alfabéticos devem ser adicionados, sem símbolos ou números, estes serão então maiúsculos.
@@ -52,6 +59,8 @@ pt-BR:
         tenant: Inquilino UUID
       add_user_to_group:
         user_ids: ID do usuário
+      defaults:
+        admin_note: Notas Administrativas
       domain_names:
         cname: Nome do domínio
       group_search:

--- a/config/locales/simple_form.zh.yml
+++ b/config/locales/simple_form.zh.yml
@@ -22,6 +22,13 @@ zh:
         file_acl: 如果使用不支持设置访问控制列表的文件系统（如 samba 或 nfs），请关闭
         file_size_limit: 这应该至少设置为 536870912000
         geonames_username: 在 http://www.geonames.org/manageaccount 注册
+        google_analytics_id: 您的 Google Analytics 帐户的 ID
+        google_oauth_app_name: Google API 控制台中 Google 应用程序的名称
+        google_oauth_app_version: Google API 控制台中的 Google 应用程序版本
+        google_oauth_client_email: OAuth 客户端电子邮件地址
+        google_oauth_private_key_path: p12 密钥文件的完整路径。 （您可以使用私钥值或路径；值优先）
+        google_oauth_private_key_secret: 创建 p12 密钥时提供的秘密
+        google_oauth_private_key_value: base64加密的p12文件的值。 （您可以使用私钥值或路径；值优先）
         gtm_id: 您的 Google 跟踪代码管理器帐户的 ID
         is_public: 用户是否可以在主页上发现您的站点或在没有特殊用户名/密码的情况下访问您的页面？
         locale_name: '添加到其 locale.yml 文件的租户特定区域设置后缀的名称。只能添加字母字符，不能添加符号或数字，这些将被大写。
@@ -52,6 +59,8 @@ zh:
         tenant: 承租人 UUID
       add_user_to_group:
         user_ids: 用户名
+      defaults:
+        admin_note: 行政笔记
       domain_names:
         cname: 域名
       group_search:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -181,15 +181,29 @@ zh:
             custom_css:
               confirm: 自定义CSS将始终覆盖其他主题选择。继续？
               warning: 如果您的主题自定义设置似乎无法正确应用，请确认自定义CSS不会覆盖它们。
+            default_button_background_color:
+              hint: 工作交互（编辑、功能等）按钮；收藏页面和搜索过滤器按钮上的工作视图。
             default_images:
               alert: 请至少上传一个文件，然后再提交。
               hint: 对于默认图像，您应该使用高度和宽度尺寸（宽度为100像素，高度为100像素）的图像（JPG，GIF或PNG）
             directory_image:
               hint: 目录图像应使用图像（JPG、GIF 或 PNG）。图片的宽度不应超过高度的 2 倍。
+            facet_panel_background_color:
+              hint: 适用于某些主题中工作页面上的分面和附加节标题。
+            facet_panel_text_color:
+              hint: 也适用于文本旁边插入符号的颜色和某些主题的作品标题。
             favicon:
               hint: Favicons 需要是 png 文件并且必须是方形的。使用的最大尺寸为 228px x 228px
+            link_color:
+              hint: 影响主页和工作页面上的链接，包括：面包屑、标签、标题和服务条款。
             logo_image:
               hint: 要将图像用作徽标，应使用不大于标题且宽度不超过400像素的图像（JPG，GIF或PNG）。
+            navbar_background_color:
+              hint: 不透明度为 40%。
+            navbar_link_background_hover_color:
+              hint: 仅适用于这些特定页面上的“主页”、“关于”、“联系方式”和“帮助”按钮（不透明度为 15%）。
+            primary_button_hover_color:
+              hint: 共享、搜索和收藏交互（编辑、功能等）按钮。这些按钮的边框也将是这种颜色。
             themes:
               confirm: 如果您的主题似乎没有正确应用，请确认该主题未被Custom CSS覆盖。
           hints:


### PR DESCRIPTION
# Story

add locales and translations for color labels and hints

Refs
- #455
- #449 

# Expected Behavior Before Changes

-  `dashboard` > `appearance` > `colors` page only has English labels and hint text
# Expected Behavior After Changes

- `dashboard` > `appearance` > `colors` page has translations for labels and hint text in:
  - de
  - es
  - fr
  - it
  - pt-BR
  - zh

# Screenshots / Video

<details>
<summary>Translations have been generated</summary>

![Show Appearance 俳句 2023-06-01 at 5 35 43 PM](https://github.com/scientist-softserv/palni-palci/assets/29311858/c9856140-d360-4167-bdcc-461c60c9dc6a)
</details>

# Notes

- From the [Playbook article](https://playbook-staging.notch8.com/en/samvera/hyrax/how_to/generate_translations), it seems like translations are run across the entire repo (not a file-by-file basis). Thus, other translations (like for `admin note`) were generated as well (not just translations for color labels and hint text). I left them in this PR because we pay to use Google Translate's API key per character translated, so I didn't want to waste those credits.