### PR TITLE
♻️ Refactor and Test Sushi Date Boundary Conditions

### DIFF
--- a/app/controllers/api/sushi_controller.rb
+++ b/app/controllers/api/sushi_controller.rb
@@ -55,7 +55,7 @@ module API
     end
 
     def report_list
-      @report = Sushi::ReportList.new.reports
+      @report = Sushi::ReportList.new
       render json: @report
     end
   end

--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -8,6 +8,11 @@ module Sushi
   end
 
   class << self
+    ##
+    # @param value [String, #to_date]
+    #
+    # @return [Date]
+    # @raise [Sushi::InvalidParameterValue] when we cannot coerce to a date.
     def coerce_to_date(value)
       value.to_date
     rescue StandardError
@@ -23,16 +28,66 @@ module Sushi
       end
     end
 
-    def first_month_available
+    ##
+    # The first day of the month of the earliest entry in {Hyrax::CounterMetric}, with some caveats.
+    #
+    # Namely if we only have one month of data, and that month happens to be the current month.
+    #
+    # @param current_date [Date] included as a dependency injection to ease testing.
+    #
+    # @return [Date] when we have data in the system
+    # @return [NilCass] when we don't have data in the system OR we only have data for the current
+    #         month.
+    # @see {.last_month_available}
+    #
+    # @note Ultimately, the goal of these date ranges is for us to inform the consumer of the API
+    #       about the complete months of data that we have.
+    def first_month_available(current_date: Time.zone.today)
       return unless Hyrax::CounterMetric.any?
 
-      Hyrax::CounterMetric.order('date ASC').first.date.strftime('%Y-%m')
+      # If, for some reason, we have only partial data for the earliest month, we'll assume that
+      # we have "all that month's data.
+      earliest_entry_beginning_of_month_date = Hyrax::CounterMetric.order('date ASC').first.date.beginning_of_month
+
+      beginning_of_month = current_date.beginning_of_month
+
+      # In this case, the only data we have is data in the current month and since the current month
+      # isn't over we should not be reporting.
+      return nil if earliest_entry_beginning_of_month_date == beginning_of_month
+
+      earliest_entry_beginning_of_month_date
     end
 
-    def last_month_available
-      return unless Hyrax::CounterMetric.any?
+    ##
+    # The earlier of:
+    #
+    # - the last day of the prior month
+    # - the last day of the month of the latest entry in {Hyrax::CounterMetric}
+    #
+    # @param current_date [Date] included as a dependency injection to ease testing.  An assumption
+    #        is that the current_date will always be on or after the last {Hyrax::CounterMetric}
+    #        entry's date.
+    #
+    # @return [Date] when we have data in the system
+    # @return [NilCass] when we don't have data in the system
+    #
+    # @see {.first_month_available}
+    #
+    # @note Ultimately, the goal of these date ranges is for us to inform the consumer of the API
+    #       about the complete months of data that we have.
+    def last_month_available(current_date: Time.zone.today)
+      return nil unless first_month_available(current_date: current_date)
 
-      Hyrax::CounterMetric.order('date DESC').first.date.strftime('%Y-%m')
+      # We're assuming that we have whole months, so we'll nudge the latest date towards that
+      # assumption.
+      latest_entry_end_of_month_date = Hyrax::CounterMetric.order('date DESC').first.date.end_of_month
+
+      # We want to avoid partial months, we look at the month prior to the current_date
+      end_of_last_month = 1.month.ago(current_date).end_of_month
+
+      return latest_entry_end_of_month_date if latest_entry_end_of_month_date < end_of_last_month
+
+      end_of_last_month
     end
   end
 
@@ -45,6 +100,8 @@ module Sushi
     end
 
     def coerce_dates(params = {})
+      # TODO: We should also be considering available dates as well.
+      #
       # Because we're receiving user input that is likely strings, we need to do some coercion.
       @begin_date = Sushi.coerce_to_date(params.fetch(:begin_date)).beginning_of_month
       @end_date = Sushi.coerce_to_date(params.fetch(:end_date)).end_of_month

