### PR TITLE
hide-per-tenant-analytics-on-prod

### DIFF
--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -196,11 +196,11 @@ module AccountSettings
       if Rails.env.production?
         # fall back to the default values if they aren't set in the tenant
         unless self.google_analytics_id.present? &&
-          self.google_oauth_app_name.present? &&
-          self.google_oauth_app_version.present? &&
-          (self.google_oauth_private_key_value.present? || self.google_oauth_private_key_path.present?) &&
-          self.google_oauth_private_key_secret.present? &&
-          self.google_oauth_client_email.present?
+               self.google_oauth_app_name.present? &&
+               self.google_oauth_app_version.present? &&
+               (self.google_oauth_private_key_value.present? || self.google_oauth_private_key_path.present?) &&
+               self.google_oauth_private_key_secret.present? &&
+               self.google_oauth_client_email.present?
 
           config = Hyrax::Analytics::Config.load_from_yaml
           self.google_analytics_id = self.google_analytics_id.presence || config.analytics_id

--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -193,6 +193,26 @@ module AccountSettings
 
     def reload_analytics
       # rubocop:disable Style/RedundantSelf
+      if Rails.env.production?
+        # fall back to the default values if they aren't set in the tenant
+        unless self.google_analytics_id.present? &&
+          self.google_oauth_app_name.present? &&
+          self.google_oauth_app_version.present? &&
+          (self.google_oauth_private_key_value.present? || self.google_oauth_private_key_path.present?) &&
+          self.google_oauth_private_key_secret.present? &&
+          self.google_oauth_client_email.present?
+
+          config = Hyrax::Analytics::Config.load_from_yaml
+          self.google_analytics_id = self.google_analytics_id.presence || config.analytics_id
+          self.google_oauth_app_name = self.google_oauth_app_name.presence || config.app_name
+          self.google_oauth_app_version = self.google_oauth_app_version.presence || config.app_version
+          self.google_oauth_private_key_value = self.google_oauth_private_key_value.presence || config.privkey_value
+          self.google_oauth_private_key_path = self.google_oauth_private_key_path.presence || config.privkey_path
+          self.google_oauth_private_key_secret = self.google_oauth_private_key_secret.presence || config.privkey_secret
+          self.google_oauth_client_email = self.google_oauth_client_email.presence || config.client_email
+        end
+      end
+
       # require the analytics to be set per tenant
       Hyrax::Analytics.config.analytics_id = self.google_analytics_id
       Hyrax::Analytics.config.app_name = self.google_oauth_app_name

--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -1,12 +1,12 @@
 #
 # To integrate your app with Google Analytics, uncomment the lines below and add your API key information.
 #
-# analytics:
-#   google:
-#     analytics_id: <%= ENV['GOOGLE_ANALYTICS_ID'] %>
-#     app_name: <%= ENV['GOOGLE_OAUTH_APP_NAME'] %>
-#     app_version: <%= ENV['GOOGLE_OAUTH_APP_VERSION'] %>
-#     privkey_value: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_VALUE'] %>
-#     # OR privkey_path: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_PATH'] %>
-#     privkey_secret: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_SECRET'] %>
-#     client_email: <%= ENV['GOOGLE_OAUTH_CLIENT_EMAIL'] %>
+analytics:
+  google:
+    analytics_id: <%= ENV['GOOGLE_ANALYTICS_ID'] %>
+    app_name: <%= ENV['GOOGLE_OAUTH_APP_NAME'] %>
+    app_version: <%= ENV['GOOGLE_OAUTH_APP_VERSION'] %>
+    privkey_value: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_VALUE'] %>
+    # OR privkey_path: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_PATH'] %>
+    privkey_secret: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_SECRET'] %>
+    client_email: <%= ENV['GOOGLE_OAUTH_CLIENT_EMAIL'] %>


### PR DESCRIPTION
use the default analytics as a default on prod only.

the per tenant analytics work was already merged to main and the defaults were hidden on staging. however, pals wants to hold off on deploying that code to production until the ga4 switch has happened so both major changes can happen at the same time.

putting the analytics defaults in a conditional ensures that we can still deploy to production from main.

related to:
- https://github.com/scientist-softserv/palni-palci/issues/569
- #487 