### PR TITLE
Rake task to get counter metric data on staging

### DIFF
--- a/app/services/generate_counter_metrics.rb
+++ b/app/services/generate_counter_metrics.rb
@@ -1,42 +1,36 @@
 # frozen_string_literal: true
 
-# Import counter views and downloads for a given tenant
-# Currently, this only imports the first resource type. Additional work would need to be done for works with multiple resource types.
-# The resource_type field in the counter_metrics table is single value and not an array.
+# Creates counter metrics for a single tenant.
 class GenerateCounterMetrics
-  def self.generate_counter_metrics(ids: 'all', limit: 10)
-    if ids == 'all' || ids.blank?
-      test_works = GenericWork.all.to_a.sample(limit)
+  def self.generate_counter_metrics(ids: :all, limit: :all)
+    fsq = "has_model_ssim: (#{Bulkrax.curation_concerns.join(' OR ')})"
+    fsq += " AND id:(\"" + Array.wrap(ids).join('" OR "') + "\")" if ids.present? && ids != :all
+    message = if ids == :all || ids.blank?
+                "Creating test data for #{limit} randomly selected works"
+              else
+                "Creating test data for works with ids #{ids}"
+              end
+    options = { fl: "id, has_model_ssim, resource_type_tesim", method: :post }
+    options[:rows] = limit if limit.is_a?(Numeric)
+    ActiveFedora::SolrService.query(fsq, options).each do |work|
+      work_type = work.fetch('has_model_ssim').first
+      work_id = work.fetch('id')
+      resource_type = work.fetch('resource_type_tesim').first
+      (0...90).each do |i|
+        date = i.days.ago.to_date
+        total_item_investigations = rand(1..10)
+        total_item_requests = rand(1..10)
 
-      test_works.concat(test_works.sample(limit - test_works.length)) while test_works.length < limit
-
-      message = "Creating test data for #{limit} randomly selected GenericWorks"
-    else
-      test_works = ActiveFedora::Base.where(id: ids).to_a
-      message = "Creating test data for works with ids #{ids}"
+        Hyrax::CounterMetric.create!(
+          worktype: work_type,
+          work_id: work_id,
+          resource_type: resource_type,
+          date: date,
+          total_item_investigations: total_item_investigations,
+          total_item_requests: total_item_requests
+        )
+      end
     end
     Rails.logger.info message
-    test_works.each do |work|
-      worktype = work.class
-      work_id = work.id
-      resource_type = work.resource_type.first
-      date = random_date_in_last_3_months
-      total_item_investigations = rand(1..10)
-      total_item_requests = rand(1..10)
-      Hyrax::CounterMetric.create!(
-        worktype: worktype,
-        work_id: work_id,
-        resource_type: resource_type,
-        date: date,
-        total_item_investigations: total_item_investigations,
-        total_item_requests: total_item_requests
-      )
-    end
-  end
-
-  def self.random_date_in_last_3_months
-    random_days_ago = rand(1..90) # 90 days in 3 months
-    random_date = Time.zone.today - random_days_ago
-    random_date.strftime("%Y%m%d")
   end
 end

--- a/app/services/generate_counter_metrics.rb
+++ b/app/services/generate_counter_metrics.rb
@@ -5,12 +5,19 @@
 # The resource_type field in the counter_metrics table is single value and not an array.
 class GenerateCounterMetrics
   def self.generate_counter_metrics(ids: 'all', limit: 10)
-    test_works = (ids == 'all' || ids.blank?) ?
-      GenericWork.all.to_a.sample(limit) :
-      ActiveFedora::Base.where(id: ids).to_a
-      ids.present? ?
-      (puts "Creating test data for works with ids #{ids}") :
-      (puts "Creating test data for randomly selected GenericWorks")
+    if ids == 'all' || ids.blank?
+      test_works = GenericWork.all.to_a.sample(limit)
+
+      while test_works.length < limit
+        test_works.concat(test_works.sample(limit - test_works.length))
+      end
+
+      message = "Creating test data for #{limit} randomly selected GenericWorks"
+    else
+      test_works = ActiveFedora::Base.where(id: ids).to_a
+      message = "Creating test data for works with ids #{ids}"
+    end
+    puts message
     test_works.each do |work|
       worktype = work.class
       work_id = work.id

