### PR TITLE
Collection name display

### DIFF
--- a/app/forms/hyrax/forms/admin/appearance.rb
+++ b/app/forms/hyrax/forms/admin/appearance.rb
@@ -40,7 +40,8 @@ module Hyrax
           'default_button_text_color'          => '#333333',
           # 'active_tabs_background_color'     => '#337ab7',
           'facet_panel_background_color'       => '#f5f5f5',
-          'facet_panel_text_color'             => '#333333'
+          'facet_panel_text_color'             => '#333333',
+          'collection_banner_text_color'       => '#000000',
         }.freeze
 
         DEFAULT_VALUES = DEFAULT_FONTS.merge(DEFAULT_COLORS).freeze
@@ -124,6 +125,11 @@ module Hyrax
         # The color for the text in the header bar
         def header_and_footer_text_color
           block_for('header_and_footer_text_color')
+        end
+
+        # the color for the text (title and last updated date) inside of the collection banner
+        def collection_banner_text_color
+          block_for('collection_banner_text_color')
         end
 
         # The color for the background of the search navbar
@@ -391,6 +397,7 @@ module Hyrax
             directory_image_alt_text
             default_collection_image_text
             default_work_image_text
+            collection_banner_text_color
           ]
         end
 

--- a/app/views/shared/_appearance_styles.html.erb
+++ b/app/views/shared/_appearance_styles.html.erb
@@ -146,6 +146,14 @@ body.public-facing .panel-default > .panel-heading {
 body.public-facing .panel-default { border-color: <%= appearance.facet_panel_border_color %>; }
 body.public-facing .panel-heading.collapse-toggle .panel-title:after { color: <%= appearance.facet_panel_text_color %>; }
 
+/* COLLECTION STYLES */
+body.public-facing .hyc-banner .hyc-title h1 {
+  color: <%= appearance.collection_banner_text_color %>;
+}
+body.public-facing .hyc-last-updated {
+  color: <%= appearance.collection_banner_text_color %>;
+}
+
 <%= appearance.custom_css_block %>
 
 </style>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -214,6 +214,8 @@ en:
               hint: 'Applies to facets and additional section headers on the work pages in some themes.'
             facet_panel_text_color:
               hint: 'Also applies to the color of the caret next to the text and the work title on some themes.'
+            collection_banner_text_color:
+              hint: 'The color for the text (title, and last updated date) inside of the collection banner.'
           tabs:
             banner_image: "Banner Image"
             directory_image: "Directory Image"


### PR DESCRIPTION
# Story
Enables updating the collection title text color

# Related
- #518 

# Expected Behavior Before Changes
- collection title was set to white no matter what, making it hard to see if you don't add a banner

# Expected Behavior After Changes
- users can update the collection title/last updated text from the appearance styles "Collection Banner Text Color" setting

# Video
https://share.getcloudapp.com/X6u7rA24

# Notes