### PR TITLE
Fix chrome container image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -220,7 +220,7 @@ services:
 
   chrome:
     # password is 'secret'
-    image: selenium/standalone-chrome-debug:3.141.59-20201010
+    image: seleniarm/standalone-chromium:latest
     logging:
       driver: none
     volumes:


### PR DESCRIPTION
# Story
Selenium specs currently do not run locally on M1 machines, and we are not able to see anything in the browser. This is a change from upstream hyku that enables running feature specs.

# Expected Behavior Before Changes
- Users with an m1 chip could not run any specs that used selenium (mostly in feature specs)

# Expected Behavior After Changes
- users should be able to see test run at `https://chrome.hyku.test`

# Related
- https://github.com/scientist-softserv/palni-palci/pull/551