--- a/app/services/generate_counter_metrics.rb
+++ b/app/services/generate_counter_metrics.rb
@@ -5,11 +5,6 @@ class GenerateCounterMetrics
   def self.generate_counter_metrics(ids: :all, limit: :all)
     fsq = "has_model_ssim: (#{Bulkrax.curation_concerns.join(' OR ')})"
     fsq += " AND id:(\"" + Array.wrap(ids).join('" OR "') + "\")" if ids.present? && ids != :all
-    message = if ids == :all || ids.blank?
-                "Creating test data for #{limit} randomly selected works"
-              else
-                "Creating test data for works with ids #{ids}"
-              end
     options = { fl: "id, has_model_ssim, resource_type_tesim", method: :post }
     options[:rows] = limit if limit.is_a?(Numeric)
     ActiveFedora::SolrService.query(fsq, options).each do |work|
@@ -31,6 +26,7 @@ class GenerateCounterMetrics
         )
       end
     end
+    message = "#{self.class}.generate_counter_metrics data for IDs = #{ids.inspect} with Limit = #{limit.inspect}."
     Rails.logger.info message
   end
 end

--- a/app/services/generate_counter_metrics.rb
+++ b/app/services/generate_counter_metrics.rb
@@ -8,16 +8,14 @@ class GenerateCounterMetrics
     if ids == 'all' || ids.blank?
       test_works = GenericWork.all.to_a.sample(limit)
 
-      while test_works.length < limit
-        test_works.concat(test_works.sample(limit - test_works.length))
-      end
+      test_works.concat(test_works.sample(limit - test_works.length)) while test_works.length < limit
 
       message = "Creating test data for #{limit} randomly selected GenericWorks"
     else
       test_works = ActiveFedora::Base.where(id: ids).to_a
       message = "Creating test data for works with ids #{ids}"
     end
-    puts message
+    Rails.logger.info message
     test_works.each do |work|
       worktype = work.class
       work_id = work.id
@@ -38,7 +36,7 @@ class GenerateCounterMetrics
 
   def self.random_date_in_last_3_months
     random_days_ago = rand(1..90) # 90 days in 3 months
-    random_date = Date.today - random_days_ago
+    random_date = Time.zone.today - random_days_ago
     random_date.strftime("%Y%m%d")
   end
 end

--- a/app/services/generate_counter_metrics.rb
+++ b/app/services/generate_counter_metrics.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+# Import counter views and downloads for a given tenant
+# Currently, this only imports the first resource type. Additional work would need to be done for works with multiple resource types.
+# The resource_type field in the counter_metrics table is single value and not an array.
+class GenerateCounterMetrics
+  def self.generate_counter_metrics(ids: 'all', limit: 10)
+    test_works = (ids == 'all' || ids.blank?) ?
+      GenericWork.all.to_a.sample(limit) :
+      ActiveFedora::Base.where(id: ids).to_a
+      ids.present? ?
+      (puts "Creating test data for works with ids #{ids}") :
+      (puts "Creating test data for randomly selected GenericWorks")
+    test_works.each do |work|
+      worktype = work.class
+      work_id = work.id
+      resource_type = work.resource_type.first
+      date = random_date_in_last_3_months
+      total_item_investigations = rand(1..10)
+      total_item_requests = rand(1..10)
+      Hyrax::CounterMetric.create!(
+        worktype: worktype,
+        work_id: work_id,
+        resource_type: resource_type,
+        date: date,
+        total_item_investigations: total_item_investigations,
+        total_item_requests: total_item_requests
+      )
+    end
+  end
+
+  def self.random_date_in_last_3_months
+    random_days_ago = rand(1..90) # 90 days in 3 months
+    random_date = Date.today - random_days_ago
+    random_date.strftime("%Y%m%d")
+  end
+end

