### PR TITLE
🐛 Buping Hyrax to resolve CSV export

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -316,9 +316,10 @@ GEM
       signet (~> 0.8)
       typhoeus
     builder (3.2.4)
-    bulkrax (5.2.1)
+    bulkrax (5.3.0)
       bagit (~> 0.4)
       coderay
+      dry-monads (~> 1.4.0)
       iso8601 (~> 0.9.0)
       kaminari
       language_list (~> 1.2, >= 1.2.1)


### PR DESCRIPTION
From Bulkrax commit:

> Prior to this commit, when exporting a FileSet and GenericWork we'd
> see a "creator_1" and "creator" column.  The "creator" column might
> look as follows: `["Sandra Samvera"]`.  Which meant that creator was
> not an `ActiveTriples::Relation` (based on the prior logic).  Yet the
> "creator" field was stored as multi-value.  Perhaps having been
> previously coerced into an Array.
>
> With this commit, we're favoring the Bulkrax parser field mapping
> `"join"` configuration over whether or not the object is an
> =ActiveTriples::Relation=.  That is to say, if you told us to join the
> field, we're going to do that regardless of the data we have.
>
> Likewise, if the field's value is not an enumerable, we're not going
> to introduce an ordinal suffix (e.g. "creator_1" when we have a scalar
> creator).
>
> In other words don't do the join logic if we don't have an "array" or
> we weren't told to join arrays.
>
> Perhaps we could interrogate the model to ask if it's single value or
> not?  But this reduces the implementation knowledge of the properties
> by looking at a more primitive level (is the data multi-valued or
> not).

Related to:

- https://github.com/samvera-labs/bulkrax/pull/847
- https://github.com/scientist-softserv/palni-palci/issues/624