--- a/app/models/sushi/platform_report.rb
+++ b/app/models/sushi/platform_report.rb
@@ -33,7 +33,7 @@ module Sushi
       @attributes_to_show = params.fetch(:attributes_to_show, ["Access_Method"]) & ALLOWED_REPORT_ATTRIBUTES_TO_SHOW
     end
 
-    def to_hash
+    def as_json(_options = {})
       {
         "Report_Header" => {
           "Release" => "5.1",
@@ -60,6 +60,8 @@ module Sushi
         }
       }
     end
+
+    alias to_hash as_json
 
     def attribute_performance_for_resource_types
       data_for_resource_types.group_by(&:resource_type).map do |resource_type, records|

--- a/app/models/sushi/platform_usage_report.rb
+++ b/app/models/sushi/platform_usage_report.rb
@@ -18,7 +18,7 @@ module Sushi
       @account = account
     end
 
-    def to_hash
+    def as_json(_options = {})
       {
         "Report_Header" => {
           "Release" => "5.1",
@@ -49,6 +49,7 @@ module Sushi
         }
       }
     end
+    alias to_hash as_json
 
     def attribute_performance_for_resource_types
       data_for_resource_types.group_by(&:resource_type).map do |resource_type, records|

--- a/app/models/sushi/report_list.rb
+++ b/app/models/sushi/report_list.rb
@@ -4,7 +4,7 @@
 module Sushi
   class ReportList
     # rubocop:disable Metrics/MethodLength, Metrics/LineLength
-    def reports
+    def as_json(_options = nil)
       [
         {
           "Report_Name" => "Server Status",
@@ -32,9 +32,9 @@ module Sushi
           "Report_ID" => "pr",
           "Release" => "5.1",
           "Report_Description" => "This resource returns COUNTER 'Platform Master Report' [PR]. A customizable report summarizing activity across a provider’s platforms that allows the user to apply filters and select other configuration options for the report.",
-          "Path" => "api/sushi/r51/reports/pr",
-          "First_Month_Available" => Sushi.first_month_available,
-          "Last_Month_Available" => Sushi.last_month_available
+          "Path" => "/api/sushi/r51/reports/pr",
+          "First_Month_Available" => Sushi.first_month_available&.strftime("%Y-%m"),
+          "Last_Month_Available" => Sushi.last_month_available&.strftime("%Y-%m")
         },
         {
           "Report_Name" => "Platform Usage",
@@ -42,8 +42,8 @@ module Sushi
           "Release" => "5.1",
           "Report_Description" => "This resource returns COUNTER 'Platform Usage' [pr_p1]. This is a Standard View of the Package Master Report that presents usage for the overall Platform broken down by Metric_Type.",
           "Path" => "/api/sushi/r51/reports/pr_p1",
-          "First_Month_Available" => Sushi.first_month_available,
-          "Last_Month_Available" => Sushi.last_month_available
+          "First_Month_Available" => Sushi.first_month_available&.strftime("%Y-%m"),
+          "Last_Month_Available" => Sushi.last_month_available&.strftime("%Y-%m")
         },
         {
           "Report_Name" => "Item Report",
@@ -51,11 +51,12 @@ module Sushi
           "Release" => "5.1",
           "Report_Description" => "This resource returns COUNTER 'Item Master Report' [IR].",
           "Path" => "/api/sushi/r51/reports/ir",
-          "First_Month_Available" => Sushi.first_month_available,
-          "Last_Month_Available" => Sushi.last_month_available
+          "First_Month_Available" => Sushi.first_month_available&.strftime("%Y-%m"),
+          "Last_Month_Available" => Sushi.last_month_available&.strftime("%Y-%m")
         }
       ]
     end
+    alias to_hash as_json
     # rubocop:enable Metrics/MethodLength, Metrics/LineLength
   end
 end

--- a/spec/models/sushi/platform_usage_report_spec.rb
+++ b/spec/models/sushi/platform_usage_report_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal:true
 
