### PR TITLE
Switches thumbnail method for gallery view partial

### DIFF
--- a/app/views/catalog/_index_gallery_collection_wrapper.html.erb
+++ b/app/views/catalog/_index_gallery_collection_wrapper.html.erb
@@ -1,0 +1,10 @@
+<%# OVERRIDE: Hyrax 3.5 to use render_thumbnail_tag for gallery view partial %>
+<div class="document col-6 col-md-3">
+  <div class="thumbnail">
+  <h1>index_gallery_collection_wrapper</h1>
+    <%= render_thumbnail_tag document, {}, { full_url: true } %>
+    <div class="caption">
+      <%= render_document_partials document, blacklight_config.view_config(:gallery).partials, :document_counter => document_counter %>
+    </div>
+  </div>
+</div>

--- a/app/views/catalog/_index_gallery_collection_wrapper.html.erb
+++ b/app/views/catalog/_index_gallery_collection_wrapper.html.erb
@@ -1,7 +1,6 @@
 <%# OVERRIDE: Hyrax 3.5 to use render_thumbnail_tag for gallery view partial %>
 <div class="document col-6 col-md-3">
   <div class="thumbnail">
-  <h1>index_gallery_collection_wrapper</h1>
     <%= render_thumbnail_tag document, {}, { full_url: true } %>
     <div class="caption">
       <%= render_document_partials document, blacklight_config.view_config(:gallery).partials, :document_counter => document_counter %>


### PR DESCRIPTION
# Story

Refs #520 

When the gallery view is selected on the Search results page, the default collection thumbnail shows up when there is a collection thumbnail added to the collection.

Switching to use the render_thumbnail_tag fixes this and probably fixes the issue with shared search as well

# Expected Behavior Before Changes
Default thumbnail shows instead of collection thumbnail when you are using the gallery view
# Expected Behavior After Changes
Collection thumbnail shows up on the gallery view
# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes