### PR TITLE
remove auth provider from account settings on delete

### DIFF
--- a/app/controllers/auth_providers_controller.rb
+++ b/app/controllers/auth_providers_controller.rb
@@ -56,7 +56,8 @@ class AuthProvidersController < ApplicationController
   # DELETE /auth_providers/1 or /auth_providers/1.json
   def destroy
     @auth_provider.destroy
-
+    current_account.settings['auth_provider'] = nil
+    current_account.save
     respond_to do |format|
       format.html { redirect_to new_auth_provider_url, notice: "Auth provider was successfully destroyed." }
       format.json { head :no_content }


### PR DESCRIPTION
# Story
Bug rework
Refs #496

# Expected Behavior Before Changes
Deleting an auth provider caused an error when accessing the auth provider page
# Expected Behavior After Changes
Deleting an auth provider does not throw error
# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes
Will need to manually reset auth_provider in the broken tenant