-RSpec.describe Sushi::PlatformReport do
-  let(:account) { double(Account, institution_name: 'Pitt', institution_id_data: {}, cname: 'pitt.hyku.test') }
+RSpec.describe Sushi::PlatformUsageReport do
+  let(:account) { double(Account, institution_name: 'Pitt', institution_id_data: {}, cname: "pitt.edu") }
 
   describe '#as_json' do
     before { create_hyrax_countermetric_objects }
@@ -21,13 +21,8 @@ RSpec.describe Sushi::PlatformReport do
     it 'has the expected keys' do
       expect(subject).to be_key('Report_Header')
       expect(subject.dig('Report_Header', 'Created')).to eq(created.rfc3339)
-      expect(subject.dig('Report_Header', 'Report_Attributes', 'Attributes_To_Show')).to eq(['Access_Method'])
       expect(subject.dig('Report_Header', 'Report_Filters', 'Begin_Date')).to eq('2022-01-01')
       expect(subject.dig('Report_Header', 'Report_Filters', 'End_Date')).to eq('2022-02-28')
-      expect(subject.dig('Report_Items', 'Attribute_Performance').first.dig('Performance', 'Total_Item_Investigations', '2022-01')).to eq(5)
-      expect(subject.dig('Report_Items', 'Attribute_Performance').first.dig('Performance', 'Total_Item_Requests', '2022-01')).to eq(16)
-      expect(subject.dig('Report_Items', 'Attribute_Performance').first.dig('Performance', 'Unique_Item_Investigations', '2022-01')).to eq(3)
-      expect(subject.dig('Report_Items', 'Attribute_Performance').first.dig('Performance', 'Unique_Item_Requests', '2022-01')).to eq(3)
       expect(subject.dig('Report_Items', 'Attribute_Performance').find { |o| o["Data_Type"] == "Platform" }.dig('Performance', 'Searches_Platform', '2022-01')).to eq(5)
     end
   end

--- a/spec/models/sushi/report_list_spec.rb
+++ b/spec/models/sushi/report_list_spec.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 RSpec.describe Sushi::ReportList do
-  describe '#reports' do
-    subject { described_class.new.reports }
+  describe '#as_json' do
+    subject { described_class.new.as_json }
 
     it 'returns the correct format' do
       expect(subject).to be_an_instance_of(Array)
@@ -26,8 +28,8 @@ RSpec.describe Sushi::ReportList do
         expect(subject.last['Release']).to eq('5.1')
         expect(subject.last['Report_Description']).to eq("This resource returns COUNTER 'Item Master Report' [IR].")
         expect(subject.last['Path']).to eq('/api/sushi/r51/reports/ir')
-        expect(subject.last['First_Month_Available']).to eq('2022-01')
-        expect(subject.last['Last_Month_Available']).to eq('2023-08')
+        expect(subject.last['First_Month_Available']).to be_a(String)
+        expect(subject.last['Last_Month_Available']).to be_a(String)
       end
     end
 

--- a/spec/models/sushi_spec.rb
+++ b/spec/models/sushi_spec.rb
@@ -23,19 +23,123 @@ RSpec.describe Sushi do
     end
   end
 
-  describe 'the available date range for any given report' do
-    before { create_hyrax_countermetric_objects }
+  describe '.first_month_available' do
+    subject { described_class.first_month_available }
 
-    context '#first_month_available' do
-      subject { described_class.first_month_available }
-
-      it { is_expected.to eq('2022-01') }
+    let(:entry) do
+      Hyrax::CounterMetric.create(
+        worktype: 'GenericWork',
+        resource_type: 'Book',
+        work_id: '12345',
+        date: entry_date,
+        total_item_investigations: 1,
+        total_item_requests: 10
+      )
     end
 
-    context '#last_month_available' do
-      subject { described_class.last_month_available }
+    context 'when first entry date is middle of the month and current date is end of this month' do
+      let(:current_date) { Time.zone.today.end_of_month }
+      let(:entry_date) { 10.days.ago(current_date) }
 
