### PR TITLE
i674 Rake tasks to move banner images to new expected file location

### DIFF
--- a/lib/tasks/move_banner_images.rake
+++ b/lib/tasks/move_banner_images.rake
@@ -27,7 +27,7 @@ namespace :hyku do
         # we can't simply point it to the new path
         Apartment::Tenant.switch(tenant_uuid) do
           site = Site.instance
-          File.open(renamed_destination) { |file| site.banner_image = file }
+          File.open(renamed_destination) { |banner_image| site.banner_image = banner_image }
           site.save!
         end
       else

--- a/lib/tasks/move_banner_images.rake
+++ b/lib/tasks/move_banner_images.rake
@@ -22,6 +22,14 @@ namespace :hyku do
         puts "#{File.basename(file)} renamed to #{File.basename(renamed_destination)}"
         puts "Copying #{file} to #{renamed_destination}"
         FileUtils.cp(file, renamed_destination)
+
+        # Since the filename has changed, we need to "re-upload" the file to the site;
+        # we can't simply point it to the new path
+        Apartment::Tenant.switch(tenant_uuid) do
+          site = Site.instance
+          File.open(renamed_destination) { |file| site.banner_image = file }
+          site.save!
+        end
       else
         puts "Copying #{file} to #{new_location}"
         FileUtils.cp(file, new_location)

--- a/lib/tasks/move_banner_images.rake
+++ b/lib/tasks/move_banner_images.rake
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# @see https://github.com/scientist-softserv/palni-palci/issues/674
+namespace :hyku do
+  desc 'Move all banner images to new expected location'
+  task copy_banner_images: :environment do
+    files_in_old_location = `find #{Rails.root}/public/uploads/*/site/banner_image/* -type f`.split("\n")
+    new_location = Rails.root.join('public', 'system', 'banner_images', '1', 'original')
+
+    FileUtils.mkdir_p(new_location)
+    files_in_old_location.each do |file|
+      puts "Copying #{file} to #{new_location}"
+      FileUtils.cp(file, new_location)
+    end
+  end
+
+  desc 'Delete all banner images in old location'
+  task delete_old_banner_images: :environment do
+    copy_first_msg = 'WARNING - before running this, run hyku:copy_banner_images and verify the ' \
+                     'files get copied successfully. Continue? (y/n)'
+    STDOUT.puts copy_first_msg
+    conf1 = STDIN.gets.chomp
+    unless %w[y yes].include?(conf1)
+      puts 'Task canceled'
+      exit 1
+    end
+
+    files_in_old_location = `find #{Rails.root}/public/uploads/*/site/banner_image/* -type f`.split("\n")
+    files_in_new_location = `find #{Rails.root}/public/system/banner_images/*/original/* -type f`.split("\n")
+
+    if files_in_old_location.length > files_in_new_location.length
+      warning = "WARNING - more files exist in the old file location (#{files_in_old_location.length}) " \
+                "than the new location (#{files_in_new_location.length}). Continue? (y/n)"
+      STDOUT.puts warning
+      conf2 = STDIN.gets.chomp
+      unless %w[y yes].include?(conf2)
+        puts 'Task canceled'
+        exit 1
+      end
+    end
+
+    files_in_old_location.each { |file| FileUtils.rm(file) }
+  end
+end

--- a/lib/tasks/move_banner_images.rake
+++ b/lib/tasks/move_banner_images.rake
@@ -7,10 +7,25 @@ namespace :hyku do
     files_in_old_location = `find #{Rails.root}/public/uploads/*/site/banner_image/* -type f`.split("\n")
     new_location = Rails.root.join('public', 'system', 'banner_images', '1', 'original')
 
+    grouped_file_paths = file_paths.group_by do |file_path|
+      File.basename(file_path)
+    end
+    duplicate_file_paths = grouped_file_paths.values.select { |paths| paths.size > 1 }.flatten
+
     FileUtils.mkdir_p(new_location)
     files_in_old_location.each do |file|
-      puts "Copying #{file} to #{new_location}"
-      FileUtils.cp(file, new_location)
+      if duplicate_file_paths.include?(file)
+        tenant_uuid = file.split('/')[2]
+        new_filename = "#{File.basename(file, '.*')}_#{tenant_uuid}#{File.extname(file)}"
+        renamed_destination = File.join(new_location, new_filename)
+
+        puts "#{File.basename(file)} renamed to #{File.basename(renamed_destination)}"
+        puts "Copying #{file} to #{renamed_destination}"
+        FileUtils.cp(file, renamed_destination)
+      else
+        puts "Copying #{file} to #{new_location}"
+        FileUtils.cp(file, new_location)
+      end
     end
   end
 


### PR DESCRIPTION
# Story

Refs
- #674 

Adds two new rake tasks: 

- `hyku:copy_banner_images`
  - Will non-destructively copy all Hyku banner images across all tenants from the old file location to the new, expected location 
  - **Run this one first** 
- `hyku:delete_old_banner_images`
  - Clean up task: will delete all banner images in the old location 
  - **Run this one second _after_ confirming the presence of banner images across exiting tenants** 