### PR TITLE
I376 consortia links

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -103,7 +103,6 @@
 
   .consortia-logos {
     display: flex;
-    max-width: 20%;
     justify-content: flex-start;
     align-items: center;
     .img-responsive {
@@ -156,9 +155,8 @@
       max-width:80%;
     }
     .consortia-logos {
-      display: block;
+      flex-direction: column;
       max-width: 80%;
-      text-align: center;
       .img-responsive {
         padding: 20px;
       }

--- a/app/views/catalog/_index_gallery_collection_wrapper.html.erb
+++ b/app/views/catalog/_index_gallery_collection_wrapper.html.erb
@@ -1,0 +1,10 @@
+<%# OVERRIDE: Hyrax 3.5 to use render_thumbnail_tag for gallery view partial %>
+<div class="document col-6 col-md-3">
+  <div class="thumbnail">
+  <h1>index_gallery_collection_wrapper</h1>
+    <%= render_thumbnail_tag document, {}, { full_url: true } %>
+    <div class="caption">
+      <%= render_document_partials document, blacklight_config.view_config(:gallery).partials, :document_counter => document_counter %>
+    </div>
+  </div>
+</div>

--- a/app/views/splash/index.html.erb
+++ b/app/views/splash/index.html.erb
@@ -9,7 +9,7 @@
     <h1>Collaborative Repository</h1>
     <h3 class="splash-page">
       Welcome to our shared repository, where you'll find scholarly research, cultural heritage items, 
-      educational materials, and more from libraries across PALNI, PALCI, and other Hyku for Consortia partners.
+      educational materials, and more from libraries across PALNI, PALCI, and other <a href="http://hykuforconsortia.org/" target="_blank">Hyku for Consortia</a> partners.
     </h3>
     <h3 class="splash-page">
       Visit our public repositories one at a time by clicking on the icons below.
@@ -60,7 +60,7 @@
         </li>
       <% end %>
       <li><%= link_to "About", "https://www.hykuforconsortia.org", target: "blank" %></li>
-      <li><%= mail_to "consortial-ir@palci.org.", "Contact" %></li>
+      <li><%= mail_to "consortial-ir@palci.org", "Contact" %></li>
     </ul>
   </nav>
 </section>

--- a/app/views/splash/index.html.erb
+++ b/app/views/splash/index.html.erb
@@ -35,13 +35,13 @@
 <section class="partnering-consortia">
   <h3>Partnering consortia:</h3>
   <div class="consortia-logos">
-    <%= image_tag "palci.png", alt: "PALCI logo", class: "img-responsive" %>
+    <%= link_to image_tag("palci.png", alt: "PALCI logo", class: "img-responsive"), "https://palci.org/", target: "_blank" %>
 
-    <%= image_tag "palni.png", alt: "PALNI logo", class: "img-responsive" %>
+    <%= link_to image_tag("palni.png", alt: "PALNI logo", class: "img-responsive"), "https://palni.org/", target: "_blank" %>
 
-    <%= image_tag "louis.png", alt: "LOUIS logo", class: "img-responsive" %>
+    <%= link_to image_tag("louis.png", alt: "LOUIS logo", class: "img-responsive"), "https://www.louislibraries.org/", target: "_blank" %>
 
-    <%= image_tag "viva.png", alt: "VIVA logo", class: "img-responsive" %>
+    <%= link_to image_tag("viva.png", alt: "VIVA logo", class: "img-responsive"), "https://vivalib.org/", target: "_blank" %>
   </div>
 </section>
 


### PR DESCRIPTION
# Story
Consortia logos on the Splash page will be links to institutions home pages
Refs #376 

# Expected Behavior Before Changes
consortia logos were not links
# Expected Behavior After Changes
consortia logos are linked
# Screenshots / Video
<img width="1191" alt="Screenshot 2023-06-08 at 9 55 35 AM" src="https://github.com/scientist-softserv/palni-palci/assets/18175797/e17d7c11-8e07-44ea-90fa-40a6d38c1d75">


# Notes