### PR TITLE
Date Facet

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -153,3 +153,4 @@ gem 'pronto-rubocop', require: false
 
 gem "order_already", "~> 0.3.1"
 gem "redcarpet"
+gem 'blacklight_range_limit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,6 +171,11 @@ GEM
     blacklight_oai_provider (6.1.1)
       blacklight (~> 6.0)
       oai (~> 1.0)
+    blacklight_range_limit (7.0.1)
+      blacklight
+      jquery-rails
+      rails (>= 3.0)
+      tether-rails
     bolognese (1.9.17)
       activesupport (>= 4.2.5)
       benchmark_methods (~> 0.7)
@@ -1253,6 +1258,7 @@ DEPENDENCIES
   aws-sdk-sqs
   blacklight (~> 6.7)
   blacklight_oai_provider (~> 6.1, >= 6.1.1)
+  blacklight_range_limit
   bolognese (>= 1.9.10)
   bootstrap-datepicker-rails
   bulkrax (~> 4.3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -45,3 +45,9 @@
 //= require flot_graph
 //= require statistics_tab_manager
 //= require blacklight_gallery/default
+
+
+// For blacklight_range_limit built-in JS, if you don't want it you don't need
+// this:
+//= require 'blacklight_range_limit'
+

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -18,4 +18,9 @@
  *= require dataTables/bootstrap/3/jquery.dataTables.bootstrap
  *= require bootstrap-datepicker
  *= require_self
- */
+ 
+ *
+ * Used by blacklight_range_limit
+ *= require  'blacklight_range_limit'
+ *
+*/

--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -610,6 +610,14 @@ span.constraint-value p, .facet-values p {
   margin-top: 3em;
 }
 
+.mt-2 {
+  margin-top: 0.5em;
+}
+
+.mb-2 {
+  margin-bottom: .5em;
+}
+
 .hyc-banner {
   padding: 15px;
   .hyc-bugs .hyc-created-by, .hyc-bugs .hyc-last-updated, .hyc-title {
@@ -626,5 +634,13 @@ span.constraint-value p, .facet-values p {
 
   .hyc-bugs div, div {
     position: relative;
+  }
+}
+
+// date range limit - blacklight_range_limit gem
+form.range_limit.range_date_ssi {
+  line-height: 1.4;
+  input.range_begin, input.range_end {
+    width: auto;
   }
 }

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -66,7 +66,6 @@ class CatalogController < ApplicationController
     config.add_facet_field 'based_near_label_sim', limit: 5
     config.add_facet_field 'publisher_sim', limit: 5
     config.add_facet_field 'file_format_sim', limit: 5
-    # config.add_facet_field 'date_created_tesim', label: 'Date Created'
     config.add_facet_field 'date_ssi', label: 'Date Created', range: { num_segments: 10, assumed_boundaries: [1100, Time.zone.now.year + 2], segments: false, slider_js: false, maxlength: 4 }
     config.add_facet_field 'member_of_collections_ssim', limit: 5, label: 'Collections'
 

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class CatalogController < ApplicationController
-
   include BlacklightRangeLimit::ControllerOverride
   include Hydra::Catalog
   include Hydra::Controller::ControllerBehavior
@@ -68,7 +67,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'publisher_sim', limit: 5
     config.add_facet_field 'file_format_sim', limit: 5
     # config.add_facet_field 'date_created_tesim', label: 'Date Created'
-    config.add_facet_field 'date_ssi', label: 'Date Created', range: { num_segments: 10, assumed_boundaries: [1100, Time.now.year + 2], segments: false, slider_js: false, maxlength: 4 }
+    config.add_facet_field 'date_ssi', label: 'Date Created', range: { num_segments: 10, assumed_boundaries: [1100, Time.zone.now.year + 2], segments: false, slider_js: false, maxlength: 4 }
     config.add_facet_field 'member_of_collections_ssim', limit: 5, label: 'Collections'
 
     # Have BL send all facet field names to Solr, which has been the default

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CatalogController < ApplicationController
+
+  include BlacklightRangeLimit::ControllerOverride
   include Hydra::Catalog
   include Hydra::Controller::ControllerBehavior
   include BlacklightOaiProvider::Controller
@@ -65,6 +67,8 @@ class CatalogController < ApplicationController
     config.add_facet_field 'based_near_label_sim', limit: 5
     config.add_facet_field 'publisher_sim', limit: 5
     config.add_facet_field 'file_format_sim', limit: 5
+    # config.add_facet_field 'date_created_tesim', label: 'Date Created'
+    config.add_facet_field 'date_ssi', label: 'Date Created', range: { num_segments: 10, assumed_boundaries: [1100, Time.now.year + 2], segments: false, slider_js: false, maxlength: 4 }
     config.add_facet_field 'member_of_collections_ssim', limit: 5, label: 'Collections'
 
     # Have BL send all facet field names to Solr, which has been the default

--- a/app/controllers/search_history_controller.rb
+++ b/app/controllers/search_history_controller.rb
@@ -1,0 +1,6 @@
+class SearchHistoryController < ApplicationController
+  include Blacklight::SearchHistory
+
+  helper BlacklightRangeLimit::ViewHelperOverride
+  helper RangeLimitHelper
+end

--- a/app/indexers/app_indexer.rb
+++ b/app/indexers/app_indexer.rb
@@ -23,7 +23,7 @@ class AppIndexer < Hyrax::WorkIndexer
     # The allowed date formats are either YYYY, YYYY-MM, or YYYY-MM-DD
     # the date must be formatted as a 4 digit year in order to be sorted.
     valid_date_formats = /\A(\d{4})(?:-\d{2}(?:-\d{2})?)?\z/
-    date_string = solr_doc['date_created_tesim'].first
+    date_string = solr_doc['date_created_tesim']&.first
     year = date_string.match(valid_date_formats)&.captures&.first
     solr_doc['date_tesi'] = year if year
     solr_doc['date_ssi'] = year if year

--- a/app/indexers/app_indexer.rb
+++ b/app/indexers/app_indexer.rb
@@ -13,7 +13,19 @@ class AppIndexer < Hyrax::WorkIndexer
   def generate_solr_document
     super.tap do |solr_doc|
       solr_doc['title_ssi'] = SortTitle.new(object.title.first).alphabetical
-      solr_doc["account_cname_tesim"] = Site.instance&.account&.cname
+      solr_doc['bulkrax_identifier_tesim'] = object.bulkrax_identifier
+      solr_doc['account_cname_tesim'] = Site.instance&.account&.cname
+      add_date(solr_doc)
     end
+  end
+
+  def add_date(solr_doc)
+    # The allowed date formats are either YYYY, YYYY-MM, or YYYY-MM-DD
+    # the date must be formatted as a 4 digit year in order to be sorted.
+    valid_date_formats = /\A(\d{4})(?:-\d{2}(?:-\d{2})?)?\z/
+    date_string = solr_doc['date_created_tesim'].first
+    year = date_string.match(valid_date_formats)&.captures&.first
+    solr_doc['date_tesi'] = year if year
+    solr_doc['date_ssi'] = year if year
   end
 end

--- a/app/indexers/app_indexer.rb
+++ b/app/indexers/app_indexer.rb
@@ -24,7 +24,7 @@ class AppIndexer < Hyrax::WorkIndexer
     # the date must be formatted as a 4 digit year in order to be sorted.
     valid_date_formats = /\A(\d{4})(?:-\d{2}(?:-\d{2})?)?\z/
     date_string = solr_doc['date_created_tesim']&.first
-    year = date_string.match(valid_date_formats)&.captures&.first
+    year = date_string&.match(valid_date_formats)&.captures&.first
     solr_doc['date_tesi'] = year if year
     solr_doc['date_ssi'] = year if year
   end

--- a/app/indexers/etd_indexer.rb
+++ b/app/indexers/etd_indexer.rb
@@ -2,20 +2,11 @@
 
 # Generated via
 #  `rails generate hyrax:work Etd`
-class EtdIndexer < Hyrax::WorkIndexer
-  # This indexes the default metadata. You can remove it if you want to
-  # provide your own metadata and indexing.
-  include Hyrax::IndexesBasicMetadata
-
-  # Fetch remote labels for based_near. You can remove this if you don't want
-  # this behavior
-  include Hyrax::IndexesLinkedMetadata
+class EtdIndexer < AppIndexer
 
   # Uncomment this block if you want to add custom indexing behavior:
   def generate_solr_document
     super.tap do |solr_doc|
-      solr_doc['bulkrax_identifier_tesim'] = object.bulkrax_identifier
-      solr_doc['title_ssi'] = SortTitle.new(object.title.first).alphabetical
       solr_doc['admin_note_tesim'] = object.admin_note
     end
   end

--- a/app/indexers/etd_indexer.rb
+++ b/app/indexers/etd_indexer.rb
@@ -3,7 +3,6 @@
 # Generated via
 #  `rails generate hyrax:work Etd`
 class EtdIndexer < AppIndexer
-
   # Uncomment this block if you want to add custom indexing behavior:
   def generate_solr_document
     super.tap do |solr_doc|

--- a/app/indexers/oer_indexer.rb
+++ b/app/indexers/oer_indexer.rb
@@ -3,7 +3,6 @@
 # Generated via
 #  `rails generate hyrax:work Oer`
 class OerIndexer < AppIndexer
-
   # Uncomment this block if you want to add custom indexing behavior:
   def generate_solr_document
     super.tap do |solr_doc|

--- a/app/indexers/oer_indexer.rb
+++ b/app/indexers/oer_indexer.rb
@@ -2,20 +2,11 @@
 
 # Generated via
 #  `rails generate hyrax:work Oer`
-class OerIndexer < Hyrax::WorkIndexer
-  # This indexes the default metadata. You can remove it if you want to
-  # provide your own metadata and indexing.
-  include Hyrax::IndexesBasicMetadata
-
-  # Fetch remote labels for based_near. You can remove this if you don't want
-  # this behavior
-  include Hyrax::IndexesLinkedMetadata
+class OerIndexer < AppIndexer
 
   # Uncomment this block if you want to add custom indexing behavior:
   def generate_solr_document
     super.tap do |solr_doc|
-      solr_doc['bulkrax_identifier_tesim'] = object.bulkrax_identifier
-      solr_doc['title_ssi'] = SortTitle.new(object.title.first).alphabetical
       solr_doc['admin_note_tesim'] = object.admin_note
     end
   end

--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -56,6 +56,10 @@ class Etd < ActiveFedora::Base
     index.as :stored_searchable
   end
 
+  property :date, predicate: ::RDF::URI("https://hykucommons.org/terms/date"), multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
+
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -21,6 +21,10 @@ class GenericWork < ActiveFedora::Base
     index.as :stored_searchable
   end
 
+  property :date, predicate: ::RDF::URI("https://hykucommons.org/terms/date"), multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
+
   include ::Hyrax::BasicMetadata
   # This line must be kept below all others that set up properties,
   # including `include ::Hyrax::BasicMetadata`. All properties must

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -25,6 +25,10 @@ class Image < ActiveFedora::Base
     index.as :stored_searchable
   end
 
+  property :date, predicate: ::RDF::URI("https://hykucommons.org/terms/date"), multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
+
   # This must come after the properties because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata

--- a/app/models/oer.rb
+++ b/app/models/oer.rb
@@ -93,6 +93,10 @@ class Oer < ActiveFedora::Base
     index.as :stored_searchable
   end
 
+  property :date, predicate: ::RDF::URI("https://hykucommons.org/terms/date"), multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
+
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -2,6 +2,8 @@
 
 class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
+  include BlacklightRangeLimit::RangeLimitBuilder
+
   include Hydra::AccessControlsEnforcement
   include Hyrax::SearchFilters
 end

--- a/app/presenters/hyku/work_show_presenter.rb
+++ b/app/presenters/hyku/work_show_presenter.rb
@@ -6,7 +6,7 @@ module Hyku
   class WorkShowPresenter < Hyrax::WorkShowPresenter
     Hyrax::MemberPresenterFactory.file_presenter_class = Hyrax::FileSetPresenter
 
-    delegate :title_or_label, :extent, :additional_information, :source, :bibliographic_citation, :admin_note, to: :solr_document
+    delegate :title_or_label, :extent, :additional_information, :source, :bibliographic_citation, :admin_note, :date, to: :solr_document
 
     # OVERRIDE Hyrax v2.9.0 here to make featured collections work
     delegate :collection_presenters, to: :member_presenter_factory
@@ -39,7 +39,7 @@ module Hyku
           "#{title.first} | ID: #{id} | #{I18n.t('hyrax.product_name')}"
         else
           "#{human_readable_type} | #{title.first} | ID: #{id} | #{I18n.t('hyrax.product_name')}"
-        end 
+        end
       end
     end
 

--- a/app/views/blacklight_range_limit/_range_limit_panel.html.erb
+++ b/app/views/blacklight_range_limit/_range_limit_panel.html.erb
@@ -1,0 +1,100 @@
+<%- # requires solr_config local passed in
+  field_config = range_config(field_name)
+  label = facet_field_label(field_name)
+
+  input_label_range_begin = field_config[:input_label_range_begin] || t("blacklight.range_limit.range_begin", field_label: label)
+  input_label_range_end   = field_config[:input_label_range_end] || t("blacklight.range_limit.range_end", field_label: label)
+  maxlength = field_config[:maxlength]
+-%>
+
+<div class="limit_content range_limit">
+  <% if has_selected_range_limit?(field_name) %>
+    <ul class="current list-unstyled facet-values">
+      <li class="selected">
+        <span class="facet-label">
+          <span class="selected"><%= range_display(field_name) %></span>
+           <%= link_to remove_range_param(field_name), :class=>"remove", :title => t('blacklight.range_limit.remove_limit') do %>
+            <span class="glyphicon glyphicon-remove"></span>
+            <span class="sr-only">[<%= t('blacklight.range_limit.remove_limit') %>]</span>
+           <% end %>
+        </span>
+        <span class="selected facet-count"><%= number_with_delimiter(@response.total) %></span>
+      </li>
+    </ul>
+
+  <% end %>
+
+  <% unless selected_missing_for_range_limit?(field_name) %>
+    <%= form_tag search_action_path, :method => :get, class: [BlacklightRangeLimit.classes[:form], "range_#{field_name}"].join(' ') do %>
+      <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:page)) %>
+
+      <!-- we need to include a dummy search_field parameter if none exists,
+           to trick blacklight into displaying actual search results instead
+           of home page. Not a great solution, but easiest for now. -->
+      <% unless params.has_key?(:search_field) %>
+        <%= hidden_field_tag("search_field", "dummy_range") %>
+      <% end %>
+
+      <div class="range_input_wrapper mt-2">
+        <div class="year-input">Between year:</div>
+        <%= render_range_input(field_name, :begin, input_label_range_begin, maxlength) %>
+      </div>
+
+      <div class="range_input_wrapper mt-2">
+        <div class="year-input">and year:</div>
+        <%= render_range_input(field_name, :end, input_label_range_end, maxlength) %>
+      </div>
+      <div class="range_input_wrapper mt-2 mb-2">
+        <%= submit_tag t('blacklight.range_limit.submit_limit'), class: BlacklightRangeLimit.classes[:submit] %>
+      </div>
+    <% end %>
+  <% end %>
+
+  <!-- no results profile if missing is selected -->
+  <% unless selected_missing_for_range_limit?(field_name) %>
+    <!-- you can hide this if you want, but it has to be on page if you want
+         JS slider and calculated facets to show up, JS sniffs it. -->
+    <div class="profile">
+        <% if stats_for_field?(field_name) %>
+          <!-- No stats information found for field  in search response -->
+        <% end %>
+
+        <% if (min = range_results_endpoint(field_name, :min)) &&
+              (max = range_results_endpoint(field_name, :max)) %>
+          <p class="range subsection <%= "slider_js" unless field_config[:slider_js] == false  %>">
+            Current results range from <span class="min"><%= range_results_endpoint(field_name, :min) %></span> to <span class="max"><%= range_results_endpoint(field_name, :max) %></span>
+          </p>
+
+          <% if field_config[:segments] != false %>
+            <div class="distribution subsection <%= 'chart_js' unless field_config[:chart_js] == false %>">
+              <!-- if  we already fetched segments from solr, display them
+                   here. Otherwise, display a link to fetch them, which JS
+                   will AJAX fetch.  -->
+              <% if solr_range_queries_to_a(field_name).length > 0 %>
+
+                 <%= render(:partial => "blacklight_range_limit/range_segments", :locals => {:solr_field => field_name}) %>
+
+              <% else %>
+                <%= link_to('View distribution', main_app.url_for(search_state.to_h.merge(action: 'range_limit', range_field: field_name, range_start: min, range_end: max)), :class => "load_distribution") %>
+              <% end %>
+            </div>
+          <% end %>
+        <% end %>
+
+
+
+        <% if (stats = stats_for_field(field_name)) && stats["missing"] > 0 %>
+          <ul class="missing list-unstyled facet-values subsection">
+            <li>
+              <span class="facet-label">
+                <%= link_to BlacklightRangeLimit.labels[:missing], add_range_missing(field_name) %>
+              </span>
+              <span class="facet-count">
+                <%= number_with_delimiter(stats["missing"]) %>
+              </span>
+            </li>
+          </ul>
+        <% end %>
+    </div>
+  <% end %>
+</div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
-  config.assets.debug = true
+  config.assets.debug = false
   config.assets.raise_runtime_errors = false
 
   # Suppress logger output for asset requests.

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
-  config.assets.debug = false
+  config.assets.debug = true
   config.assets.raise_runtime_errors = false
 
   # Suppress logger output for asset requests.

--- a/config/locales/blacklight.en.yml
+++ b/config/locales/blacklight.en.yml
@@ -49,3 +49,5 @@ en:
           title_tesim: Title
     search:
       start_over: New Search
+    range_limit:
+      submit_limit: Update

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1132,7 +1132,7 @@ en:
         based_near: A place name related to the work, such as its site of publication, or the city, state, or country the work contents are about. Calls upon the <a href='http://www.geonames.org'>GeoNames web service</a>.
         contributor: A person or group you want to recognize for playing a role in the creation of the work, but not the primary role.
         creator: The person or group responsible for the work. Usually this is the author of the content. Personal names should be entered with the last name first, e.g. &quot;Smith, John.&quot;.
-        date_created: The date on which the work was created.
+        date_created: The date on which the work was created. Must adhere to either the format YYYY, YYYY-MM, or YYYY-MM-DD in order to be filtered and sorted.
         description: Free-text notes about the work. Examples include abstracts of a paper or citation information for a journal article.
         extent: The extent (size, duration, number, etc.) of the work.
         identifier: A unique handle identifying the work. An example would be a DOI for a journal article, or an ISBN or OCLC number for a book.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ require 'sidekiq/web'
 Sidekiq::Web.set :session_secret, Rails.application.secrets[:secret_key_base]
 
 Rails.application.routes.draw do
+concern :range_searchable, BlacklightRangeLimit::Routes::RangeSearchable.new
   concern :oai_provider, BlacklightOaiProvider::Routes.new
   mount Riiif::Engine => 'images', as: :riiif if Hyrax.config.iiif_image_server?
 
@@ -59,6 +60,8 @@ Rails.application.routes.draw do
     concerns :oai_provider
 
     concerns :searchable
+    concerns :range_searchable
+
   end
 
   resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do


### PR DESCRIPTION
# Story
Adds a facet for date created

# Related
- #519 

# Expected Behavior Before Changes
- there was no facet for date/date created

# Expected Behavior After Changes
- [ ] As a user, i can see a facet for date created. I can enter 2 years to filter by date. functionality should be the same as in [Atla Digital Library](https://dl.atla.com/catalog?utf8=%E2%9C%93&q=)

# Screenshots / Video

<details>
<summary>Working date facet</summary>
<img width="315" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/73361970/b849ce28-41d0-4140-8a41-0368d34136d0">

</details>

Video: 
https://share.getcloudapp.com/yAu9LWGY

# Notes
- All works will need to be reindexed in order to have a date that can be sorted. 