### PR TITLE
Facet count justification & filter x color

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -576,3 +576,9 @@ span.constraint-value p, .facet-values p {
   display: inline-block;
   margin-bottom: 0;
 }
+
+// make the facet counts appear at the end of the facet panel
+.facet-content .panel-body .facet-values p {
+  display: flex;
+  justify-content: space-between;
+}

--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -582,3 +582,8 @@ span.constraint-value p, .facet-values p {
   display: flex;
   justify-content: space-between;
 }
+
+// button to remove a filter should be red instead of white
+.remove.dropdown-toggle .glyphicon.glyphicon-remove {
+  color: #c4302b;
+}


### PR DESCRIPTION
# Story
#525 - On the facets on the search results page, the number of items that are available under a given heading are not justified and move around depending upon the length of the word or phrase from the facet.

#526 - The X to remove filters can be hard to see for many users. Change the color to make it more clear.

# Related 
- https://github.com/scientist-softserv/palni-palci/issues/525
- https://github.com/scientist-softserv/palni-palci/issues/526

# Screenshots

Facet count justification
<img width="963" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/73361970/606b55d4-7d45-4ff0-948a-bf47093d2747">

X is now red
<img width="713" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/73361970/60e11b2f-cce0-4611-9ca0-28c466bb8e5b">