### PR TITLE
687 Metric type filter for platform usage report

### DIFF
--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -163,20 +163,28 @@ module Sushi
       # "Unique_Title_Requests"
     ].freeze
 
-    def coerce_metric_types(params = {})
+    ALLOWED_METRIC_TYPES_PLATFORM_USAGE = [
+      # the platform usage report only contains requests. see https://countermetrics.stoplight.io/docs/counter-sushi-api/mgu8ibcbgrwe0-pr-p1-performance-other for details
+      "Unique_Item_Requests",
+      "Total_Item_Requests"
+    ].freeze
+
+    def coerce_metric_types(params = {}, platform_usage_report = false)
+      metric_types_array = platform_usage_report ? ALLOWED_METRIC_TYPES_PLATFORM_USAGE : ALLOWED_METRIC_TYPES
+
       metric_types_from_params = Array.wrap(params[:metric_type]&.split('|'))
 
       @metric_type_in_params = metric_types_from_params.any? do |metric_type|
         normalized_metric_type = metric_type.downcase
-        ALLOWED_METRIC_TYPES.any? { |allowed_type| allowed_type.downcase == normalized_metric_type }
+        metric_types_array.any? { |allowed_type| allowed_type.downcase == normalized_metric_type }
       end
 
       @metric_types = if metric_types_from_params.empty?
-                        ALLOWED_METRIC_TYPES
+                        metric_types_array
                       else
                         metric_types_from_params.map do |metric_type|
                           normalized_metric_type = metric_type.downcase
-                          metric_type.titleize.tr(' ', '_') if ALLOWED_METRIC_TYPES.any? { |allowed_type| allowed_type.downcase == normalized_metric_type }
+                          metric_type.titleize.tr(' ', '_') if metric_types_array.any? { |allowed_type| allowed_type.downcase == normalized_metric_type }
                         end.compact
                       end
     end

--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -167,8 +167,6 @@ module Sushi
     end
 
     def coerce_metric_types(params = {})
-      raise 'hell'
-
       metric_types_from_params = Array.wrap(params[:metric_type]&.split('|'))
 
       @metric_type_in_params = metric_types_from_params.any? do |metric_type|

--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -150,41 +150,38 @@ module Sushi
     included do
       attr_reader :metric_types, :metric_type_in_params
     end
-    ALLOWED_METRIC_TYPES = [
-      "Total_Item_Investigations",
-      "Total_Item_Requests",
-      "Unique_Item_Investigations",
-      "Unique_Item_Requests",
-      # Unique_Title metrics exist to count how many chapters or sections are accessed for Book resource types in a given user session.
-      # This implementation currently does not support historical data from individual chapters/sections of Books,
-      # so these metrics will not be shown.
-      # See https://cop5.projectcounter.org/en/5.1/03-specifications/03-counter-report-common-attributes-and-elements.html#metric-types for details
-      # "Unique_Title_Investigations",
-      # "Unique_Title_Requests"
-    ].freeze
 
-    ALLOWED_METRIC_TYPES_PLATFORM_USAGE = [
-      # the platform usage report only contains requests. see https://countermetrics.stoplight.io/docs/counter-sushi-api/mgu8ibcbgrwe0-pr-p1-performance-other for details
-      "Unique_Item_Requests",
-      "Total_Item_Requests"
-    ].freeze
+    def allowed_metric_types
+      [
+        "Total_Item_Investigations",
+        "Total_Item_Requests",
+        "Unique_Item_Investigations",
+        "Unique_Item_Requests"
+        # Unique_Title metrics exist to count how many chapters or sections are accessed for Book resource types in a given user session.
+        # This implementation currently does not support historical data from individual chapters/sections of Books,
+        # so these metrics will not be shown.
+        # See https://cop5.projectcounter.org/en/5.1/03-specifications/03-counter-report-common-attributes-and-elements.html#metric-types for details
+        # "Unique_Title_Investigations",
+        # "Unique_Title_Requests"
+      ]
+    end
 
-    def coerce_metric_types(params = {}, platform_usage_report = false)
-      metric_types_array = platform_usage_report ? ALLOWED_METRIC_TYPES_PLATFORM_USAGE : ALLOWED_METRIC_TYPES
+    def coerce_metric_types(params = {})
+      raise 'hell'
 
       metric_types_from_params = Array.wrap(params[:metric_type]&.split('|'))
 
       @metric_type_in_params = metric_types_from_params.any? do |metric_type|
         normalized_metric_type = metric_type.downcase
-        metric_types_array.any? { |allowed_type| allowed_type.downcase == normalized_metric_type }
+        allowed_metric_types.any? { |allowed_type| allowed_type.downcase == normalized_metric_type }
       end
 
       @metric_types = if metric_types_from_params.empty?
-                        metric_types_array
+                        allowed_metric_types
                       else
                         metric_types_from_params.map do |metric_type|
                           normalized_metric_type = metric_type.downcase
-                          metric_type.titleize.tr(' ', '_') if metric_types_array.any? { |allowed_type| allowed_type.downcase == normalized_metric_type }
+                          metric_type.titleize.tr(' ', '_') if allowed_metric_types.any? { |allowed_type| allowed_type.downcase == normalized_metric_type }
                         end.compact
                       end
     end

