### PR TITLE
🐛 Use UTK Hyku build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,14 @@
-FROM ghcr.io/scientist-softserv/dev-ops/samvera:e9200061 as hyku-base
+ARG RUBY_VERSION=2.7.6
+FROM ruby:$RUBY_VERSION-alpine3.15 as builder
+
+RUN apk add build-base
+RUN wget -O - https://github.com/jemalloc/jemalloc/releases/download/5.2.1/jemalloc-5.2.1.tar.bz2 | tar -xj && \
+    cd jemalloc-5.2.1 && \
+    ./configure && \
+    make && \
+    make install
+
+FROM ghcr.io/scientist-softserv/dev-ops/samvera:f71b284f as hyku-base
 
 COPY --chown=1001:101 $APP_PATH/Gemfile* /app/samvera/hyrax-webapp/
 RUN sh -l -c " \
@@ -18,6 +28,8 @@ RUN ln -sf /app/samvera/branding /app/samvera/hyrax-webapp/public/branding
 
 CMD ./bin/web
 
+COPY --from=builder /usr/local/lib/libjemalloc.so.2 /usr/local/lib/
+ENV LD_PRELOAD=/usr/local/lib/libjemalloc.so.2
+
 FROM hyku-base as hyku-worker
-ENV MALLOC_ARENA_MAX=2
 CMD ./bin/worker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ x-app: &app
     target: hyku-base
     args:
       - EXTRA_APK_PACKAGES=less vim bash openjdk11-jre ffmpeg rsync exiftool
+      - HYKU_BULKRAX_ENABLED=true
   image: ghcr.io/scientist-softserv/palni-palci:${TAG:-latest}
   env_file:
     - .env
@@ -41,7 +42,6 @@ services:
       - 2181:2181
       - 7001:7000
     environment:
-      - ALLOW_ANONYMOUS_LOGIN=yes
       - ZOO_MY_ID=1
       - ZOO_SERVERS=server.1=zoo:2888:3888;2181
       - ZOO_4LW_COMMANDS_WHITELIST=mntr,srvr,ruok,conf
@@ -83,11 +83,11 @@ services:
     networks:
       internal:
     healthcheck:
-      test: curl -sf http://$$SOLR_ADMIN_USER:$$SOLR_ADMIN_PASSWORD@solr:8983/solr/admin/cores?action=STATUS || exit 1
-      start_period: 3s
-      interval: 5s
+      test: curl -sf http://$$SOLR_ADMIN_USER:$$SOLR_ADMIN_PASSWORD@localhost:8983/solr/admin/cores?action=STATUS || exit 1
+      start_period: 30s
+      interval: 20s
       timeout: 5s
-      retries: 6
+      retries: 3
     depends_on:
       zoo:
         condition: service_healthy
@@ -124,8 +124,7 @@ services:
 
   web:
     <<: *app
-    # Uncomment command to access container with out starting Rails. Useful for debugging
-    # command: sleep infinity
+    # command: sh -l -c "bundle && bundle exec puma -v -b tcp://0.0.0.0:3000"
     environment:
       - VIRTUAL_PORT=3000
       - VIRTUAL_HOST=.hyku.test
@@ -160,6 +159,7 @@ services:
       target: hyku-worker
       args:
         - EXTRA_APK_PACKAGES=less vim bash openjdk11-jre ffmpeg rsync exiftool
+        - HYKU_BULKRAX_ENABLED=true
       cache_from:
         - ghcr.io/scientist-softserv/palni-palci:${TAG:-latest}
         - ghcr.io/scientist-softserv/palni-palci/worker:${TAG:-latest}


### PR DESCRIPTION
The primary change in Docker is moving from JDK 11 to 17 and improving the FITs xml config.

```
❯ git slog e9200061..f71b284f --no-merges
* e1c0510 — update fits xml Kirk Wang, (2022-12-01)
* 78eea74 — update jdk from 11 to 17 Kirk Wang, (2022-11-30)
* a404d11 — make cluster name a variable Rob Kaufman, (2022-11-19)
* d5745de — fix loki deploy Rob Kaufman, (2022-11-15)
```

Related to:

- https://github.com/scientist-softserv/palni-palci/issues/690

<details>
<summary>Commits since the reference point I'm bringing over from UTK</summary>

```
❯ git slog f71b284f.. --no-merges
* 99e6df9 — remove mimir, fix postgres Rob Kaufman, (2023-07-20) (origin/mimir_begon)
* 7e3d1c2 — add signoz to stack Rob Kaufman, (2023-06-21) (origin/signoz)
* abb6747 — build a new version of the LB with opentracing installed Rob Kaufman, (2023-06-21) (origin/loadbalancer_tracing)
* f91dddd — Update label_maker.rb to do description Rob Kaufman, (2023-06-22)
* 607051a — Update labels in label_maker.rb Crystal Richardson, (2023-06-22)
* e152146 — rotate mimir password Rob Kaufman, (2023-06-07)
* 5899db9 — try the zalando postgres opperator Rob Kaufman, (2023-06-07)
* d53fa35 — k8s notes. need to encrypt secrets to commit rest Rob Kaufman, (2023-05-18) (origin/smorgasbord_of_changes)
* 6a4d0e2 — aws loadbalancer, static ip support, nginx updates, mirmir, database backups and monitoring update. yes these should have been seperate Rob Kaufman, (2023-05-18)
| * e14543c — update syntax for deployment April Rieger, (2023-06-07)
| * 6fdca19 — Add issue template: dockerize application Diem ("Yeem") Tran, (2023-06-07)
| * fdd7967 — Add issue template: restore tests Diem ("Yeem") Tran, (2023-06-07)
| * 6596297 — Add issue template: project setup Diem ("Yeem") Tran, (2023-06-07)
| * b3fe36f — Updates to personnel from Sherwin April Rieger, (2022-12-17) (origin/glass-canvas-personnel-updates)
| * 66200ab — remove templates from legacy workflow Diem Tran, (2023-06-07)
| * e033ec4 — remove default issue template and add dev ops templates Diem Tran, (2023-06-02)
| * f58b80c — remove gitlab templates and add github templates Diem Tran, (2023-03-17)
| * bd50b88 — Updates the resource allocation based on the ticket April Rieger, (2023-06-05) (origin/695-update-resource-allocations)
|/
* b914ee8 — install ruby Rob Kaufman, (2023-04-21)
* c97f874 — install ruby Rob Kaufman, (2023-04-21)
* 23112df — working on workflows Rob Kaufman, (2023-04-21)
* 42d50a6 — working on label maker action Rob Kaufman, (2023-04-21)
* c806d99 — fix action Rob Kaufman, (2023-04-21)
* bcfc3c1 — label maker initial commit Rob Kaufman, (2023-04-21)
* f231359 — jemaloc base until hyrax gets it Rob Kaufman, (2023-03-24)
* 9c759e5 — deployment needs for r2-friends, move runners Rob Kaufman, (2022-11-28)
```

</details>

