### PR TITLE
🐛 Fix issue of calling private solr_document method

### DIFF
--- a/app/presenters/concerns/hyrax/iiif_av/displays_content_decorator.rb
+++ b/app/presenters/concerns/hyrax/iiif_av/displays_content_decorator.rb
@@ -8,15 +8,15 @@ module Hyrax
     #   request.base_url => hostname
     # also to remove #auth_service since it was not working for now
     module DisplaysContentDecorator
+      def solr_document
+        defined?(super) ? super : object
+      end
+
+      def current_ability
+        defined?(super) ? super : @ability
+      end
+
       private
-
-        def solr_document
-          defined?(super) ? super : object
-        end
-
-        def current_ability
-          defined?(super) ? super : @ability
-        end
 
         Request = Struct.new(:base_url, keyword_init: true)
 

--- a/spec/presenters/concerns/hyrax/iiif_av/displays_content_decorator_spec.rb
+++ b/spec/presenters/concerns/hyrax/iiif_av/displays_content_decorator_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Hyrax::IiifAv::DisplaysContentDecorator do
+  # We're prepending the DisplaysContentDecorator to the Hyrax::IiifAv::DisplaysContent
+  describe Hyrax::IiifAv::DisplaysContent do
+    describe '.public_instance_methods' do
+      subject { Hyrax::IiifAv::DisplaysContent.public_instance_methods }
+
+      it { is_expected.to include(:solr_document) }
+      it { is_expected.to include(:current_ability) }
+    end
+  end
+end


### PR DESCRIPTION
Prior to this commit, we had a private `#solr_document` method.  This resulted in an error in the `Hyrax::Ability` as follows:

```
NoMethodError
private method `solr_document' called for #<Hyrax::IiifAv::IiifFileSetPresenter:0x00007ff118124808>
Did you mean?  solr_document=
```

With this commit, I'm making public two methods that might cause issues being private.  (And adding a test verifying the interface)

Oh dear reviewer, were that I were able to duplicate the bug locally.  I tried toggling on and off the feature flag.  I also tried toggling the allow downloads.  But to no avail.  Alas, I cannot replicate but must instead rely on addressing the specific error.

Related to:

- https://github.com/scientist-softserv/palni-palci/issues/659
- https://scientist-inc.sentry.io/issues/4368889816/?environment=production&project=6707374&referrer=project-issue-stream
