### PR TITLE
Reverts change for 530rework that was doing nothing

### DIFF
--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -67,11 +67,4 @@ class Etd < ActiveFedora::Base
   # including `include ::Hyrax::BasicMetadata`. All properties must
   # be declared before their values can be ordered.
   include OrderMetadataValues
-
-  # These needed to be added again in order to enable destroy for based_near, even though they are in Hyrax::BasicMetadata.
-  # the OrderAlready OrderMetadataValues above somehow prevents them from running
-  id_blank = proc { |attributes| attributes[:id].blank? }
-  class_attribute :controlled_properties
-  self.controlled_properties = [:based_near]
-  accepts_nested_attributes_for :based_near, reject_if: id_blank, allow_destroy: true
 end

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -30,13 +30,5 @@ class GenericWork < ActiveFedora::Base
   # including `include ::Hyrax::BasicMetadata`. All properties must
   # be declared before their values can be ordered.
   include OrderMetadataValues
-
-  # These needed to be added again in order to enable destroy for based_near, even though they are in Hyrax::BasicMetadata.
-  # the OrderAlready OrderMetadataValues above somehow prevents them from running
-  id_blank = proc { |attributes| attributes[:id].blank? }
-  class_attribute :controlled_properties
-  self.controlled_properties = [:based_near]
-  accepts_nested_attributes_for :based_near, reject_if: id_blank, allow_destroy: true
-
   self.indexer = GenericWorkIndexer
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -37,13 +37,6 @@ class Image < ActiveFedora::Base
   # be declared before their values can be ordered.
   include OrderMetadataValues
 
-  # These needed to be added again in order to enable destroy for based_near, even though they are in Hyrax::BasicMetadata.
-  # the OrderAlready OrderMetadataValues above somehow prevents them from running
-  id_blank = proc { |attributes| attributes[:id].blank? }
-  class_attribute :controlled_properties
-  self.controlled_properties = [:based_near]
-  accepts_nested_attributes_for :based_near, reject_if: id_blank, allow_destroy: true
-
   self.indexer = ImageIndexer
   # Change this to restrict which works can be added as a child.
   # self.valid_child_concerns = []

--- a/app/models/oer.rb
+++ b/app/models/oer.rb
@@ -105,13 +105,6 @@ class Oer < ActiveFedora::Base
   # be declared before their values can be ordered.
   include OrderMetadataValues
 
-  # These needed to be added again in order to enable destroy for based_near, even though they are in Hyrax::BasicMetadata.
-  # the OrderAlready OrderMetadataValues above somehow prevents them from running
-  id_blank = proc { |attributes| attributes[:id].blank? }
-  class_attribute :controlled_properties
-  self.controlled_properties = [:based_near]
-  accepts_nested_attributes_for :based_near, reject_if: id_blank, allow_destroy: true
-
   def previous_version
     @previous_version ||= Oer.where(id: previous_version_id) if previous_version_id
   end


### PR DESCRIPTION
# Story
Reverts part of a rework pr that was doing nothing. The `allow_destroy` functionality still does not work on initial load so this will need to be fixed in a different way. 

# Related
- PR this is reverting - https://github.com/scientist-softserv/palni-palci/pull/596
  - The 2 additional changes in the pr above (updating locale for location, & updating attribute rows to make the location a dl) should remain. 
- Original ticket this was trying to fix: #530 