### PR TITLE
I522 start over button

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -589,6 +589,6 @@ span.constraint-value p, .facet-values p {
 }
 
 .catalog_startOverLink {
-  font-size: 1.25em;
+  font-size: 1.15em;
   font-weight: bold;
 }

--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -587,3 +587,8 @@ span.constraint-value p, .facet-values p {
 .remove.dropdown-toggle .glyphicon.glyphicon-remove {
   color: #c4302b;
 }
+
+.catalog_startOverLink {
+  font-size: 1.25em;
+  font-weight: bold;
+}

--- a/app/views/catalog/_index_gallery_collection_wrapper.html.erb
+++ b/app/views/catalog/_index_gallery_collection_wrapper.html.erb
@@ -1,0 +1,10 @@
+<%# OVERRIDE: Hyrax 3.5 to use render_thumbnail_tag for gallery view partial %>
+<div class="document col-6 col-md-3">
+  <div class="thumbnail">
+  <h1>index_gallery_collection_wrapper</h1>
+    <%= render_thumbnail_tag document, {}, { full_url: true } %>
+    <div class="caption">
+      <%= render_document_partials document, blacklight_config.view_config(:gallery).partials, :document_counter => document_counter %>
+    </div>
+  </div>
+</div>

--- a/config/locales/blacklight.de.yml
+++ b/config/locales/blacklight.de.yml
@@ -48,3 +48,5 @@ de:
           rights_tesim: Rechte
           subject_tesim: Fach
           title_tesim: Titel
+    search:
+      start_over: Neue Suche

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -47,3 +47,5 @@ en:
           rights_tesim: Rights
           subject_tesim: Subject
           title_tesim: Title
+    search:
+      start_over: New Search

--- a/config/locales/blacklight.es.yml
+++ b/config/locales/blacklight.es.yml
@@ -48,3 +48,5 @@ es:
           rights_tesim: Derechos
           subject_tesim: Tema
           title_tesim: Título
+    search:
+      start_over: Nueva búsqueda

--- a/config/locales/blacklight.fr.yml
+++ b/config/locales/blacklight.fr.yml
@@ -48,3 +48,5 @@ fr:
           rights_tesim: Droits
           subject_tesim: Assujettir
           title_tesim: Titre
+    search:
+      start_over: Nouvelle recherche

--- a/config/locales/blacklight.it.yml
+++ b/config/locales/blacklight.it.yml
@@ -48,3 +48,5 @@ it:
           rights_tesim: Diritti
           subject_tesim: Soggetto
           title_tesim: Titolo
+    search:
+      start_over: Nuova ricerca

--- a/config/locales/blacklight.pt-BR.yml
+++ b/config/locales/blacklight.pt-BR.yml
@@ -48,3 +48,5 @@ pt-BR:
           rights_tesim: Direitos
           subject_tesim: Sujeito
           title_tesim: Título
+    search:
+      start_over: Nova pesquisa

--- a/config/locales/blacklight.zh.yml
+++ b/config/locales/blacklight.zh.yml
@@ -48,3 +48,5 @@ zh:
           rights_tesim: 权
           subject_tesim: 学科
           title_tesim: 标题
+    search:
+      start_over: 新搜索


### PR DESCRIPTION
# Story

Refs #522 

The start over button was confusing to users. Changed the text to "New Search" and make the font a little bigger and bolder.

# Expected Behavior Before Changes
Start over link was small
# Expected Behavior After Changes
Start over link is a bit bigger and now says "New Search"
# Screenshots / Video

<details>
<summary>New Search button</summary>
<img width="326" alt="Screenshot 2023-06-06 at 10 49 17 AM" src="https://github.com/scientist-softserv/palni-palci/assets/18175797/50a8727e-9298-4af2-979c-2af1eaa5ab3b">
</details>

# Notes