### PR TITLE
Remove #prepend from all Form classes (except CDL)

### DIFF
--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -7,7 +7,7 @@ module Hyrax
     self.model_class = ::Etd
     include HydraEditor::Form::Permissions
 
-    self.terms.prepend(:admin_note).uniq! # rubocop:disable Style/RedundantSelf
+    self.terms = [:admin_note] + self.terms # rubocop:disable Style/RedundantSelf
     self.terms += [
       :resource_type,
       :format,

--- a/app/forms/hyrax/generic_work_form.rb
+++ b/app/forms/hyrax/generic_work_form.rb
@@ -7,7 +7,8 @@ module Hyrax
     include Hyrax::FormTerms
     self.model_class = ::GenericWork
     include HydraEditor::Form::Permissions
-    self.terms.prepend(:admin_note).uniq! # rubocop:disable Style/RedundantSelf
+
+    self.terms = [:admin_note] + self.terms # rubocop:disable Style/RedundantSelf
     self.terms += %i[resource_type additional_information bibliographic_citation]
     self.required_fields = %i[title creator keyword rights_statement resource_type]
   end

--- a/app/forms/hyrax/image_form.rb
+++ b/app/forms/hyrax/image_form.rb
@@ -6,7 +6,8 @@ module Hyrax
   class ImageForm < Hyrax::Forms::WorkForm
     include Hyrax::FormTerms
     self.model_class = ::Image
-    self.terms.prepend(:admin_note).uniq! # rubocop:disable Style/RedundantSelf
+
+    self.terms = [:admin_note] + self.terms # rubocop:disable Style/RedundantSelf
     self.terms += %i[resource_type extent additional_information bibliographic_citation]
     self.required_fields = %i[title creator keyword rights_statement resource_type]
   end


### PR DESCRIPTION
# Story

Refs
- #683 

The terms added by #prepend were bubbling up to the parent class (Hyrax::Forms::WorkForm). Depending on the order things were called in, this was causing issues on other Form classes that didn't have a property matching the prepended term(s):

```
unknown attribute 'library_catalog_identifier' for Etd
```

Even though both `prepend` and `+=` are mutators, `+=` doesn't seem to have the same "bubble up" behavior that `prepend` does.

As stated above, this only happened when things were run in a specific order; if the Form class with the unique term was invoked before a Form class that didn't have the term, it would appear on both classes:

```ruby
Hyrax::CdlForm.terms.include?(:contributing_library)
=> true

Hyrax::EtdForm.terms.include?(:contributing_library)
=> true

reload!
=> true

Hyrax::EtdForm.terms.include?(:contributing_library)
=> false

Hyrax::CdlForm.terms.include?(:contributing_library)
=> true

Hyrax::EtdForm.terms.include?(:contributing_library)
=> false
```

Evidence points to this being because the parent class's terms (i.e. Hyrax::Forms::WorkForm.terms) themselves were being mutated:

```ruby
Hyrax::CdlForm.terms.include?(:contributing_library)
=> true

Hyrax::Forms::WorkForm.terms.include?(:contributing_library)
=> true
```

#prepend will be removed from CdlForm in #683
