### PR TITLE
add feature flipper for auth provider tab

### DIFF
--- a/app/views/hyrax/dashboard/sidebar/_configuration.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_configuration.html.erb
@@ -11,13 +11,15 @@
           <span class="fa fa-gear"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.account') %></span>
         <% end %>
         
-        <% if AuthProvider.count > 0 %>
-          <%= menu.nav_link(main_app.edit_auth_provider_path(AuthProvider.where(account_id: @current_account.id).first)) do %>
-            <span class="fa fa-key"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.auth_provider') %></span>
-          <% end %>
-        <% else %>
-        <%= menu.nav_link(main_app.new_auth_provider_path) do %>
-            <span class="fa fa-key"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.auth_provider') %></span>
+        <% if Flipflop.show_auth_provider_in_admin_dashboard? %>
+          <% if AuthProvider.count > 0 %>
+            <%= menu.nav_link(main_app.edit_auth_provider_path(AuthProvider.where(account_id: @current_account.id).first)) do %>
+              <span class="fa fa-key"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.auth_provider') %></span>
+            <% end %>
+          <% else %>
+          <%= menu.nav_link(main_app.new_auth_provider_path) do %>
+              <span class="fa fa-key"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.auth_provider') %></span>
+            <% end %>
           <% end %>
         <% end %>
 

--- a/config/features.rb
+++ b/config/features.rb
@@ -20,4 +20,8 @@ Flipflop.configure do
   feature :show_recently_uploaded,
           default: true,
           description: "Shows the Recently Uploaded tab on the homepage."
+
+  feature :show_auth_provider_in_admin_dashboard,
+          default: false,
+          description: "Shows the Auth Provider tab on the admin dashboard."
 end


### PR DESCRIPTION
# Story

Refs #628 
Adds a feature flipper for auth provider tab on dashboard so we can deploy to demo

# Expected Behavior Before Changes
Auth provider tab was on dashboard

# Expected Behavior After Changes
Auth provider tab only shows if feature flipper is set to true

# Screenshots /
<img width="1620" alt="Screenshot 2023-07-24 at 9 31 58 AM" src="https://github.com/scientist-softserv/palni-palci/assets/18175797/421f2c0f-e372-46ef-8c1f-edb5777979df">
 Video


# Notes