-      it { is_expected.to eq('2023-08') }
+      before { entry }
+
+      it 'will return nil (because we have less than one month of data)' do
+        expect(subject).to be_nil
+      end
+    end
+
+    context 'when first entry is the middle of two months ago and current date is middle of this month' do
+      let(:current_date) { 10.days.ago(Time.zone.today.end_of_month) }
+      let(:entry_date) { 10.days.ago(2.months.ago(Time.zone.today.end_of_month)) }
+
+      before { entry }
+
+      it 'will return the beginning of the month of the earliest entry' do
+        expect(subject).to eq(entry_date.beginning_of_month)
+      end
+    end
+
+    context 'when there are no entries' do
+      it { is_expected.to be_nil }
+    end
+  end
+
+  describe '.last_month_available' do
+    subject { described_class.last_month_available }
+
+    let(:entry) do
+      Hyrax::CounterMetric.create(
+        worktype: 'GenericWork',
+        resource_type: 'Book',
+        work_id: '12345',
+        date: entry_date,
+        total_item_investigations: 1,
+        total_item_requests: 10
+      )
+    end
+    let(:create_older_entry) do
+      # Because sometimes we nee
+      Hyrax::CounterMetric.create(
+        worktype: 'GenericWork',
+        resource_type: 'Book',
+        work_id: '12345',
+        date: 2.years.ago,
+        total_item_investigations: 1,
+        total_item_requests: 10
+      )
+    end
+
+    context 'when we have one month of data and the current date is within that month' do
+      let(:current_date) { Time.zone.today.end_of_month }
+      let(:entry_date) { 5.days.ago(Time.zone.today.end_of_month) }
+
+      before { entry }
+      it { is_expected.to be_nil }
+    end
+
+    context 'when last entry date is middle of the month and current date is end of this month' do
+      let(:current_date) { Time.zone.today.end_of_month }
+      let(:entry_date) { 10.days.ago(current_date) }
+
+      before do
+        create_older_entry
+        entry
+      end
+      it 'will use the end of the previous current month' do
+        expect(subject).to eq(1.month.ago(current_date).end_of_month)
+      end
+    end
+
+    context 'when last entry is the middle of two months ago and current date is middle of this month' do
+      let(:current_date) { 10.days.ago(Time.zone.today.end_of_month) }
+      let(:entry_date) { 10.days.ago(2.months.ago(Time.zone.today.end_of_month)) }
+
+      before do
+        create_older_entry
+        entry
+      end
+
+      it 'will return the end of the month of the last entry' do
+        expect(subject).to eq(entry_date.end_of_month)
+      end
+    end
+
+    context 'when last entry date is beginning of the month and current entry date is beginning of the month' do
+      let(:current_date) { Time.zone.today.beginning_of_month }
+      let(:entry_date) { Time.zone.today.beginning_of_month }
+
+      before do
+        create_older_entry
+        entry
+      end
+
+      it 'will return the end of the month prior to the last entry' do
+        expect(subject).to eq(1.month.ago(current_date).end_of_month)
+      end
+    end
+
+    context 'when there are no entries' do
+      it { is_expected.to be_nil }
     end
   end
 end


### PR DESCRIPTION
This commit contains two primary changes:

1. Favoring objects responding to `#as_json`
2. Date range boundaries for Sushi report dates

**`#as_json`**

In Rails, when an object responds to `#as_json`, that object can be directly passed to the `render json: object` directive, and Rails will "figure it out".

This refactor also adds a spec to the Sushi::PlatformUsageReport. Having a single spec will help us with further code refactoring as we discover common behavior.

**Date Range Boundaries**

In discussions with team members, the date range boundaries happen in month chunks.  I have taken time to write specs whose documentation (e.g. the strings after the `it` and `context` and `describe`) read as the intended behavior.

I have also added comments to explain the intention.  Please read these carefully and flag any inconsistencies.  Date range logic is tricky, especially considering the constraints of both Sushi's expected interface and the reality of having delays in reporting logic.

Ultimately, the goal of these date ranges is for us to inform the consumer of the API about the complete months of data that we have.

**Miscellaney**

It also addesses a type, namely that path to one of the API end-points did not have a leading "/"