### PR TITLE
688 access method filter

### DIFF
--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -195,6 +195,7 @@ module Sushi
     ##
     # @param params [Hash, ActionController::Parameters]
     def validate_access_method(params)
+      return true unless params.key?(:access_method)
       allowed_access_methods_from_params = Array.wrap(params[:access_method].split('|')).map { |am| am.strip.downcase } & ALLOWED_ACCESS_METHODS
 
       raise Sushi::InvalidParameterValue.invalid_access_method(params[:access_method], ALLOWED_ACCESS_METHODS) unless allowed_access_methods_from_params.any?
@@ -206,6 +207,7 @@ module Sushi
     ##
     # @param params [Hash, ActionController::Parameters]
     def validate_item_id(params)
+      return true unless params.key?(:item_id)
       raise Sushi::NotFoundError.invalid_item_id(params[:item_id]) unless Hyrax::CounterMetric.exists?(work_id: params[:item_id])
 
       @item_id = params[:item_id]
@@ -215,6 +217,7 @@ module Sushi
     ##
     # @param params [Hash, ActionController::Parameters]
     def validate_platform(params, account)
+      return true unless params.key?(:platform)
       raise Sushi::InvalidParameterValue.invalid_platform(params[:platform], account) unless params[:platform] == account.cname
 
       @platform = account.cname

--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -192,27 +192,33 @@ module Sushi
 
     ALLOWED_ACCESS_METHODS = ['regular'].freeze
 
+    ##
+    # @param params [Hash, ActionController::Parameters]
     def validate_access_method(params)
       allowed_access_methods_from_params = Array.wrap(params[:access_method].split('|')).map { |am| am.strip.downcase } & ALLOWED_ACCESS_METHODS
 
       raise Sushi::InvalidParameterValue.invalid_access_method(params[:access_method], ALLOWED_ACCESS_METHODS) unless allowed_access_methods_from_params.any?
 
       @access_methods = allowed_access_methods_from_params
-      @access_method_in_params = params.key?(:access_method)
+      @access_method_in_params = true
     end
 
+    ##
+    # @param params [Hash, ActionController::Parameters]
     def validate_item_id(params)
       raise Sushi::NotFoundError.invalid_item_id(params[:item_id]) unless Hyrax::CounterMetric.exists?(work_id: params[:item_id])
 
       @item_id = params[:item_id]
-      @item_id_in_params = params.key?(:item_id)
+      @item_id_in_params = true
     end
 
+    ##
+    # @param params [Hash, ActionController::Parameters]
     def validate_platform(params, account)
-      raise Sushi::InvalidParameterValue.invalid_platform(params[:platform], account) unless params[:platform].blank? || params[:platform] == account.cname
+      raise Sushi::InvalidParameterValue.invalid_platform(params[:platform], account) unless params[:platform] == account.cname
 
       @platform = account.cname
-      @platform_in_params = params.key?(:platform)
+      @platform_in_params = true
     end
   end
 

--- a/app/models/sushi/item_report.rb
+++ b/app/models/sushi/item_report.rb
@@ -45,9 +45,9 @@ module Sushi
 
     def validate_item_report_parameters(params:, account:)
       coerce_metric_types(params, allowed_types: ALLOWED_METRIC_TYPES)
-      validate_access_method(params) if params[:access_method]
-      validate_item_id(params) if params[:item_id]
-      validate_platform(params, account) if params[:platform]
+      validate_access_method(params) if params.key?(:access_method)
+      validate_item_id(params) if params.key?(:item_id)
+      validate_platform(params, account) if params.key?(:platform)
     end
 
     def as_json(_options = {})

--- a/app/models/sushi/item_report.rb
+++ b/app/models/sushi/item_report.rb
@@ -45,6 +45,7 @@ module Sushi
 
     def validate_item_report_parameters(params:, account:)
       coerce_metric_types(params, allowed_types: ALLOWED_METRIC_TYPES)
+      validate_access_method(params) if params[:access_method]
       validate_item_id(params) if params[:item_id]
       validate_platform(params, account) if params[:platform]
     end
@@ -73,10 +74,11 @@ module Sushi
 
       raise Sushi::NotFoundError.no_records_within_date_range if report_items.blank?
 