--- a/lib/tasks/counter_metrics.rake
+++ b/lib/tasks/counter_metrics.rake
@@ -9,8 +9,8 @@ namespace :counter_metrics do
     ImportCounterMetrics.import_requests(args.csv_path)
   end
 
-  desc 'import historical counter investigations'
   # bundle exec rake counter_metrics:import_requests['pittir.hykucommons.org','spec/fixtures/csv/pittir-downloads.csv']
+  desc 'import historical counter investigations'
   task 'import_investigations', [:tenant_cname, :csv_path] => [:environment] do |_cmd, args|
     raise ArgumentError, 'A tenant cname is required: `rake counter_metrics:import_investigations[tenant_cname]`' if args.tenant_cname.blank?
     raise ArgumentError, "Tenant not found: #{args.tenant_cname}. Are you sure this is the correct tenant cname?" unless Account.where(cname: args.tenant_cname).first

--- a/lib/tasks/counter_metrics.rake
+++ b/lib/tasks/counter_metrics.rake
@@ -20,13 +20,16 @@ namespace :counter_metrics do
   end
 
   # You can optionally pass work IDs to have hyrax counter metrics created for specific works.
-  # Or, you can pass a limit for the number of CounterMetric entries you would like to create. currently they are randomly created for GenericWorks.
+  # Or, you can pass a limit for the number of CounterMetric entries you would like to create. currently they are randomly created.
   # Example for pitt tenant in dev without ids:
   # bundle exec rake counter_metrics:generate_staging_metrics[pitt.hyku.test]
   # Example with ids:
   # bundle exec rake "counter_metrics:generate_staging_metrics[pitt.hyku.test, ab3c1f9d-684a-4c14-93b1-75586ec05f7a|891u493hdfhiu939]"
   # Example with limit of 1:
   # bundle exec rake "counter_metrics:generate_staging_metrics[pitt.hyku.test, , 1]"
+  #
+  # NOTE: this should never be run in prod.
+  # It generates fake data, so running in prod would risk contaminating prod data.
   desc 'generate counter metric test data for staging'
   task 'generate_staging_metrics', [:tenant_cname, :ids, :limit] => [:environment] do |_cmd, args|
     raise ArgumentError, 'A tenant cname is required: `rake counter_metrics:generate_staging_metrics[tenant_cname]`' if args.tenant_cname.blank?

--- a/lib/tasks/counter_metrics.rake
+++ b/lib/tasks/counter_metrics.rake
@@ -9,13 +9,35 @@ namespace :counter_metrics do
     ImportCounterMetrics.import_requests(args.csv_path)
   end
 
-  # bundle exec rake counter_metrics:import_requests['pittir.hykucommons.org','spec/fixtures/csv/pittir-downloads.csv']
   desc 'import historical counter investigations'
+  # bundle exec rake counter_metrics:import_requests['pittir.hykucommons.org','spec/fixtures/csv/pittir-downloads.csv']
   task 'import_investigations', [:tenant_cname, :csv_path] => [:environment] do |_cmd, args|
     raise ArgumentError, 'A tenant cname is required: `rake counter_metrics:import_investigations[tenant_cname]`' if args.tenant_cname.blank?
     raise ArgumentError, "Tenant not found: #{args.tenant_cname}. Are you sure this is the correct tenant cname?" unless Account.where(cname: args.tenant_cname).first
     AccountElevator.switch!(args.tenant_cname)
     puts "Importing historical investigations for #{args.tenant_cname}"
     ImportCounterMetrics.import_investigations(args.csv_path)
