### PR TITLE
change the layout for the collection show page

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -600,3 +600,33 @@ span.constraint-value p, .facet-values p {
   font-size: 1.15em;
   font-weight: bold;
 }
+
+// collection show page styles
+
+.space-between {
+  justify-content: space-between;
+  align-items: center;
+}
+
+.mt-5 {
+  margin-top: 3em;
+}
+
+.hyc-banner {
+  padding: 15px;
+  .hyc-bugs .hyc-created-by, .hyc-bugs .hyc-last-updated, .hyc-title {
+    padding: 0;
+  }
+
+  .hyc-item-count {
+    margin: 0;
+    background: rgba(255, 255, 255, 0.75);
+    padding: 10px;
+    border-radius: 0.5em;
+    color: #333;
+  }
+
+  .hyc-bugs div, div {
+    position: relative;
+  }
+}

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -11,14 +11,42 @@
         <div class="hyc-generic">
       <% end %>
 
-      <div class="hyc-title">
-        <h1><%= markdown(@presenter.title.first) %></h1>
-        <%= @presenter.collection_type_badge %>
-        <%= @presenter.permission_badge %>
+      <div class='d-flex space-between'>
+        <div class="hyc-title">
+          <h1><%= markdown(@presenter.title.first) %></h1>
+          <%= @presenter.collection_type_badge %>
+          <%= @presenter.permission_badge %>
+        </div>
+        <div class="hyc-item-count">
+          <%= pluralize(@presenter.total_viewable_items, t('.item_count')) %>
+        </div>
+      </div>
+
+      <%# OVERRIDE here to add admin actions buttons to show page %>
+      <div class='show-actions-container'>
+        <% id = @presenter.id %>
+        <section class="collection-title-row-wrapper"
+          data-source="show"
+          data-id="<%= id %>"
+          data-colls-hash="<%= available_parent_collections_data(collection: @presenter) %>"
+          data-post-url="<%= hyrax.dashboard_create_nest_collection_within_path(id) %>"
+          data-post-delete-url="<%= hyrax.dashboard_collection_path(id) %>">
+          <div class="collection-title-row-content">
+            <%= render 'hyrax/dashboard/collections/show_actions', presenter: @presenter %>
+          </div>
+        </section>
+      </div>
+      <%# end OVERRIDE %>
+
+      <!-- Search bar -->
+      <div class='row'>
+        <div class="col-sm-8 mt-5">
+          <%= render 'search_form', presenter: @presenter, url: hyrax.collection_path(@presenter.id) %>
+        </div>
       </div>
 
       <% unless @presenter.logo_record.blank? %>
-          <div class="hyc-logos">
+          <div class="hyc-logos mt-5">
             <% @presenter.logo_record.each_with_index  do |lr, i| %>
                 <% if lr[:linkurl].blank? %>
                     <img alt="<%= lr[:alttext] %>" src="<%= lr[:file_location] %>" onerror="this.style.display='none'"/>
@@ -31,57 +59,40 @@
           </div>
       <% end %>
       <% unless @presenter.total_viewable_items.blank? %>
-          <div class="hyc-bugs">
-            <div class="hyc-item-count">
-              <%= pluralize(@presenter.total_viewable_items, t('.item_count')) %></div>
-            <% unless @presenter.creator.blank? %>
-                <div class="hyc-created-by">Created by: <%= @presenter.creator.first %></div>
-            <% end %>
-            <% unless @presenter.modified_date.blank? %>
-                <div class="hyc-last-updated">Last Updated: <%= @presenter.modified_date %></div>
-            <% end %>
-          </div>
+        <div class="hyc-bugs d-flex space-between">
+          <% unless @presenter.creator.blank? %>
+              <div class="hyc-created-by">Created by: <%= @presenter.creator.first %></div>
+          <% end %>
+          <% unless @presenter.modified_date.blank? %>
+              <div class="hyc-last-updated">Last Updated: <%= @presenter.modified_date %></div>
+          <% end %>
+        </div>
       <% end %>
 
       </div>
 
     </div>
   </div>
-  <%# OVERRIDE here to add admin actions buttons to show page %>
-  <div class='show-actions-container'>
-    <% id = @presenter.id %>
-    <section class="collection-title-row-wrapper"
-      data-source="show"
-      data-id="<%= id %>"
-      data-colls-hash="<%= available_parent_collections_data(collection: @presenter) %>"
-      data-post-url="<%= hyrax.dashboard_create_nest_collection_within_path(id) %>"
-      data-post-delete-url="<%= hyrax.dashboard_collection_path(id) %>">
-      <div class="collection-title-row-content">
-        <%= render 'hyrax/dashboard/collections/show_actions', presenter: @presenter %>
-      </div>
-    </section>
-  </div>
-  <%# end OVERRIDE %>
+
   <div class="row hyc-body">
