### PR TITLE
add-analytics-yml-fallback

### DIFF
--- a/config/analytics.yml
+++ b/config/analytics.yml
@@ -3,10 +3,10 @@
 #
 analytics:
   google:
-    analytics_id: <%= ENV['GOOGLE_ANALYTICS_ID'] %>
-    app_name: <%= ENV['GOOGLE_OAUTH_APP_NAME'] %>
-    app_version: <%= ENV['GOOGLE_OAUTH_APP_VERSION'] %>
-    privkey_value: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_VALUE'] %>
-    # OR privkey_path: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_PATH'] %>
-    privkey_secret: <%= ENV['GOOGLE_OAUTH_PRIVATE_KEY_SECRET'] %>
-    client_email: <%= ENV['GOOGLE_OAUTH_CLIENT_EMAIL'] %>
+    analytics_id: <%= ENV.fetch('GOOGLE_ANALYTICS_ID', '') %>
+    app_name: <%= ENV.fetch('GOOGLE_OAUTH_APP_NAME', '') %>
+    app_version: <%= ENV.fetch('GOOGLE_OAUTH_APP_VERSION', '') %>
+    privkey_value: <%= ENV.fetch('GOOGLE_OAUTH_PRIVATE_KEY_VALUE', '') %>
+    privkey_path: <%= ENV.fetch('GOOGLE_OAUTH_PRIVATE_KEY_PATH', '') %>
+    privkey_secret: <%= ENV.fetch('GOOGLE_OAUTH_PRIVATE_KEY_SECRET', '') %>
+    client_email: <%= ENV.fetch('GOOGLE_OAUTH_CLIENT_EMAIL', '') %>


### PR DESCRIPTION
default the env variables in analytics.yml to be empty strings so they do not fail when the env variable is not present

ref:
- #579 
- [slack thread](https://assaydepot.slack.com/archives/C0311DNF3MG/p1687473554171879) outlining the issue that this pr solves