### PR TITLE
Add source code editing to content editor

### DIFF
--- a/config/tinymce.yml
+++ b/config/tinymce.yml
@@ -4,13 +4,14 @@ content_block:
   <<: *default
   menubar: false
   image_uploadtab: true
-  toolbar1: styleselect | bold italic underline | link hr | undo redo | image
-  toolbar2: indent outdent | alignleft aligncenter alignright | table | fullscreen 
+  toolbar1: styleselect | bold italic underline | link hr | undo redo | image | code
+  toolbar2: indent outdent | alignleft aligncenter alignright | table | fullscreen
   plugins:
     - table
     - fullscreen
     - link
     - autolink
     - image
+    - code
 custom:
   <<: *default


### PR DESCRIPTION
# Story
- Adds the source code option to content editor
- The ticker said they also wanted images, but this had been added already

# Related
- #205 

# Expected Behavior Before Changes
- Could not edit source code of content blocks/custom pages

# Expected Behavior After Changes
- Can edit source code in the wysiwyg editor for all of the content blocks/custom pages

# Screenshots / Video

Video: https://github.com/scientist-softserv/palni-palci/pull/new/205-improved-text-editing

<details>
<summary>Custom pages will have the same editor options</summary>

<img width="1165" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/73361970/1435775f-9aa2-423f-836c-b5bc8f031fb6">

</details>

# Notes