### PR TITLE
i682 Fix Contributing Library facet labels

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -87,7 +87,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'based_near_label_sim', limit: 5
     config.add_facet_field 'publisher_sim', limit: 5
     config.add_facet_field 'file_format_sim', limit: 5
-    config.add_facet_field 'contributing_library_sim', limit: 5
+    config.add_facet_field 'contributing_library_sim', label: 'Contributing Library', limit: 5
     config.add_facet_field 'date_ssi', label: 'Date Created', range: { num_segments: 10, assumed_boundaries: [1100, Time.zone.now.year + 2], segments: false, slider_js: false, maxlength: 4 }
     config.add_facet_field 'member_of_collections_ssim', limit: 5, label: 'Collections'
 

--- a/app/indexers/cdl_indexer.rb
+++ b/app/indexers/cdl_indexer.rb
@@ -5,6 +5,7 @@ class CdlIndexer < AppIndexer
   def generate_solr_document
     super.tap do |solr_doc|
       solr_doc['admin_note_tesim'] = object.admin_note
+      solr_doc['contributing_library_sim'] = object.contributing_library.map { |id| Hyrax::ContributingLibraryService.label(id) }
     end
   end
 end


### PR DESCRIPTION
# Story

Refs 
- #682 

# Expected Behavior Before Changes

The facet's label displayed as "Facet Label Sim"

# Expected Behavior After Changes

Now, it displays as "Facet Label"

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes

Will most likely need to reindex all CDL works after deploying these changes. 