### PR TITLE
I534 citation editions

### DIFF
--- a/app/helpers/hyrax/citations_behaviors/formatters/apa_formatter.rb
+++ b/app/helpers/hyrax/citations_behaviors/formatters/apa_formatter.rb
@@ -38,12 +38,12 @@ module Hyrax
           return '' if authors_list.blank?
           authors_list = Array.wrap(authors_list).collect { |name| name.strip }
           text = ''
-          text += authors_list.first if authors_list.first
+          text += convert_to_initials(authors_list.first) if authors_list.first
           authors_list[1..-1].each do |author|
             text += if author == authors_list.last
-                      ", &amp; #{author}"
+                      ", &amp; #{convert_to_initials(author)}"
                     else
-                      ", #{author}"
+                      ", #{convert_to_initials(author)}"
                     end
           end
           text += "." unless text.end_with?(".")
@@ -72,6 +72,11 @@ module Hyrax
             else
               pub_info + "."
             end
+          end
+
+          def convert_to_initials(name)
+            name = name.split(" ")
+            name.map { |n| n.equal?(name.last) ? n.capitalize : n[0].capitalize }.join(". ")
           end
 
         public

--- a/app/views/catalog/_index_gallery_collection_wrapper.html.erb
+++ b/app/views/catalog/_index_gallery_collection_wrapper.html.erb
@@ -1,0 +1,10 @@
+<%# OVERRIDE: Hyrax 3.5 to use render_thumbnail_tag for gallery view partial %>
+<div class="document col-6 col-md-3">
+  <div class="thumbnail">
+  <h1>index_gallery_collection_wrapper</h1>
+    <%= render_thumbnail_tag document, {}, { full_url: true } %>
+    <div class="caption">
+      <%= render_document_partials document, blacklight_config.view_config(:gallery).partials, :document_counter => document_counter %>
+    </div>
+  </div>
+</div>

--- a/app/views/hyrax/base/_citations.html.erb
+++ b/app/views/hyrax/base/_citations.html.erb
@@ -11,21 +11,21 @@
          
 <div id="collapse-citations" class="collapse">
   <br/>
-  <h4>MLA citation style</h4>
+  <h4>MLA citation style (9th ed.)</h4>
   <span class="mla-citation"><%= export_as_mla_citation(@presenter) %>
-  <%= request.original_url %>
+  <%= request.original_url.sub(/^https?\:\/\/(www.)?/,'') %>.
   </span>
   <br /><br />
 
-  <h4>APA citation style</h4>
+  <h4>APA citation style (7th ed.)</h4>
   <span class="apa-citation"><%= export_as_apa_citation(@presenter) %>
    <%= request.original_url %>
   </span>
   <br /><br />
 
-  <h4>Chicago citation style</h4>
+  <h4>Chicago citation style (CMOS 17, author-date)</h4>
   <span class="chicago-citation"><%= export_as_chicago_citation(@presenter) %>
-  <%= request.original_url %></span>
+  <%= request.original_url %>.</span>
   <br /><br />
 
   <p>


### PR DESCRIPTION
# Story
Client requests updates to the Citations dropdown on the work show page
Refs #534 

# Expected Behavior Before Changes
Citations did not have editions, MLA link had http/https, APA did not use creator initials
# Expected Behavior After Changes
Updated Citations with Editions, add periods, remove http/https from MLA link, use initials on APA
# Screenshots / Video
<img width="345" alt="Screenshot 2023-06-06 at 11 39 59 AM" src="https://github.com/scientist-softserv/palni-palci/assets/18175797/b79d51f8-26d6-4a35-8383-00a69164a081">



# Notes