### PR TITLE
Hide feature flipper for IIIF print in the UI

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -678,3 +678,9 @@ form.range_limit.range_date_ssi {
 .d-block {
   display: block;
 }
+
+// hide iiif-print feature flipper
+
+tr[data-feature="use-iiif-print"] {
+  display: none;
+}


### PR DESCRIPTION
references scientist-softserv/palni-palci#712

# Story
Hides the IIIF print feature flipper in the UI per customer request

# Expected Behavior Before Changes
IIIF Print feature flipper shows on feature page
# Expected Behavior After Changes
iiif print feature flipper is hidden in the UI

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes
