### PR TITLE
i567-creator-label-missing

### DIFF
--- a/config/locales/blacklight.de.yml
+++ b/config/locales/blacklight.de.yml
@@ -48,5 +48,4 @@ de:
           rights_tesim: Rechte
           subject_tesim: Fach
           title_tesim: Titel
-    search:
       start_over: Neue Suche

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -47,5 +47,4 @@ en:
           rights_tesim: Rights
           subject_tesim: Subject
           title_tesim: Title
-    search:
       start_over: New Search

--- a/config/locales/blacklight.es.yml
+++ b/config/locales/blacklight.es.yml
@@ -48,5 +48,4 @@ es:
           rights_tesim: Derechos
           subject_tesim: Tema
           title_tesim: Título
-    search:
       start_over: Nueva búsqueda

--- a/config/locales/blacklight.fr.yml
+++ b/config/locales/blacklight.fr.yml
@@ -48,5 +48,4 @@ fr:
           rights_tesim: Droits
           subject_tesim: Assujettir
           title_tesim: Titre
-    search:
       start_over: Nouvelle recherche

--- a/config/locales/blacklight.it.yml
+++ b/config/locales/blacklight.it.yml
@@ -48,5 +48,4 @@ it:
           rights_tesim: Diritti
           subject_tesim: Soggetto
           title_tesim: Titolo
-    search:
       start_over: Nuova ricerca

--- a/config/locales/blacklight.pt-BR.yml
+++ b/config/locales/blacklight.pt-BR.yml
@@ -48,5 +48,4 @@ pt-BR:
           rights_tesim: Direitos
           subject_tesim: Sujeito
           title_tesim: Título
-    search:
       start_over: Nova pesquisa

--- a/config/locales/blacklight.zh.yml
+++ b/config/locales/blacklight.zh.yml
@@ -48,5 +48,4 @@ zh:
           rights_tesim: 权
           subject_tesim: 学科
           title_tesim: 标题
-    search:
       start_over: 新搜索


### PR DESCRIPTION
# Story

fix nesting issue in locale files
Refs #567

The locale files had an extra `search`, which broke some nesting. The original `search` is on lines 4/5 of these files. The extra `search` broke locales on the search page:
- facets
- search results

## To Do:
- [x] en
- [x] de
- [x] es
- [x] fr
- [x] it
- [x] pt-BR
- [x] zh

# Expected Behavior Before Changes

- locales are broken for search page:
  - facets
  - search results

# Expected Behavior After Changes

- locales are fixed for search page:
  - facets
  - search results

# Screenshots / Video

<details>
<summary>Before changes: search page's facets and results had broken locales</summary>

![diembtran@yambookpro~devpalni-palci 2023-06-12 at 3 18 27 PM](https://github.com/scientist-softserv/palni-palci/assets/29311858/b358365c-299d-4125-ba63-f057cfb1f21c)
![diembtran@yambookpro~devpalni-palci 2023-06-12 at 3 17 41 PM](https://github.com/scientist-softserv/palni-palci/assets/29311858/4c8d6556-920c-4dc0-b9e7-68547761277e)
</details>

<details>
<summary>After changes: search page's facets and results locales are fixed. I also checked to make sure that the "New Search" text is correct in all languages</summary>

![Index Catalog Hyku Commons 2023-06-13 at 2 30 44 PM](https://github.com/scientist-softserv/palni-palci/assets/29311858/00255b60-f79d-403e-9c68-fa3d17b5563e)
![Index Catalog Hyku Commons 2023-06-13 at 2 31 14 PM](https://github.com/scientist-softserv/palni-palci/assets/29311858/3f4efc4c-c6e6-48af-92b5-4f70e8afe456)
![Index Catalog 俳句 2023-06-13 at 2 30 23 PM](https://github.com/scientist-softserv/palni-palci/assets/29311858/ee0410fe-9fda-431a-aca7-f119de8d3821)
![Index Catalog 俳句 2023-06-13 at 2 30 12 PM](https://github.com/scientist-softserv/palni-palci/assets/29311858/326f65f9-b842-48b9-bd03-5e37af8cbe05)
</details>

# Notes