### PR TITLE
686 Granularity Filter

### DIFF
--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -157,12 +157,17 @@ module Sushi
     end
   end
 
+
+  # This param specifies the granularity of the usage data to include in the report.
+  # Permissible values are Month (default) and Totals.
+  # For Totals, each Item_Performance element represents the aggregated usage for the reporting period.
+  # See https://cop5.projectcounter.org/en/5.1/03-specifications/03-counter-report-common-attributes-and-elements.html#report-filters-and-report-attributes for details
   module GranularityCoercion
     extend ActiveSupport::Concern
     included do
       attr_reader :granularity_string, :granularity_in_params
     end
-    ALLOWED_GRANULARITY = ["Month", "Total"].freeze
+    ALLOWED_GRANULARITY = ["Month", "Totals"].freeze
 
     def coerce_granularity(params = {})
       @granularity_in_params = params.key?(:granularity) &&

--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -164,14 +164,14 @@ module Sushi
   module GranularityCoercion
     extend ActiveSupport::Concern
     included do
-      attr_reader :granularity_string, :granularity_in_params
+      attr_reader :granularity, :granularity_in_params
     end
     ALLOWED_GRANULARITY = ["Month", "Totals"].freeze
 
     def coerce_granularity(params = {})
       @granularity_in_params = params.key?(:granularity) &&
                                ALLOWED_GRANULARITY.any? { |allowed_granularity| allowed_granularity.casecmp(params[:granularity].downcase).zero? }
-      @granularity_string = params.fetch(:granularity, "Month").capitalize
+      @granularity = params.fetch(:granularity, "Month").capitalize
     end
   end
 end

--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -157,7 +157,6 @@ module Sushi
     end
   end
 
-
   # This param specifies the granularity of the usage data to include in the report.
   # Permissible values are Month (default) and Totals.
   # For Totals, each Item_Performance element represents the aggregated usage for the reporting period.
@@ -171,7 +170,7 @@ module Sushi
 
     def coerce_granularity(params = {})
       @granularity_in_params = params.key?(:granularity) &&
-                               ALLOWED_GRANULARITY.any? { |allowed_granularity| allowed_granularity.downcase == params[:granularity].downcase }
+                               ALLOWED_GRANULARITY.any? { |allowed_granularity| allowed_granularity.casecmp(params[:granularity].downcase).zero? }
       @granularity_string = params.fetch(:granularity, "Month").capitalize
     end
   end

--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -156,4 +156,18 @@ module Sushi
                       end
     end
   end
+
+  module GranularityCoercion
+    extend ActiveSupport::Concern
+    included do
+      attr_reader :granularity_string, :granularity_in_params
+    end
+    ALLOWED_GRANULARITY = ["Month", "Total"].freeze
+
+    def coerce_granularity(params = {})
+      @granularity_in_params = params.key?(:granularity) &&
+                               ALLOWED_GRANULARITY.any? { |allowed| allowed.downcase == params[:granularity].downcase }
+      @granularity_string = params.fetch(:granularity, "Month")
+    end
+  end
 end

--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -171,8 +171,8 @@ module Sushi
 
     def coerce_granularity(params = {})
       @granularity_in_params = params.key?(:granularity) &&
-                               ALLOWED_GRANULARITY.any? { |allowed| allowed.downcase == params[:granularity].downcase }
-      @granularity_string = params.fetch(:granularity, "Month")
+                               ALLOWED_GRANULARITY.any? { |allowed_granularity| allowed_granularity.downcase == params[:granularity].downcase }
+      @granularity_string = params.fetch(:granularity, "Month").capitalize
     end
   end
 end

--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -169,8 +169,7 @@ module Sushi
     ALLOWED_GRANULARITY = ["Month", "Totals"].freeze
 
     def coerce_granularity(params = {})
-      @granularity_in_params = params.key?(:granularity) &&
-                               ALLOWED_GRANULARITY.any? { |allowed_granularity| allowed_granularity.casecmp(params[:granularity].downcase).zero? }
+      @granularity_in_params = ALLOWED_GRANULARITY.include?(params[:granularity].to_s.capitalize)
       @granularity = params.fetch(:granularity, "Month").capitalize
     end
   end

