### PR TITLE
Add depositor name to published tab

### DIFF
--- a/app/views/hyrax/admin/workflows/index.html.erb
+++ b/app/views/hyrax/admin/workflows/index.html.erb
@@ -73,7 +73,9 @@
                           <%= link_to document, [main_app, document] %>
                         </td>
                         <td>
-                        <%= safe_join(document.creator, tag(:br)) %>
+                          <%# OVERRIDE: show the user/depositor's display_name if available %>
+                          <% user = User.find_by(email: document.depositor) %>
+                          <%= user&.display_name.presence %>
                         <td>
                           <%= document.date_modified %>
                         </td>


### PR DESCRIPTION
# Story

Refs #444 
We made an update for Depositor name in the Under Review tab but missed the Published tab
# Expected Behavior Before Changes
The under review tab showed the correct depositor, but the published tab still had creator
# Expected Behavior After Changes
The published tab shows the correct depositor
# Screenshots / Video

<details>
<summary>Published tab</summary>
<img width="819" alt="Screenshot 2023-06-14 at 4 36 26 PM" src="https://github.com/scientist-softserv/palni-palci/assets/18175797/6a3c2ba2-df1a-4a53-b75b-de0540d2a9c3">


</details>

# Notes