### PR TITLE
688 refactor query validation

### DIFF
--- a/app/controllers/api/sushi_controller.rb
+++ b/app/controllers/api/sushi_controller.rb
@@ -18,7 +18,7 @@ module API
       # @param [Exception]
       #
       def render_not_found(error)
-        render json: { error: error.message}, status: 404
+        render json: { error: error.message }, status: 404
       end
       rescue_from Sushi::NotFoundError, with: :render_not_found
 

--- a/app/controllers/api/sushi_controller.rb
+++ b/app/controllers/api/sushi_controller.rb
@@ -12,6 +12,16 @@ module API
       end
       rescue_from ActionController::ParameterMissing, Sushi::InvalidParameterValue, with: :render_error_that_is_user_correctable
 
+      ##
+      # We have encountered some semblance of missing data, we've thrown that via an exception, and we're
+      # handling that missing data by presenting the error to the end user.
+      # @param [Exception]
+      #
+      def render_not_found(error)
+        render json: { error: error.message}, status: 404
+      end
+      rescue_from Sushi::NotFoundError, with: :render_not_found
+
     public
 
     ##

--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal:true
 
 module Sushi
+  class Sushi::NotFoundError < StandardError; end
+  class Sushi::MissingItemIdError < Sushi::NotFoundError; end
+  class Sushi::NoRecordsWithinDateRangeError < Sushi::NotFoundError; end
+
   ##
   # Raised when the parameter we are given does not match our expectations; e.g. we can't convert
   # the text value to a Date.

--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -1,14 +1,17 @@
 # frozen_string_literal:true
 
 module Sushi
-  class Sushi::NotFoundError < StandardError
+  class NotFoundError < StandardError
     class << self
       def no_records_within_date_range
         new('There are no results for the given date range.')
       end
+
+      def invalid_item_id(item_id)
+        new("The given parameter `item_id=#{item_id}` is invalid. Please provide a valid item_id, or none at all.")
+      end
     end
   end
-
 
   ##
   # Raised when the parameter we are given does not match our expectations; e.g. we can't convert
@@ -16,10 +19,6 @@ module Sushi
   class InvalidParameterValue < StandardError
     # rubocop:disable Metrics/LineLength
     class << self
-      def invalid_item_id(item_id)
-        new("The given parameter `item_id=#{item_id}` is invalid. Please provide a valid item_id, or none at all.")
-      end
-
       def invalid_platform(platform, account)
         new("The given parameter `platform=#{platform}` is not supported at this endpoint. Please use #{account.cname} instead. (Or do not pass the parameter at all, which will default to #{account.cname})}")
       end
@@ -200,7 +199,7 @@ module Sushi
     end
 
     def validate_item_id(params)
-      raise Sushi::InvalidParameterValue.invalid_item_id(params[:item_id]) unless Hyrax::CounterMetric.exists?(['work_id LIKE ?', params[:item_id]])
+      raise Sushi::NotFoundError.invalid_item_id(params[:item_id]) unless Hyrax::CounterMetric.exists?(['work_id LIKE ?', params[:item_id]])
 
       @item_id = params[:item_id]
     end

--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -199,7 +199,7 @@ module Sushi
     end
 
     def validate_item_id(params)
-      raise Sushi::NotFoundError.invalid_item_id(params[:item_id]) unless Hyrax::CounterMetric.exists?(['work_id LIKE ?', params[:item_id]])
+      raise Sushi::NotFoundError.invalid_item_id(params[:item_id]) unless Hyrax::CounterMetric.exists?(work_id: params[:item_id])
 
       @item_id = params[:item_id]
     end

--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -185,13 +185,26 @@ module Sushi
   module QueryParameterValidation
     extend ActiveSupport::Concern
     included do
-      attr_reader :platform
+      attr_reader :item_id, :platform
     end
 
-    def validate_platform(params, account)
-      raise Sushi::InvalidParameterValue.invalid_platform(params[:platform], account) unless params[:platform].blank? || params[:platform] == account.cname
+    class << self
+      def validate_item_report_parameters(params:, account:, data:)
+        validate_item_id(params, data)
+        validate_platform(params, account)
+      end
 
-      @platform = account.cname
+      def validate_item_id(params, data)
+        raise Sushi::InvalidParameterValue.invalid_item_id(params[:item_id]) if params[:item_id] && data.blank?
+
+        @item_id = params[:item_id]
+      end
+
+      def validate_platform(params, account)
+        raise Sushi::InvalidParameterValue.invalid_platform(params[:platform], account) unless params[:platform].blank? || params[:platform] == account.cname
+
+        @platform = account.cname
+      end
     end
   end
 end

--- a/spec/models/sushi/item_report_spec.rb
+++ b/spec/models/sushi/item_report_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Sushi::ItemReport do
       end
 
       it 'raises an error' do
-        expect { described_class.new(params, created: created, account: account).as_json }.to raise_error(Sushi::InvalidParameterValue)
+        expect { described_class.new(params, created: created, account: account).as_json }.to raise_error(Sushi::NotFoundError)
       end
     end
   end

--- a/spec/models/sushi/item_report_spec.rb
+++ b/spec/models/sushi/item_report_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe Sushi::ItemReport do
         end
 
         it 'raises an error' do
-          expect { described_class.new(params, created: created, account: account).as_json }.to raise_error(Sushi::InvalidParameterValue)
+          expect { described_class.new(params, created: created, account: account).as_json }.to raise_error(Sushi::NotFoundError)
         end
       end
     end

--- a/spec/requests/api/sushi_spec.rb
+++ b/spec/requests/api/sushi_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe 'api/sushi/r51', type: :request, singletenant: true do
   describe 'GET /api/sushi/r51/reports/ir' do
     it_behaves_like 'without required parameters', 'ir'
 
+    before { create_hyrax_countermetric_objects }
+
     it 'returns a 200 with correct response for item report' do
       get '/api/sushi/r51/reports/ir', params: required_parameters
       expect(response).to have_http_status(200)
@@ -26,8 +28,6 @@ RSpec.describe 'api/sushi/r51', type: :request, singletenant: true do
     end
 
     context 'with a valid item_id parameter' do
-      before { create_hyrax_countermetric_objects }
-
       it 'returns a 200 status report for the given item' do
         get '/api/sushi/r51/reports/ir', params: { **required_parameters, item_id: '54321' }
         expect(response).to have_http_status(200)

--- a/spec/requests/api/sushi_spec.rb
+++ b/spec/requests/api/sushi_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'api/sushi/r51', type: :request, singletenant: true do
     context 'with an invalid item_id parameter' do
       it 'returns a 422 status report for the given item' do
         get '/api/sushi/r51/reports/ir', params: { **required_parameters, item_id: 'qwerty123' }
-        expect(response).to have_http_status(422)
+        expect(response).to have_http_status(404)
         parsed_body = JSON.parse(response.body)
         expect(parsed_body['error']).not_to be_nil
       end


### PR DESCRIPTION
# Story
refactor the item report errors

instead of always throwing a 422 error for having no results, we will throw a 422 only if the parameter given is invalid. e.g., the item_id does not exist in the `Hyrax::CounterMetric` table.

if there are no results because of the date range given however, we will throw a 404 and inform the user of that.

- #688 