--- a/app/models/sushi/platform_report.rb
+++ b/app/models/sushi/platform_report.rb
@@ -84,7 +84,7 @@ module Sushi
         "Access_Method" => "Regular",
         "Performance" => {
           "Searches_Platform" => if granularity == 'Totals'
-                                   total_for_platform = data_for_platform.map(&:total_item_investigations).sum
+                                   total_for_platform = data_for_platform.sum(&:total_item_investigations)
                                    { "Totals" => total_for_platform }
                                  else
                                    data_for_platform.each_with_object({}) do |record, hash|

--- a/app/models/sushi/platform_report.rb
+++ b/app/models/sushi/platform_report.rb
@@ -64,7 +64,7 @@ module Sushi
       }
       report_hash["Report_Header"]["Report_Filters"]["Data_Type"] = data_types if data_type_in_params
       report_hash["Report_Header"]["Report_Filters"]["Metric_Type"] = metric_types if metric_type_in_params
-      report_hash["Report_Header"]["Report_Attributes"]["Granularity"] = granularity_string if granularity_in_params
+      report_hash["Report_Header"]["Report_Attributes"]["Granularity"] = granularity if granularity_in_params
       report_hash
     end
 
@@ -83,7 +83,7 @@ module Sushi
         "Data_Type" => "Platform",
         "Access_Method" => "Regular",
         "Performance" => {
-          "Searches_Platform" => if granularity_string == 'Totals'
+          "Searches_Platform" => if granularity == 'Totals'
                                    total_for_platform = data_for_platform.map(&:total_item_investigations).sum
                                    { "Totals" => total_for_platform }
                                  else
@@ -98,7 +98,7 @@ module Sushi
 
     def performance(records)
       metric_types.each_with_object({}) do |metric_type, hash|
-        hash[metric_type] = if granularity_string == 'Totals'
+        hash[metric_type] = if granularity == 'Totals'
                               total_per_metric_type = records.map do |record|
                                 record[metric_type.downcase.to_s]
                               end.sum

--- a/app/models/sushi/platform_report.rb
+++ b/app/models/sushi/platform_report.rb
@@ -11,6 +11,7 @@ module Sushi
     include Sushi::DateCoercion
     include Sushi::DataTypeCoercion
     include Sushi::MetricTypeCoercion
+    include Sushi::GranularityCoercion
     ALLOWED_REPORT_ATTRIBUTES_TO_SHOW = [
       "Access_Method",
       # These are all the counter compliant query attributes, they are not currently supported in this implementation.
@@ -27,6 +28,7 @@ module Sushi
       coerce_dates(params)
       coerce_data_types(params)
       coerce_metric_types(params)
+      coerce_granularity(params)
       @created = created
       @account = account
 
@@ -62,6 +64,7 @@ module Sushi
       }
       report_hash["Report_Header"]["Report_Filters"]["Data_Type"] = data_types if data_type_in_params
       report_hash["Report_Header"]["Report_Filters"]["Metric_Type"] = metric_types if metric_type_in_params
+      report_hash["Report_Header"]["Report_Attributes"]["Granularity"] = granularity_string if granularity_in_params
       report_hash
     end
 
@@ -95,6 +98,12 @@ module Sushi
           end
         }
       }]
+    end
+
+    # Specifies the granularity of the usage data to include in the report.
+    # Permissible values are Month (default) and Totals.
+    # For Totals each Item_Performance element represents the aggregated usage for the reporting period.
+    def granularity
     end
 
     ##

--- a/app/models/sushi/platform_report.rb
+++ b/app/models/sushi/platform_report.rb
@@ -83,24 +83,24 @@ module Sushi
         "Data_Type" => "Platform",
         "Access_Method" => "Regular",
         "Performance" => {
-          "Searches_Platform" => if granularity_string.casecmp("Totals").zero?
+          "Searches_Platform" => if granularity_string === 'Totals'
                                   total_for_platform = data_for_platform.map do |record|
                                     record.total_item_investigations
                                   end.sum
                                   { "Totals" => total_for_platform }
                                  else
                                   data_for_platform.each_with_object({}) do |record, hash|
-                                  hash[record.year_month.strftime("%Y-%m")] = record.total_item_investigations
-                                  hash
-                                 end
-          end
+                                    hash[record.year_month.strftime("%Y-%m")] = record.total_item_investigations
+                                    hash
+                                  end
+                                end
         }
       }]
     end
 
       def performance(records)
         metric_types.each_with_object({}) do |metric_type, hash|
