### PR TITLE
I516 missing locale

### DIFF
--- a/app/views/catalog/_index_gallery_collection_wrapper.html.erb
+++ b/app/views/catalog/_index_gallery_collection_wrapper.html.erb
@@ -1,0 +1,10 @@
+<%# OVERRIDE: Hyrax 3.5 to use render_thumbnail_tag for gallery view partial %>
+<div class="document col-6 col-md-3">
+  <div class="thumbnail">
+  <h1>index_gallery_collection_wrapper</h1>
+    <%= render_thumbnail_tag document, {}, { full_url: true } %>
+    <div class="caption">
+      <%= render_document_partials document, blacklight_config.view_config(:gallery).partials, :document_counter => document_counter %>
+    </div>
+  </div>
+</div>

--- a/app/views/layouts/hyrax.html.erb
+++ b/app/views/layouts/hyrax.html.erb
@@ -1,6 +1,6 @@
 <!-- add body classes to make styling easier -->
 <!DOCTYPE html>
-<html lang="<%= I18n.locale.to_s %>" prefix="og:http://ogp.me/ns#">
+<html lang="<%= I18n.locale.to_s || :en %>" prefix="og:http://ogp.me/ns#">
   <head>
     <%= render partial: 'layouts/head_tag_content' %>
     <%= content_for(:head) %>

--- a/app/views/themes/cultural_repository/layouts/hyrax.html.erb
+++ b/app/views/themes/cultural_repository/layouts/hyrax.html.erb
@@ -1,6 +1,6 @@
 <!-- add body classes to make styling easier for theming -->
 <!DOCTYPE html>
-<html lang="<%= I18n.locale.to_s %>" prefix="og:http://ogp.me/ns#">
+<html lang="<%= I18n.locale.to_s || :en %>" prefix="og:http://ogp.me/ns#">
   <head>
     <%= render partial: 'layouts/head_tag_content' %>
     <%= content_for(:head) %>

--- a/app/views/themes/institutional_repository/layouts/hyrax.html.erb
+++ b/app/views/themes/institutional_repository/layouts/hyrax.html.erb
@@ -1,6 +1,6 @@
 <% # OVERRIDE: Hyrax 2.9 template to add themeing body_classes %>
 <!DOCTYPE html>
-<html lang="<%= I18n.locale.to_s %>" prefix="og:http://ogp.me/ns#">
+<html lang="<%= I18n.locale.to_s || :en %>" prefix="og:http://ogp.me/ns#">
   <head>
     <%= render partial: 'layouts/head_tag_content' %>
     <%= content_for(:head) %>


### PR DESCRIPTION
# Story

Refs #516 

Pages fail to render because the locale is a blank string

This PR adds a default locale in the head tag to see if this fixes the error with locale being blank
# Expected Behavior Before Changes
Pages do not load
# Expected Behavior After Changes
Pages will load
# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes
