### PR TITLE
i679 Reorder CDL form fields

### DIFF
--- a/app/forms/hyrax/cdl_form.rb
+++ b/app/forms/hyrax/cdl_form.rb
@@ -6,8 +6,9 @@ module Hyrax
     include Hyrax::FormTerms
     self.model_class = ::Cdl
     include HydraEditor::Form::Permissions
-    self.terms.prepend(:admin_note).uniq! # rubocop:disable Style/RedundantSelf
-    self.terms += %i[resource_type additional_information bibliographic_citation contributing_library library_catalog_identifier chronology_note]
+    # List these terms first after the "Additional fields" divider
+    self.terms.prepend(:contributing_library, :library_catalog_identifier, :admin_note).uniq! # rubocop:disable Style/RedundantSelf
+    self.terms += %i[resource_type additional_information bibliographic_citation chronology_note]
     self.terms -= %i[based_near]
     self.required_fields = %i[title creator keyword rights_statement resource_type]
   end

--- a/app/forms/hyrax/cdl_form.rb
+++ b/app/forms/hyrax/cdl_form.rb
@@ -7,7 +7,7 @@ module Hyrax
     self.model_class = ::Cdl
     include HydraEditor::Form::Permissions
     # List these terms first after the "Additional fields" divider
-    self.terms.prepend(:contributing_library, :library_catalog_identifier, :admin_note).uniq! # rubocop:disable Style/RedundantSelf
+    self.terms = %i[contributing_library library_catalog_identifier admin_note] + self.terms # rubocop:disable Style/RedundantSelf
     self.terms += %i[resource_type additional_information bibliographic_citation chronology_note]
     self.terms -= %i[based_near]
     self.required_fields = %i[title creator keyword rights_statement resource_type]

--- a/spec/forms/hyrax/cdl_form_spec.rb
+++ b/spec/forms/hyrax/cdl_form_spec.rb
@@ -24,5 +24,15 @@ RSpec.describe Hyrax::CdlForm do
     end
   end
 
+  describe 'order of terms' do
+    it 'lists :contributing_library first' do
+      expect(described_class.terms.first).to eq(:contributing_library)
+    end
+
+    it 'lists :library_catalog_identifier second' do
+      expect(described_class.terms.second).to eq(:library_catalog_identifier)
+    end
+  end
+
   include_examples("work_form")
 end


### PR DESCRIPTION
# Story

Ref
- #679

Reorder CdlForm terms so that the form fields for :contributing_library and :library_catalog_identifier are listed first after the "Additional fields" button

# Expected Behavior Before Changes

The `Contributing library` and `Library Catalog Identifier` form fields are listed at the bottom of the form

# Expected Behavior After Changes

The `Contributing library` and `Library Catalog Identifier` form fields are listed towards the top of the form. Specifically, they are listed first after the "Additional fields" button. 

# Screenshots / Video

<details><summary>"After" screenshot</summary>

![Cdl   Hyku Commons 2023-08-14 at 12 18 33 PM](https://github.com/scientist-softserv/palni-palci/assets/32469930/9a61e9bc-df4a-419d-bd23-cc07cbae5b3d)

</details>