--- a/app/models/sushi/platform_usage_report.rb
+++ b/app/models/sushi/platform_usage_report.rb
@@ -65,7 +65,7 @@ module Sushi
 
     def performance(records)
       metric_types.each_with_object({}) do |metric_type, hash|
-        next if (['Total_Item_Investigations', 'Unique_Item_Investigations']).include?(metric_type)
+        next if ['Total_Item_Investigations', 'Unique_Item_Investigations'].include?(metric_type)
         hash[metric_type] = records.each_with_object({}) do |record, inner_hash|
           inner_hash[record.year_month.strftime("%Y-%m")] = record[metric_type.downcase.to_s]
           inner_hash

--- a/app/models/sushi/platform_usage_report.rb
+++ b/app/models/sushi/platform_usage_report.rb
@@ -14,10 +14,15 @@ module Sushi
     def initialize(params = {}, created: Time.zone.now, account:)
       coerce_dates(params)
       coerce_data_types(params)
-      coerce_metric_types(params, true)
+      coerce_metric_types(params)
 
       @created = created
       @account = account
+    end
+
+    def allowed_metric_types
+      # the platform usage report only contains requests. see https://countermetrics.stoplight.io/docs/counter-sushi-api/mgu8ibcbgrwe0-pr-p1-performance-other for details
+      ["Unique_Item_Requests", "Total_Item_Requests"]
     end
 
     def as_json(_options = {})

--- a/app/models/sushi/platform_usage_report.rb
+++ b/app/models/sushi/platform_usage_report.rb
@@ -65,7 +65,6 @@ module Sushi
 
     def performance(records)
       metric_types.each_with_object({}) do |metric_type, hash|
-        next if ['Total_Item_Investigations', 'Unique_Item_Investigations'].include?(metric_type)
         hash[metric_type] = records.each_with_object({}) do |record, inner_hash|
           inner_hash[record.year_month.strftime("%Y-%m")] = record[metric_type.downcase.to_s]
           inner_hash

--- a/app/models/sushi/platform_usage_report.rb
+++ b/app/models/sushi/platform_usage_report.rb
@@ -21,7 +21,7 @@ module Sushi
     end
 
     # the platform usage report only contains requests. see https://countermetrics.stoplight.io/docs/counter-sushi-api/mgu8ibcbgrwe0-pr-p1-performance-other for details
