### PR TITLE
☑️  Add spring to provide option for faster tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,6 +99,7 @@ gem 'sidekiq'
 gem 'simplecov', require: false, group: %i[development test]
 gem 'solr_wrapper', '~> 2.0', group: %i[development test]
 gem 'spring', '~> 1.7', group: %i[development]
+gem 'spring-commands-rspec', group: %i[development]
 gem 'spring-watcher-listen', '~> 2.0.0', group: %i[development]
 gem 'terser' # to support the Safe Navigation / Optional Chaining operator (?.) and avoid uglifier precompile issue
 gem 'tether-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1291,6 +1291,8 @@ GEM
       net-http-persistent (~> 4.0, >= 4.0.1)
       rdf (~> 3.1)
     spring (1.7.2)
+    spring-commands-rspec (1.0.4)
+      spring (>= 0.9.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
@@ -1499,6 +1501,7 @@ DEPENDENCIES
   simplecov
   solr_wrapper (~> 2.0)
   spring (~> 1.7)
+  spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
   terser
   tether-rails


### PR DESCRIPTION
To leverage spring, you will need to:

- Start the containers (e.g. `sc up`)
- Run the specs using spring (e.g. `spring rspec path/to/my_spec.rb`)

Spring boots up a Rails server and re-uses that between invocations. This means that instead of spending about 1 minute booting the application to run a 1 second test, you can re-use that app (spending about 8 seconds or so connecting to it) then run that 1 second test.

But beware of spring, as it can create odd behavior in the application. As a matter of practice when you are done testing, run `spring stop` to terminate the spring booted applications.

In past years, some of the pernicious bugs in development were because folks had spring running.  However, for unit tests, having a quick feedback is critical so I believe this is worth the risk.  Especially given that you must explicitly start spring.

Related to:

- https://github.com/scientist-softserv/britishlibrary/pull/252
- https://github.com/scientist-softserv/adventist-dl/pull/229
