### PR TITLE
I548 fix specs

### DIFF
--- a/app/views/catalog/_index_gallery_collection_wrapper.html.erb
+++ b/app/views/catalog/_index_gallery_collection_wrapper.html.erb
@@ -1,0 +1,10 @@
+<%# OVERRIDE: Hyrax 3.5 to use render_thumbnail_tag for gallery view partial %>
+<div class="document col-6 col-md-3">
+  <div class="thumbnail">
+  <h1>index_gallery_collection_wrapper</h1>
+    <%= render_thumbnail_tag document, {}, { full_url: true } %>
+    <div class="caption">
+      <%= render_document_partials document, blacklight_config.view_config(:gallery).partials, :document_counter => document_counter %>
+    </div>
+  </div>
+</div>

--- a/spec/forms/hyrax/forms/permission_template_form_spec.rb
+++ b/spec/forms/hyrax/forms/permission_template_form_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
           count_template_accesses_for(user, access_level)
         }.from(0).to(1).and change {
           count_workflow_responsibilities_for(user)
-        }.from(0).to(9)
+        }.from(0).to(6)
       end
 
       it 'removes workflow responsibilities' do
@@ -79,7 +79,7 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
             permission_template.access_grants.find_by(agent_id: user.user_key, access: access_level)
           )
         end.to change { count_workflow_responsibilities_for(user) }
-          .from(9).to(0)
+          .from(6).to(0)
       end
     end
 
@@ -92,7 +92,7 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
           count_template_accesses_for(user, access_level)
         }.from(0).to(1).and change {
           count_workflow_responsibilities_for(user)
-        }.from(0).to(3)
+        }.from(0).to(2)
       end
 
       it 'removes workflow responsibilities' do
@@ -102,7 +102,7 @@ RSpec.describe Hyrax::Forms::PermissionTemplateForm do
             permission_template.access_grants.find_by(agent_id: user.user_key, access: access_level)
           )
         end.to change { count_workflow_responsibilities_for(user) }
-          .from(3).to(0)
+          .from(2).to(0)
       end
     end
 

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -116,15 +116,6 @@ RSpec.describe Etd do
       end
     end
 
-    context ':based_near' do
-      let(:etd) { FactoryBot.build(:etd) }
-      it 'is a property' do
-        etd.based_near = [Hyrax::ControlledVocabularies::Location.new]
-        expect(etd.resource.dump(:ttl)).to match(/xmlns.com\/foaf\/0.1\/based_near/)
-        expect(etd.based_near.first).to be_an_instance_of(Hyrax::ControlledVocabularies::Location)
-      end
-    end
-
     context ':source' do
       let(:etd) { FactoryBot.build(:etd) }
       it 'is a property' do

--- a/spec/views/hyrax/oers/_attribute_rows.html.erb_spec.rb
+++ b/spec/views/hyrax/oers/_attribute_rows.html.erb_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe 'hyrax/oers/_attributes.html.erb' do
   before do
     allow(presenter).to receive(:member_of_collection_presenters).and_return([])
     allow(view).to receive(:dom_class).and_return('')
-
+    allow(presenter).to receive(:editor?).and_return(true)
     render 'hyrax/oers/attribute_rows', presenter: presenter
   end
 


### PR DESCRIPTION
# Story
#548 
Fixes some specs
- based_near is not on ETD worktype so removed from ETD spec
- Changed permission template spec to match Hyku
- OER attribute rows added a can? ability so modified the test to account for that
# Expected Behavior Before Changes
specs fail in CI
# Expected Behavior After Changes
specs pass in CI
# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes