### PR TITLE
Change default for use iiif_print to false per client request

### DIFF
--- a/config/features.rb
+++ b/config/features.rb
@@ -25,9 +25,7 @@ Flipflop.configure do
           default: false,
           description: "Shows the Identity Provider tab on the admin dashboard."
 
-  # As of <2023-08-10 Thu> we had presumptively defaulted to `true`, hence I'm setting this to
-  # default to true.
   feature :use_iiif_print,
-          default: true,
+          default: false,
           description: "Use IIIF Print for derivative generation (with PDF splitting and OCR)."         
 end

--- a/spec/services/iiif_print/tenant_config_spec.rb
+++ b/spec/services/iiif_print/tenant_config_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe 'Tenant Config for IIIF Print' do
       subject { described_class.use_iiif_print? }
 
       context 'by default' do
-        it { is_expected.to be_truthy }
+        it { is_expected.to be_falsey }
       end
 
       context 'when the feature is flipped to false' do


### PR DESCRIPTION
# Story

Refs #659 

Client would like default for using IIIF Print to be false

# Expected Behavior Before Changes

# Expected Behavior After Changes

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes
