### PR TITLE
error handling for json

### DIFF
--- a/app/controllers/identity_providers_controller.rb
+++ b/app/controllers/identity_providers_controller.rb
@@ -36,6 +36,12 @@ class IdentityProvidersController < ApplicationController
         format.json { render json: @identity_provider.errors, status: :unprocessable_entity }
       end
     end
+  rescue JSON::ParserError => e
+    @identity_provider.add_error(:options, "Invalid JSON #{e.message}")
+    respond_to do |format|
+      format.html { render :new, status: :unprocessable_entity }
+      format.json { render json: @identity_provider.errors, status: :unprocessable_entity }
+    end
   end
 
   # PATCH/PUT /identity_providers/1 or /identity_providers/1.json
@@ -51,6 +57,12 @@ class IdentityProvidersController < ApplicationController
         format.html { render :edit, status: :unprocessable_entity }
         format.json { render json: @identity_provider.errors, status: :unprocessable_entity }
       end
+    end
+  rescue JSON::ParserError => e
+    @identity_provider.add_error(:options, "Invalid JSON #{e.message}")
+    respond_to do |format|
+      format.html { render :new, status: :unprocessable_entity }
+      format.json { render json: @identity_provider.errors, status: :unprocessable_entity }
     end
   end
 


### PR DESCRIPTION
when creating or updating an IdentityProvider, display an error if the JSON does not parse instead of throwing an exception