### PR TITLE
More sso rework

### DIFF
--- a/app/controllers/auth_providers_controller.rb
+++ b/app/controllers/auth_providers_controller.rb
@@ -7,7 +7,7 @@ class AuthProvidersController < ApplicationController
   # GET /auth_providers/new
   def new
     add_breadcrumbs
-    existing_auth_provider = AuthProvider&.first
+    existing_auth_provider = AuthProvider.find(current_account.settings['auth_provider']) if current_account.settings['auth_provider']
 
     # users should not be able to reach the new auth provider page unless it is the first time they are setting up an auth provider.
     if existing_auth_provider
@@ -25,9 +25,10 @@ class AuthProvidersController < ApplicationController
   # POST /auth_providers or /auth_providers.json
   def create
     @auth_provider = AuthProvider.new(auth_provider_params)
-
     respond_to do |format|
       if @auth_provider.save
+        current_account.settings['auth_provider'] = @auth_provider.id
+        current_account.save
         format.html { redirect_to edit_auth_provider_url(@auth_provider), notice: "Auth provider was successfully created." }
         format.json { render :show, status: :created, location: @auth_provider }
       else
@@ -41,6 +42,8 @@ class AuthProvidersController < ApplicationController
   def update
     respond_to do |format|
       if @auth_provider.update(auth_provider_params)
+        current_account.settings['auth_provider'] = @auth_provider.id
+        current_account.save
         format.html { redirect_to edit_auth_provider_url(@auth_provider), notice: "Auth provider was successfully updated." }
         format.json { render :show, status: :ok, location: @auth_provider }
       else

--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -16,6 +16,7 @@ module AccountSettings
 
     setting :allow_signup, type: 'boolean', default: true
     setting :allow_downloads, type: 'boolean', default: true
+    setting :auth_provider, type: 'string'
     setting :bulkrax_validations, type: 'boolean', disabled: true
     setting :cache_api, type: 'boolean', default: false
     setting :contact_email, type: 'string', default: 'consortial-ir@palci.org'


### PR DESCRIPTION
# Coauthors 
@labradford  @sephirothkod 

# Summary
Should make the auth providers actually only have one auth provider. 
Adds a setting so the tenant has the id of the auth provider saved

# Notes
Will need to delete the existing auth providers from staging tenants so this functions correctly 