### PR TITLE
Use current year

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,3 +1,4 @@
+<% current_year = Time.now.year %>
 <footer class="navbar navbar-inverse site-footer">
   <div class="container-fluid">
     <div class="navbar-text text-left">
@@ -6,7 +7,7 @@
     </div>
     <div class="navbar-right">
       <div class="navbar-text text-right">
-        <p><%= t('hyrax.footer.copyright_html') %></p>
+        <p><%= t('hyrax.footer.copyright_html', current_year: current_year) %></p>
         <p><%= t('hyrax.background_attribution_html') %></p>
         <% if admin_host? && !user_signed_in? %>
           <p><%= link_to t('hyku.footer.admin_login', default: [:'hyrax.toolbar.profile.login']), main_app.new_user_session_path %></p>

--- a/config/locales/hyrax.de.yml
+++ b/config/locales/hyrax.de.yml
@@ -809,7 +809,7 @@ de:
       groups_description:
         description_html: Die Liste der Gruppen in der Dropdown-Liste mit der Bezeichnung "Gruppe auswählen" ist eine Liste der vom Benutzer verwalteten Gruppen, in denen Sie Mitglied sind. Sie können eine bestimmte Gruppe auswählen und eine Zugriffsebene für eine Datei in %{application_name} zuweisen, ähnlich wie beim Hinzufügen von Benutzerzugriffsebenen.
     footer:
-      copyright_html: "<strong>Copyright © 2017 Samvera lizenziert</strong> unter der Apache Lizenz, Version 2.0"
+      copyright_html: "<strong>Copyright © 2019 - %{current_year} Samvera lizenziert</strong> unter der Apache Lizenz, Version 2.0"
       service_html: Ein Dienst von <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a> .
     help:
       header: Benutzer-Support

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -9,7 +9,7 @@ en:
     directory:
       suffix: "@hydrainabox.org"
     footer:
-      copyright_html: "<strong>Copyright &copy; 2019 Samvera</strong> Licensed under the Apache License, Version 2.0"
+      copyright_html: "<strong>Copyright &copy; 2019 - %{current_year} Samvera</strong> Licensed under the Apache License, Version 2.0"
       service_html: A service of <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.
     account_label: User
     activefedora:

--- a/config/locales/hyrax.es.yml
+++ b/config/locales/hyrax.es.yml
@@ -810,7 +810,7 @@ es:
       groups_description:
         description_html: La lista de grupos en el menú desplegable marcado "Seleccionar un grupo" es una lista de grupos administrados por usuarios de los que es miembro. Puede seleccionar un grupo específico y asignar un nivel de acceso para un archivo dentro de %{application_name}, de manera similar a agregar niveles de acceso de usuario.
     footer:
-      copyright_html: "<strong>Copyright &copy; 2019 Samvera</strong> bajo licencia de Apache, Version 2.0"
+      copyright_html: "<strong>Copyright &copy; 2019 - %{current_year} Samvera</strong> bajo licencia de Apache, Version 2.0"
       service_html: Un servicio de <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.
     help:
       header: Soporte al usuario

--- a/config/locales/hyrax.fr.yml
+++ b/config/locales/hyrax.fr.yml
@@ -808,7 +808,7 @@ fr:
       groups_description:
         description_html: La liste des groupes dans la liste déroulante intitulée «Sélectionnez un groupe» est une liste des groupes gérés par l'utilisateur dont vous êtes membre. Vous pouvez sélectionner un groupe spécifique et attribuer un niveau d'accès à un fichier dans %{application_name}, de la même manière que l'ajout de niveaux d'accès utilisateur.
     footer:
-      copyright_html: "<strong>Copyright © 2017 Samvera</strong> Licence sous Licence Apache, Version 2.0"
+      copyright_html: "<strong>Copyright © 2019 - %{current_year} Samvera</strong> Licence sous Licence Apache, Version 2.0"
       service_html: Un service de <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a> .
     help:
       header: Support utilisateur

--- a/config/locales/hyrax.it.yml
+++ b/config/locales/hyrax.it.yml
@@ -810,7 +810,7 @@ it:
       groups_description:
         description_html: L'elenco dei gruppi nel menu a discesa contrassegnato "Seleziona un gruppo" è un elenco di gruppi gestiti dall'utente di cui sei membro. È possibile selezionare un gruppo specifico e assegnare un livello di accesso per un file all'interno di %{application_name}, in modo simile all'aggiunta dei livelli di accesso dell'utente.
     footer:
-      copyright_html: "<strong>Copyright © 2017 Samvera</strong> Licenza sotto la licenza Apache, versione 2.0"
+      copyright_html: "<strong>Copyright © 2019 - %{current_year} Samvera</strong> Licenza sotto la licenza Apache, versione 2.0"
       service_html: Un servizio di <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a> .
     help:
       header: Supporto per l'utente

--- a/config/locales/hyrax.pt-BR.yml
+++ b/config/locales/hyrax.pt-BR.yml
@@ -810,7 +810,7 @@ pt-BR:
       groups_description:
         description_html: A lista de grupos no menu suspenso marcado "Selecionar um grupo" é uma lista de Grupos gerenciados por usuários dos quais você é membro. Você pode selecionar um grupo específico e atribuir um nível de acesso a um arquivo no %{application_name}, da mesma forma que adiciona níveis de acesso do usuário.
     footer:
-      copyright_html: "<strong>Copyright © 2017 Samvera Licenciado</strong> sob a Licença Apache, Versão 2.0"
+      copyright_html: "<strong>Copyright © 2019 - %{current_year} Samvera Licenciado</strong> sob a Licença Apache, Versão 2.0"
       service_html: Um serviço de <a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a> .
     help:
       header: Suporte ao usuário

--- a/config/locales/hyrax.zh.yml
+++ b/config/locales/hyrax.zh.yml
@@ -810,7 +810,7 @@ zh:
       groups_description:
         description_html: 标记为“选择组”的下拉列表中的组列表是您所属的用户管理组的列表。您可以选择特定的组并为%{application_name}中的文件分配访问级别，类似于添加用户访问级别。
     footer:
-      copyright_html: "<strong>版权所有 &copy; 2017 Samvera</strong> 根据Apache许可证2.0版许可"
+      copyright_html: "<strong>版权所有 &copy; 2019 - %{current_year} Samvera</strong> 根据Apache许可证2.0版许可"
       service_html: 的服务<a href="http://samvera.org/" class="navbar-link" target="_blank">Samvera</a>.
     help:
       header: 用户支援


### PR DESCRIPTION
# Story
In the footer update the 2019 Samvera copyright date to say 2019-2023 (with 2023 set to the current year).

# Related
- https://github.com/scientist-softserv/palni-palci/issues/531

# Acceptance

- [ ] The home page shows a copyright date of 2019 - 2023
- [ ] The copyright end date auto updates to the current year.