-    <div class="col-md-8 hyc-description">
-      <%= render 'collection_description', presenter: @presenter %>
-      <% if @presenter.collection_type_is_nestable? && @presenter.total_parent_collections > 0 %>
-          <div class="hyc-blacklight hyc-bl-title">
-            <h2>
-              <%= t('.parent_collection_header') %> (<%= @presenter.total_parent_collections %>)
-            </h2>
-          </div>
-          <div class="hyc-blacklight hyc-bl-results">
-            <%= render 'show_parent_collections', presenter: @presenter %>
-          </div>
-      <% end %>
-
-    </div>
-    <div class="col-md-4 hyc-metadata">
+    <div class='col-md-3'>
       <%= render 'hyrax/collections/media_display', presenter: @presenter %>
+    </div>
+    <div class="col-md-9 hyc-metadata">
+      <h2><%= t('hyrax.dashboard.collections.show.metadata_header') %></h2>
+      <%= render 'collection_description', presenter: @presenter %>
       <% unless collection_search_parameters? %>
-          <h2><%= t('hyrax.dashboard.collections.show.metadata_header') %></h2>
-          <%= render 'show_descriptions' %>
+        <%= render 'show_descriptions' %>
+      <% end %>
+      <% if @presenter.collection_type_is_nestable? && @presenter.total_parent_collections > 0 %>
+        <div class="hyc-blacklight hyc-bl-title">
+          <h2>
+            <%= t('.parent_collection_header') %> (<%= @presenter.total_parent_collections %>)
+          </h2>
+        </div>
+        <div class="hyc-blacklight hyc-bl-results">
+          <%= render 'show_parent_collections', presenter: @presenter %>
+        </div>
       <% end %>
     </div>
   </div>
@@ -96,13 +107,6 @@
       <% end %>
     </div>
   <% end %>
-
-  <!-- Search bar -->
-  <div class="hyc-blacklight hyc-bl-search hyc-body row">
-    <div class="col-sm-8">
-      <%= render 'search_form', presenter: @presenter, url: hyrax.collection_path(@presenter.id) %>
-    </div>
-  </div>
 
   <!-- Subcollections -->
   <% if @presenter.collection_type_is_nestable? && @subcollection_count > 0 %>

--- a/app/views/hyrax/collections/show.html.erb
+++ b/app/views/hyrax/collections/show.html.erb
@@ -1,4 +1,4 @@
-<%# OVERRIDE Hyrax 2.9.1 add show actions buttons to collection show page, enable markdown in title %>
+<%# OVERRIDE Hyrax 3.5.0 to update the layout of the collection show page to be more visually appealing %>
 
 <% provide :page_title, construct_page_title(@presenter.title) %>
 <div class="hyc-container" itemscope itemtype="http://schema.org/CollectionPage">

--- a/app/views/shared/_appearance_styles.html.erb
+++ b/app/views/shared/_appearance_styles.html.erb
@@ -147,10 +147,9 @@ body.public-facing .panel-default { border-color: <%= appearance.facet_panel_bor
 body.public-facing .panel-heading.collapse-toggle .panel-title:after { color: <%= appearance.facet_panel_text_color %>; }
 
 /* COLLECTION STYLES */
-body.public-facing .hyc-banner .hyc-title h1 {
-  color: <%= appearance.collection_banner_text_color %>;
-}
-body.public-facing .hyc-last-updated {
+body.public-facing .hyc-banner .hyc-title h1,
+body.public-facing .hyc-last-updated,
+body.public-facing .hyc-created-by {
   color: <%= appearance.collection_banner_text_color %>;
 }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -72,7 +72,7 @@ if ENV['CHROME_HOSTNAME'].present?
 
   Capybara.register_driver :chrome do |app|
     # Uncomment this to run selenium tests with M1 Machines
-   # WebMock.allow_net_connect!
+    # WebMock.allow_net_connect!
     d = Capybara::Selenium::Driver.new(app,
                                        browser: :remote,
                                        desired_capabilities: capabilities,

--- a/spec/support/spec_statistic.rb
+++ b/spec/support/spec_statistic.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # This is a replacement for the OpenStruct usage. The idea is to expose
 # an object with a common interface.
 


### PR DESCRIPTION
# Story
- Edits to the collection:show page

# Related
- #523
- #528
- #529

# Wireframe
- https://github.com/scientist-softserv/palni-palci/issues/541
- [figma project](https://www.figma.com/file/mBmGMQCeoBNWhrsZmvCkvh/Pals-Collection-Show-Page?type=design&node-id=0-1&t=rGlmwNZt0iLc46tc-0)

# Screenshots / Video

<details>
<summary>Logged out</summary>

![screencapture-pals-hyku-test-collections-6c0938ef-5bb9-43f3-a07b-9156077b88d5-2023-06-07-13_26_21](https://github.com/scientist-softserv/palni-palci/assets/73361970/18f00987-91ce-46b1-8039-d613857c6d3b)

</details>

<details>
<summary>Logged in</summary>

![screencapture-pals-hyku-test-collections-6c0938ef-5bb9-43f3-a07b-9156077b88d5-2023-06-07-13_16_37](https://github.com/scientist-softserv/palni-palci/assets/73361970/2bc71d81-0ae5-4ca7-87e1-063492f43d82)


</details>

# Acceptance criteria
- [ ] White space is reduced on the page under the description
- [ ] Search bar is moved up
- [ ] Thumbnail size is comparatively smaller