### PR TITLE
🐛 Fix method arity to remove exception

### DIFF
--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -331,10 +331,10 @@ module Blacklight
     #
     # @param [String] format suffix
     # @yield
-    def with_format(format, _block)
+    def with_format(format)
       old_formats = formats
       self.formats = [format]
-      yield
+      yield if block_given?
       self.formats = old_formats
       nil
     end


### PR DESCRIPTION
The method signature for `with_format` should take one positional argument.  The method as defined had two positional arguments (e.g. `format` and `_block`).  Likely what was meant by `_block` whas `&block`; and perhaps Rubocop had an opinion about that.

```bash
ArgumentError: wrong number of arguments (given 1, expected 2)
```

Related to:

- https://scientist-inc.sentry.io/issues/4381160445/?environment=production&project=6707374&referrer=project-issue-stream
