### PR TITLE
530 - Rework for based_near

### DIFF
--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -67,4 +67,11 @@ class Etd < ActiveFedora::Base
   # including `include ::Hyrax::BasicMetadata`. All properties must
   # be declared before their values can be ordered.
   include OrderMetadataValues
+
+  # These needed to be added again in order to enable destroy for based_near, even though they are in Hyrax::BasicMetadata.
+  # the OrderAlready OrderMetadataValues above somehow prevents them from running
+  id_blank = proc { |attributes| attributes[:id].blank? }
+  class_attribute :controlled_properties
+  self.controlled_properties = [:based_near]
+  accepts_nested_attributes_for :based_near, reject_if: id_blank, allow_destroy: true
 end

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -31,5 +31,12 @@ class GenericWork < ActiveFedora::Base
   # be declared before their values can be ordered.
   include OrderMetadataValues
 
+  # These needed to be added again in order to enable destroy for based_near, even though they are in Hyrax::BasicMetadata.
+  # the OrderAlready OrderMetadataValues above somehow prevents them from running
+  id_blank = proc { |attributes| attributes[:id].blank? }
+  class_attribute :controlled_properties
+  self.controlled_properties = [:based_near]
+  accepts_nested_attributes_for :based_near, reject_if: id_blank, allow_destroy: true
+
   self.indexer = GenericWorkIndexer
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -37,6 +37,13 @@ class Image < ActiveFedora::Base
   # be declared before their values can be ordered.
   include OrderMetadataValues
 
+  # These needed to be added again in order to enable destroy for based_near, even though they are in Hyrax::BasicMetadata.
+  # the OrderAlready OrderMetadataValues above somehow prevents them from running
+  id_blank = proc { |attributes| attributes[:id].blank? }
+  class_attribute :controlled_properties
+  self.controlled_properties = [:based_near]
+  accepts_nested_attributes_for :based_near, reject_if: id_blank, allow_destroy: true
+
   self.indexer = ImageIndexer
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []

--- a/app/models/oer.rb
+++ b/app/models/oer.rb
@@ -105,6 +105,13 @@ class Oer < ActiveFedora::Base
   # be declared before their values can be ordered.
   include OrderMetadataValues
 
+  # These needed to be added again in order to enable destroy for based_near, even though they are in Hyrax::BasicMetadata.
+  # the OrderAlready OrderMetadataValues above somehow prevents them from running
+  id_blank = proc { |attributes| attributes[:id].blank? }
+  class_attribute :controlled_properties
+  self.controlled_properties = [:based_near]
+  accepts_nested_attributes_for :based_near, reject_if: id_blank, allow_destroy: true
+
   def previous_version
     @previous_version ||= Oer.where(id: previous_version_id) if previous_version_id
   end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -7,7 +7,7 @@
 <%= presenter.attribute_to_html(:publisher, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:language, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:identifier, render_as: :linked, search_field: 'identifier_tesim', html_dl: true) %>
-<%= presenter.attribute_to_html(:based_near_label) %>
+<%= presenter.attribute_to_html(:based_near_label, html_dl: true) %>
 <%= presenter.attribute_to_html(:keyword, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:date_created, render_as: :linked, search_field: 'date_created_tesim', html_dl: true) %>
 <%= presenter.attribute_to_html(:related_url, render_as: :external_link, html_dl: true, label: 'Related URL') %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1165,7 +1165,7 @@ en:
         title: Type name
       defaults:
         admin_set_id: Administrative Set
-        based_near: Based Near
+        based_near: Location
         contributor: Contributor
         creator: Creator
         date_created: Date Created


### PR DESCRIPTION
# Story
Rework for the Based Near (Location) field

# Related
- #530 
- 
# Expected Behavior Before Changes
- Deleting items from the `based_near` field was not working.
- The field was still being called Based Near in the form.

# Expected Behavior After Changes
- enables users to be able to delete values from the `based_near` field
- The label for the field in the edit form is now "Location" instead of "Based Near"
- the label for Location is now bold on the work show page for default theme