-          hash[metric_type] = if granularity_string.casecmp("Totals").zero?
+          hash[metric_type] = if granularity_string === 'Totals'
                                 total_per_metric_type = records.map do |record|
                                   record[metric_type.downcase.to_s]
                                 end.sum

--- a/app/models/sushi/platform_report.rb
+++ b/app/models/sushi/platform_report.rb
@@ -83,36 +83,34 @@ module Sushi
         "Data_Type" => "Platform",
         "Access_Method" => "Regular",
         "Performance" => {
-          "Searches_Platform" => if granularity_string === 'Totals'
-                                  total_for_platform = data_for_platform.map do |record|
-                                    record.total_item_investigations
-                                  end.sum
-                                  { "Totals" => total_for_platform }
+          "Searches_Platform" => if granularity_string == 'Totals'
+                                   total_for_platform = data_for_platform.map(&:total_item_investigations).sum
+                                   { "Totals" => total_for_platform }
                                  else
-                                  data_for_platform.each_with_object({}) do |record, hash|
-                                    hash[record.year_month.strftime("%Y-%m")] = record.total_item_investigations
-                                    hash
-                                  end
-                                end
+                                   data_for_platform.each_with_object({}) do |record, hash|
+                                     hash[record.year_month.strftime("%Y-%m")] = record.total_item_investigations
+                                     hash
+                                   end
+                                 end
         }
       }]
     end
 
-      def performance(records)
-        metric_types.each_with_object({}) do |metric_type, hash|
-          hash[metric_type] = if granularity_string === 'Totals'
-                                total_per_metric_type = records.map do |record|
-                                  record[metric_type.downcase.to_s]
-                                end.sum
-                                { "Totals" => total_per_metric_type }
-                              else
-                                records.each_with_object({}) do |record, inner_hash|
-                                  inner_hash[record.year_month.strftime("%Y-%m")] = record[metric_type.downcase.to_s]
-                                  inner_hash
-                                end
+    def performance(records)
+      metric_types.each_with_object({}) do |metric_type, hash|
+        hash[metric_type] = if granularity_string == 'Totals'
+                              total_per_metric_type = records.map do |record|
+                                record[metric_type.downcase.to_s]
+                              end.sum
+                              { "Totals" => total_per_metric_type }
+                            else
+                              records.each_with_object({}) do |record, inner_hash|
+                                inner_hash[record.year_month.strftime("%Y-%m")] = record[metric_type.downcase.to_s]
+                                inner_hash
                               end
-        end
+                            end
       end
+    end
 
     ##
     # @note the `date_trunc` SQL function is specific to Postgresql.  It will take the date/time field

--- a/spec/models/sushi/item_report_spec.rb
+++ b/spec/models/sushi/item_report_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Sushi::ItemReport do
       expect(subject.dig('Report_Items', 0, 'Items', 0, 'Attribute_Performance', 0, 'Performance', 'Total_Item_Investigations', '2023-08')).to eq(2)
       expect(subject.dig('Report_Items', 0, 'Items', 0, 'Attribute_Performance', 0, 'Data_Type')).to eq('Article')
       expect(subject.dig('Report_Items', 0, 'Items', 0, 'Attribute_Performance', 0, 'Performance', 'Unique_Item_Investigations', '2023-08')).to eq(1)
-      expect(subject.dig('Report_Items', 2, 'Items', 0, 'Attribute_Performance', 0, 'Performance', 'Unique_Item_Investigations', '2022-01')).to eq(2)
+      expect(subject.dig('Report_Items', 2, 'Items', 0, 'Attribute_Performance', 0, 'Performance', 'Unique_Item_Investigations', '2022-01')).to eq(1)
     end
 
     context 'with a valid item_id param' do