-    ALLOWED_METRIC_TYPES = ["Unique_Item_Requests", "Total_Item_Requests"]
+    ALLOWED_METRIC_TYPES = ["Unique_Item_Requests", "Total_Item_Requests"].freeze
 
     def as_json(_options = {})
       report_hash = {

--- a/app/models/sushi/platform_usage_report.rb
+++ b/app/models/sushi/platform_usage_report.rb
@@ -14,7 +14,7 @@ module Sushi
     def initialize(params = {}, created: Time.zone.now, account:)
       coerce_dates(params)
       coerce_data_types(params)
-      coerce_metric_types(params)
+      coerce_metric_types(params, true)
 
       @created = created
       @account = account

--- a/app/models/sushi/platform_usage_report.rb
+++ b/app/models/sushi/platform_usage_report.rb
@@ -9,17 +9,19 @@ module Sushi
     attr_reader :created, :account
     include Sushi::DateCoercion
     include Sushi::DataTypeCoercion
+    include Sushi::MetricTypeCoercion
 
     def initialize(params = {}, created: Time.zone.now, account:)
       coerce_dates(params)
       coerce_data_types(params)
+      coerce_metric_types(params)
 
       @created = created
       @account = account
     end
 
     def as_json(_options = {})
-      {
+      report_hash = {
         "Report_Header" => {
           "Release" => "5.1",
           "Report_ID" => "PR_P1",
@@ -30,12 +32,6 @@ module Sushi
           "Institution_Name" => account.institution_name,
           "Registry_Record" => "",
           "Report_Filters" => {
-            "Metric_Type" => [
-              "Searches_Platform",
-              "Total_Item_Requests",
-              "Unique_Item_Requests",
-              "Unique_Title_Requests"
-            ],
             "Begin_Date" => begin_date.iso8601,
             "End_Date" => end_date.iso8601,
             "Access_Method" => [
@@ -48,6 +44,9 @@ module Sushi
           "Attribute_Performance" => attribute_performance_for_resource_types + attribute_performance_for_platform
         }
       }
+      report_hash["Report_Header"]["Report_Filters"]["Data_Type"] = data_types if data_type_in_params
+      report_hash["Report_Header"]["Report_Filters"]["Metric_Type"] = metric_types if metric_type_in_params
+      report_hash
     end
     alias to_hash as_json
 
@@ -55,18 +54,17 @@ module Sushi
       data_for_resource_types.group_by(&:resource_type).map do |resource_type, records|
         { "Data_Type" => resource_type || "",
           "Access_Method" => "Regular",
-          "Performance" => {
-            "Total_Item_Requests" =>
-            records.each_with_object({}) do |record, hash|
-              hash[record.year_month.strftime("%Y-%m")] = record.total_item_requests
-              hash
-            end,
-            "Unique_Item_Requests" =>
-            records.each_with_object({}) do |record, hash|
-              hash[record.year_month.strftime("%Y-%m")] = record.unique_item_requests
-              hash
-            end
-          } }
+          "Performance" => performance(records) }
+      end
+    end
+
+    def performance(records)
+      metric_types.each_with_object({}) do |metric_type, hash|
+        next if (['Total_Item_Investigations', 'Unique_Item_Investigations']).include?(metric_type)
+        hash[metric_type] = records.each_with_object({}) do |record, inner_hash|
+          inner_hash[record.year_month.strftime("%Y-%m")] = record[metric_type.downcase.to_s]
+          inner_hash
+        end
       end
     end
 

--- a/spec/models/sushi/platform_usage_report_spec.rb
+++ b/spec/models/sushi/platform_usage_report_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Sushi::PlatformUsageReport do
 
     subject { described_class.new(params, created: created, account: account).as_json }
 
-
     let(:created) { Time.zone.now }
 
     context 'with only required params' do

--- a/spec/models/sushi/platform_usage_report_spec.rb
+++ b/spec/models/sushi/platform_usage_report_spec.rb
@@ -8,22 +8,45 @@ RSpec.describe Sushi::PlatformUsageReport do
 
     subject { described_class.new(params, created: created, account: account).as_json }
 
-    let(:params) do
-      {
-        attributes_to_show: ['Access_Method', 'Fake_Value'],
-        begin_date: '2022-01-03',
-        end_date: '2022-02-05'
-      }
-    end
 
     let(:created) { Time.zone.now }
 
-    it 'has the expected keys' do
-      expect(subject).to be_key('Report_Header')
-      expect(subject.dig('Report_Header', 'Created')).to eq(created.rfc3339)
-      expect(subject.dig('Report_Header', 'Report_Filters', 'Begin_Date')).to eq('2022-01-01')
-      expect(subject.dig('Report_Header', 'Report_Filters', 'End_Date')).to eq('2022-02-28')
-      expect(subject.dig('Report_Items', 'Attribute_Performance').find { |o| o["Data_Type"] == "Platform" }.dig('Performance', 'Searches_Platform', '2022-01')).to eq(6)
+    context 'with only required params' do
+      let(:params) do
+        {
+          attributes_to_show: ['Access_Method', 'Fake_Value'],
+          begin_date: '2022-01-03',
+          end_date: '2022-02-05'
+        }
+      end
+
+      it 'has the expected keys' do
+        expect(subject).to be_key('Report_Header')
+        expect(subject.dig('Report_Header', 'Created')).to eq(created.rfc3339)
+        expect(subject.dig('Report_Header', 'Report_Filters', 'Begin_Date')).to eq('2022-01-01')
+        expect(subject.dig('Report_Header', 'Report_Filters', 'End_Date')).to eq('2022-02-28')
+        expect(subject.dig('Report_Items', 'Attribute_Performance').find { |o| o["Data_Type"] == "Platform" }.dig('Performance', 'Searches_Platform', '2022-01')).to eq(6)
+      end
+    end
+
+    context 'with additional params that are not required' do
+      let(:params) do
+        {
+          begin_date: '2023-08',
+          end_date: '2023-09',
+          metric_type: 'total_item_investigations|total_item_requests|fake_value',
+          attributes_to_show: ['Access_Method', 'Fake_Value']
+        }
+      end
+
+      # Platform usage report should NOT show investigations, even if it is passed in the params.
+      it "only shows the requested metric types, and does not include metric types that aren't allowed" do
+        expect(subject.dig('Report_Header', 'Report_Filters', 'Metric_Type')).to eq(['Total_Item_Requests'])
+        expect(subject.dig('Report_Items', 'Attribute_Performance').first.dig('Performance')).to have_key('Total_Item_Requests')
+        expect(subject.dig('Report_Items', 'Attribute_Performance').first.dig('Performance')).not_to have_key('Unique_Item_Requests')
+        expect(subject.dig('Report_Items', 'Attribute_Performance').first.dig('Performance')).not_to have_key('Total_Item_Investigations')
+        expect(subject.dig('Report_Items', 'Attribute_Performance').first.dig('Performance')).not_to have_key('Unique_Item_Investigations')
+      end
     end
   end
 end


### PR DESCRIPTION
# Story
Adds the metric type filter to the platform usage report

- #687 

# Expected Behavior Before Changes
- users could not filter by metric type

# Expected Behavior After Changes
- [ ] As a user, i can add a metric_type filter to the params
- [ ] As a user, I should be able to filter by total_item_requests and unique_item_requests
- [ ] The platform usage report should only show requests  - not investigations, so if i add any investigation metric types, they should not appear in the JSON
- [ ] As a user, if i pass a random value to the metric_type filter param, nothing happens

# Screenshots / Video

<details>
<summary>JSON Structure when filtering by total_item_requests</summary>
<img width="852" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/73361970/f5ea93e1-1bce-49bc-8b30-cd0bc81d9ce3">

</details>