+  end
+
+  # You can optionally pass work IDs to have hyrax counter metrics created for specific works.
+  # Or, you can pass a limit for the number of CounterMetric entries you would like to create. currently they are randomly created for GenericWorks.
+  # Example for pitt tenant in dev without ids:
+  # bundle exec rake counter_metrics:generate_staging_metrics[pitt.hyku.test]
+  # Example with ids:
+  # bundle exec rake counter_metrics:generate_staging_metrics[pitt.hyku.test,'ab3c1f9d-684a-4c14-93b1-75586ec05f7a']
+  # Example with limit:
+  # LIMIT=1 bundle exec rake counter_metrics:generate_staging_metrics[pitt.hyku.test]
+  desc 'generate counter metric test data for staging'
+  task 'generate_staging_metrics', [:tenant_cname, :ids] => [:environment] do |_cmd, args|
+    raise ArgumentError, 'A tenant cname is required: `rake counter_metrics:generate_staging_metrics[tenant_cname]`' if args.tenant_cname.blank?
+    raise ArgumentError, "Tenant not found: #{args.tenant_cname}. Are you sure this is the correct tenant cname?" unless Account.where(cname: args.tenant_cname).first
+    ids = args.ids.present? ? args.ids.split("|") : []
+    limit = ENV['LIMIT'].present? ? ENV['LIMIT'].to_i : 10
+    raise ArgumentError, 'The ids argument must be an array: `bundle exec rake counter_metrics:generate_staging_metrics[tenant_cname, [ids], limit]' unless (ids.is_a?(Array))
+    raise ArgumentError, 'limit argument must an integer. The default is 10' unless (limit.is_a?(Integer))
+    AccountElevator.switch!(args.tenant_cname)
+    puts "Creating test counter metric data for #{args.tenant_cname}"
+    GenerateCounterMetrics.generate_counter_metrics(ids: ids, limit: limit)
+    puts 'Test data created successfully'
   end
 end

--- a/lib/tasks/counter_metrics.rake
+++ b/lib/tasks/counter_metrics.rake
@@ -33,8 +33,8 @@ namespace :counter_metrics do
     raise ArgumentError, "Tenant not found: #{args.tenant_cname}. Are you sure this is the correct tenant cname?" unless Account.where(cname: args.tenant_cname).first
     ids = args.ids.present? ? args.ids.split("|") : []
     limit = ENV['LIMIT'].present? ? ENV['LIMIT'].to_i : 10
-    raise ArgumentError, 'The ids argument must be an array: `bundle exec rake counter_metrics:generate_staging_metrics[tenant_cname, [ids], limit]' unless (ids.is_a?(Array))
-    raise ArgumentError, 'limit argument must an integer. The default is 10' unless (limit.is_a?(Integer))
+    raise ArgumentError, 'The ids argument must be an array: `bundle exec rake counter_metrics:generate_staging_metrics[tenant_cname, [ids], limit]' unless ids.is_a?(Array)
+    raise ArgumentError, 'limit argument must an integer. The default is 10' unless limit.is_a?(Integer)
     AccountElevator.switch!(args.tenant_cname)
     puts "Creating test counter metric data for #{args.tenant_cname}"
     GenerateCounterMetrics.generate_counter_metrics(ids: ids, limit: limit)

--- a/lib/tasks/counter_metrics.rake
+++ b/lib/tasks/counter_metrics.rake
@@ -24,20 +24,18 @@ namespace :counter_metrics do
   # Example for pitt tenant in dev without ids:
   # bundle exec rake counter_metrics:generate_staging_metrics[pitt.hyku.test]
   # Example with ids:
-  # bundle exec rake counter_metrics:generate_staging_metrics[pitt.hyku.test,'ab3c1f9d-684a-4c14-93b1-75586ec05f7a']
-  # Example with limit:
-  # LIMIT=1 bundle exec rake counter_metrics:generate_staging_metrics[pitt.hyku.test]
+  # bundle exec rake "counter_metrics:generate_staging_metrics[pitt.hyku.test, ab3c1f9d-684a-4c14-93b1-75586ec05f7a|891u493hdfhiu939]"
+  # Example with limit of 1:
+  # bundle exec rake "counter_metrics:generate_staging_metrics[pitt.hyku.test, , 1]"
   desc 'generate counter metric test data for staging'
-  task 'generate_staging_metrics', [:tenant_cname, :ids] => [:environment] do |_cmd, args|
+  task 'generate_staging_metrics', [:tenant_cname, :ids, :limit] => [:environment] do |_cmd, args|
     raise ArgumentError, 'A tenant cname is required: `rake counter_metrics:generate_staging_metrics[tenant_cname]`' if args.tenant_cname.blank?