-      report_hash['Report_Header']['Report_Filters']['Item_ID'] = item_id if item_id_in_params
-      report_hash['Report_Header']['Report_Filters']['Platform'] = platform if platform_in_params
+      report_hash['Report_Header']['Report_Filters']['Access_Method'] = access_methods if access_method_in_params
       report_hash['Report_Header']['Report_Filters']['Data_Type'] = data_types if data_type_in_params
+      report_hash['Report_Header']['Report_Filters']['Item_ID'] = item_id if item_id_in_params
       report_hash['Report_Header']['Report_Filters']['Metric_Type'] = metric_types if metric_type_in_params
+      report_hash['Report_Header']['Report_Filters']['Platform'] = platform if platform_in_params
 
       report_hash
     end
@@ -89,6 +91,7 @@ module Sushi
           'Items' => [{
             'Attribute_Performance' => [{
               'Data_Type' => record.resource_type.titleize,
+              # We are only supporting the 'Regular' access method at this time. If that changes, we will need to update this.
               'Access_Method' => 'Regular',
               'Performance' => attribute_performance_for_resource_types(performance: record.performance)
             }],

--- a/app/models/sushi/item_report.rb
+++ b/app/models/sushi/item_report.rb
@@ -45,9 +45,9 @@ module Sushi
 
     def validate_item_report_parameters(params:, account:)
       coerce_metric_types(params, allowed_types: ALLOWED_METRIC_TYPES)
-      validate_access_method(params) if params.key?(:access_method)
-      validate_item_id(params) if params.key?(:item_id)
-      validate_platform(params, account) if params.key?(:platform)
+      validate_access_method(params)
+      validate_item_id(params)
+      validate_platform(params, account)
     end
 
     def as_json(_options = {})

--- a/spec/models/sushi/item_report_spec.rb
+++ b/spec/models/sushi/item_report_spec.rb
@@ -36,6 +36,49 @@ RSpec.describe Sushi::ItemReport do
     end
   end
 
+  describe 'with an access_method parameter' do
+    context 'that is fully valid' do
+      let(:params) do
+        {
+          **required_parameters,
+          access_method: 'regular'
+        }
+      end
+
+      it 'returns the item report' do
+        expect(subject.dig('Report_Header', 'Report_Filters', 'Access_Method')).to eq(['regular'])
+        expect(subject.dig('Report_Items', 0, 'Items', 0, 'Attribute_Performance', 0, 'Access_Method')).to eq('Regular')
+      end
+    end
+
+    context 'that is partially valid' do
+      let(:params) do
+        {
+          **required_parameters,
+          access_method: 'regular|tdm'
+        }
+      end
+
+      it 'returns the item report' do
+        expect(subject.dig('Report_Header', 'Report_Filters', 'Access_Method')).to eq(['regular'])
+        expect(subject.dig('Report_Items', 0, 'Items', 0, 'Attribute_Performance', 0, 'Access_Method')).to eq('Regular')
+      end
+    end
+
+    context 'that is invalid' do
+      let(:params) do
+        {
+          **required_parameters,
+          access_method: 'other'
+        }
+      end
+
+      it 'raises an error' do
+        expect { described_class.new(params, created: created, account: account).as_json }.to raise_error(Sushi::InvalidParameterValue)
+      end
+    end
+  end
+
   describe 'with an item_id parameter' do
     context 'that is valid' do
       context 'and metrics during the dates specified for that id' do


### PR DESCRIPTION
# Story
create validations for the `access_method` query param.

if the `access_method` query param is passed in with at least one valid option, we return the valid option(s) to
 be reflected in the `report filters` array.
if no valid options are passed through the param, we throw a `Sushi::InvalidParameterValue` error.

either way, the `access_method` that shows in the `item_report` is hard coded to say `Regular` because that's the only option we are allowing at this time. if that changes, the code in Sushi::ItemReport#report_items will need to be updated.

- #688 

# Screenshots / Video
![image](https://github.com/scientist-softserv/palni-palci/assets/29032869/1ac3d317-d935-4a9e-945e-852aea2f6fe3)