--- a/spec/models/sushi/platform_report_spec.rb
+++ b/spec/models/sushi/platform_report_spec.rb
@@ -38,7 +38,8 @@ RSpec.describe Sushi::PlatformReport do
           end_date: '2023-09',
           metric_type: 'total_item_investigations|unique_item_investigations|fake_value',
           data_type: 'article',
-          attributes_to_show: ['Access_Method', 'Fake_Value']
+          attributes_to_show: ['Access_Method', 'Fake_Value'],
+          granularity: 'totals'
         }
       end
 
@@ -57,6 +58,11 @@ RSpec.describe Sushi::PlatformReport do
       it 'does not show title requests/investigations for non-book resource types' do
         expect(subject.dig('Report_Items', 'Attribute_Performance').first.dig('Performance')).not_to have_key('Unique_Title_Requests')
         expect(subject.dig('Report_Items', 'Attribute_Performance').first.dig('Performance')).not_to have_key('Unique_Title_Investigations')
+      end
+
+      it 'sums the totals for each metric type' do
+        expect(subject.dig('Report_Header', 'Report_Attributes', 'Granularity')).to eq('Totals')
+        expect(subject.dig('Report_Items', 'Attribute_Performance').first.dig('Performance', 'Total_Item_Investigations', 'Totals')).to eq(6)
       end
     end
   end

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -27,6 +27,7 @@ def expect_additional_fields
   assert_select "input[name=?]", "user[preferred_locale]"
 end
 
+# rubocop:disable Metrics/MethodLength
 def create_hyrax_countermetric_objects
   Hyrax::CounterMetric.create(
     worktype: 'GenericWork',
@@ -70,3 +71,4 @@ def create_hyrax_countermetric_objects
     total_item_requests: 3
   )
 end
+# rubocop:enable Metrics/MethodLength

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -44,6 +44,7 @@ def create_hyrax_countermetric_objects
     total_item_investigations: 3,
     total_item_requests: 5
   )
+  # used to test the case where a hyrax countermetric has a unique date, but same work ID.
   Hyrax::CounterMetric.create(
     worktype: 'GenericWork',
     resource_type: 'Book',
@@ -52,7 +53,6 @@ def create_hyrax_countermetric_objects
     total_item_investigations: 2,
     total_item_requests: 4
   )
-  # used to test the case where a hyrax countermetric has a unique date, but same work ID.
   Hyrax::CounterMetric.create(
     worktype: 'GenericWork',
     resource_type: 'Article',
@@ -60,5 +60,13 @@ def create_hyrax_countermetric_objects
     date: '2023-08-09',
     total_item_investigations: 2,
     total_item_requests: 8
+  )
+  Hyrax::CounterMetric.create(
+    worktype: 'GenericWork',
+    resource_type: 'Article',
+    work_id: '99999',
+    date: '2023-08-09',
+    total_item_investigations: 4,
+    total_item_requests: 3
   )
 end


### PR DESCRIPTION
# Story
Adds a Granularity filter to the Platform Report

Granularity - documentation: https://cop5.projectcounter.org/en/5.1/03-specifications/03-counter-report-common-attributes-and-elements.html#report-filters-and-report-attributes
<img width="860" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/73361970/911f5837-2913-4b4b-9a86-cbe3411087f6">

# Related
- #686 

# Expected Behavior Before Changes
- User could not filter by granularity

# Expected Behavior After Changes
 - [ ] As a user, I can set the granularity param to "Totals" or "totals to see the total counts for each metric type within my specified begin & end date range
 
 # Testing instructions
 - Go to `/api/sushi/r51/reports/pr?begin_date=2023-05&end_date=2023-07&granularity=totals`
 - Check that you see the total counts for each metric type as opposed to the counts separated by month. 
 
# Screenshots / Video
Video : https://share.getcloudapp.com/DOuKZRdW
<details>
<summary>JSON example</summary>
<img width="793" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/73361970/f868c36e-7f9f-4605-b68d-f3928436550a">

</details>

