### PR TITLE
i694 Remove member list report from the reports list

### DIFF
--- a/app/controllers/api/sushi_controller.rb
+++ b/app/controllers/api/sushi_controller.rb
@@ -49,11 +49,6 @@ module API
       render json: @status
     end
 
-    def member_list
-      # Logic to retrieve members data
-      render json: { "members" => 'message' }
-    end
-
     def report_list
       @report = Sushi::ReportList.new
       render json: @report

--- a/app/models/sushi/report_list.rb
+++ b/app/models/sushi/report_list.rb
@@ -14,13 +14,6 @@ module Sushi
           "Path" => "/api/sushi/r51/status"
         },
         {
-          "Report_Name" => "Member List",
-          "Report_ID" => "members",
-          "Release" => "5.1",
-          "Report_Description" => "This resource returns the list of consortium members related to a Customer_ID.",
-          "Path" => "/api/sushi/r51/members"
-        },
-        {
           "Report_Name" => "Report List",
           "Report_ID" => "reports",
           "Release" => "5.1",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,6 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
     resource :sushi do
       collection do
         get 'r51/status', to: 'sushi#server_status'
-        get 'r51/members', to: 'sushi#member_list'
         get 'r51/reports', to: 'sushi#report_list'
         get 'r51/reports/pr', to: 'sushi#platform_report'
         get 'r51/reports/pr_p1', to: 'sushi#platform_usage'

--- a/spec/models/sushi/report_list_spec.rb
+++ b/spec/models/sushi/report_list_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Sushi::ReportList do
 
     it 'returns the correct format' do
       expect(subject).to be_an_instance_of(Array)
-      expect(subject.length).to eq(6)
+      expect(subject.length).to eq(5)
     end
 
     it 'has the expected keys' do

--- a/spec/requests/api/sushi_spec.rb
+++ b/spec/requests/api/sushi_spec.rb
@@ -55,15 +55,6 @@ RSpec.describe 'api/sushi/r51', type: :request, singletenant: true do
     end
   end
 
-  describe 'GET /api/sushi/r51/members (e.g. members report)' do
-    it 'returns a 200 status' do
-      get '/api/sushi/r51/members'
-      expect(response).to have_http_status(200)
-      parsed_body = JSON.parse(response.body)
-      expect(parsed_body['members']).to eq 'message'
-    end
-  end
-
   describe 'GET /api/sushi/r51/reports (e.g. reports list)' do
     it 'returns a 200 status' do
       get '/api/sushi/r51/reports'


### PR DESCRIPTION
# Story

This feature is not currently needed, so we're not going to worry about maintaining it.

Ref
- #694

# Expected Behavior Before Changes

- Can see a "Members List" report name in the report list (`/api/sushi/r51/reports`) 
- Can view the members report at `/api/sushi/r51/members` 

# Expected Behavior After Changes

- Cannot see a "Members List" report name in the report list (`/api/sushi/r51/reports`) 
- Cannot view the members report at `/api/sushi/r51/members` 

# Screenshots / Video

<details>
<summary>No "Members List" report name</summary>

![image](https://github.com/scientist-softserv/palni-palci/assets/32469930/1837d019-db31-4dbb-bc33-0dc26a2c655a)

</details>

---

Co-authored-by: Alisha Evans <alishaevn2@gmail.com>
Co-authored-by: Lea Ann Bradford <ltrammer@gmail.com>