-    raise ArgumentError, "Tenant not found: #{args.tenant_cname}. Are you sure this is the correct tenant cname?" unless Account.where(cname: args.tenant_cname).first
-    ids = args.ids.present? ? args.ids.split("|") : []
-    limit = ENV['LIMIT'].present? ? ENV['LIMIT'].to_i : 10
-    raise ArgumentError, 'The ids argument must be an array: `bundle exec rake counter_metrics:generate_staging_metrics[tenant_cname, [ids], limit]' unless ids.is_a?(Array)
-    raise ArgumentError, 'limit argument must an integer. The default is 10' unless limit.is_a?(Integer)
+    kwargs = {}
+    kwargs[:ids] = args.ids.split("|") if args.ids.present?
+    kwargs[:limit] = Integer(args.limit) if args.limit.present?
     AccountElevator.switch!(args.tenant_cname)
     puts "Creating test counter metric data for #{args.tenant_cname}"
-    GenerateCounterMetrics.generate_counter_metrics(ids: ids, limit: limit)
+    GenerateCounterMetrics.generate_counter_metrics(**kwargs)
     puts 'Test data created successfully'
   end
 end

--- a/lib/tasks/counter_metrics.rake
+++ b/lib/tasks/counter_metrics.rake
@@ -23,6 +23,7 @@ namespace :counter_metrics do
   # Or, you can pass a limit for the number of CounterMetric entries you would like to create. currently they are randomly created.
   # Example for pitt tenant in dev without ids:
   # bundle exec rake counter_metrics:generate_staging_metrics[pitt.hyku.test]
+  #
   # Example with ids:
   # bundle exec rake "counter_metrics:generate_staging_metrics[pitt.hyku.test, ab3c1f9d-684a-4c14-93b1-75586ec05f7a|891u493hdfhiu939]"
   # Example with limit of 1:

--- a/lib/tasks/counter_metrics.rake
+++ b/lib/tasks/counter_metrics.rake
@@ -21,6 +21,7 @@ namespace :counter_metrics do
 
   # You can optionally pass work IDs to have hyrax counter metrics created for specific works.
   # Or, you can pass a limit for the number of CounterMetric entries you would like to create. currently they are randomly created.
+  #
   # Example for pitt tenant in dev without ids:
   # bundle exec rake counter_metrics:generate_staging_metrics[pitt.hyku.test]
   #

--- a/lib/tasks/counter_metrics.rake
+++ b/lib/tasks/counter_metrics.rake
@@ -27,6 +27,7 @@ namespace :counter_metrics do
   #
   # Example with ids:
   # bundle exec rake "counter_metrics:generate_staging_metrics[pitt.hyku.test, ab3c1f9d-684a-4c14-93b1-75586ec05f7a|891u493hdfhiu939]"
+  #
   # Example with limit of 1:
   # bundle exec rake "counter_metrics:generate_staging_metrics[pitt.hyku.test, , 1]"
   #


### PR DESCRIPTION
# Story
Sets up a rake task to get counter metric data on staging. 

# Related
- #699

# Expected Behavior Before Changes
- there was no real way to get counter metric data besides importing historical data. 

# Expected Behavior After Changes
- [ ] As a developer, I can run `bundle exec rake counter_metrics:generate_staging_metrics[tenant_cname]` to generate a random number of `Hyrax::CounterMetric`s using random existing `GenericWorks`
- [ ] As a developer, I can run `bundle exec rake counter_metrics:generate_staging_metrics[pitt.hyku.test,'work_id_1|work_id_2|work_id_3']` to add `Hyrax::CounterMetric`s for a specified list of work ids. Work IDs must be passed in a string, separated by pipes.
- [ ] As a developer, I can run `LIMIT=1 bundle exec rake counter_metrics:generate_staging_metrics[pitt.hyku.test]` to generate a single counter metric. the limit can be changed according to the number of counter metrics i would like to generate. The default is 10

# Notes
