### PR TITLE
⚙️ Reduce exceptions reported to Sentry

### DIFF
--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,31 @@
+# Sentry is valid in this case; as is Raven.  I'm configuring both of them
+#
+# The baseline sentry excluded exceptions is not the same as what all we have in Hyrax/Hyku.
+# As such, we're seeing a lot of chatter in the exceptions that we probably don't need.
+#
+# By appending the `Rails.configuration.action_dispatch.rescue_responses.keys` we're saying that
+# any "hyrax/hyku exceptions that we specifically rescue with a named response should be excluded
+# from reporting to sentry."
+#
+# The array of strings is from Rails.configuration.action_dispatch.rescue_responses.keys
+
+app_excluded_exceptions = ["ActiveRecord::RecordNotFound",
+                           "ActiveRecord::StaleObjectError",
+                           "ActiveRecord::RecordInvalid",
+                           "ActiveRecord::RecordNotSaved",
+                           "ActiveFedora::ObjectNotFoundError",
+                           "BlacklightRangeLimit::InvalidRange",
+                           "Blacklight::Exceptions::RecordNotFound",
+                           "Valkyrie::Persistence::ObjectNotFoundError",
+                           "Hyrax::ObjectNotFoundError",
+                           "Riiif::ImageNotFoundError",
+                           "I18n::InvalidLocale"]
+
+
+Sentry.init do |config|
+  config.excluded_exceptions = (config.excluded_exceptions + app_excluded_exceptions).uniq
+end
+
+Raven.configure do |config|
+  config.excluded_exceptions = (config.excluded_exceptions + app_excluded_exceptions).uniq
+end


### PR DESCRIPTION
Prior to this commit Sentry's default excluded
exceptions (e.g. `config.excluded_exceptions`) were as follows:

```ruby
["Mongoid::Errors::DocumentNotFound",
 "Rack::QueryParser::InvalidParameterError",
 "Rack::QueryParser::ParameterTypeError",
 "Sinatra::NotFound",
 "AbstractController::ActionNotFound",
 "ActionController::BadRequest",
 "ActionController::InvalidAuthenticityToken",
 "ActionController::InvalidCrossOriginRequest",
 "ActionController::MethodNotAllowed",
 "ActionController::NotImplemented",
 "ActionController::ParameterMissing",
 "ActionController::RoutingError",
 "ActionController::UnknownAction",
 "ActionController::UnknownFormat",
 "ActionDispatch::Http::MimeNegotiation::InvalidType",
 "ActionController::UnknownHttpMethod",
 "ActionDispatch::Http::Parameters::ParseError",
 "ActiveRecord::RecordNotFound"]
```

However, we also had the following exceptions as specifically handled by
the application (e.g. `Rails.configuration.action_dispatch.rescue_responses.key`):

```ruby
["ActiveRecord::RecordNotFound",
 "ActiveRecord::StaleObjectError",
 "ActiveRecord::RecordInvalid",
 "ActiveRecord::RecordNotSaved",
 "ActiveFedora::ObjectNotFoundError",
 "BlacklightRangeLimit::InvalidRange",
 "Blacklight::Exceptions::RecordNotFound",
 "Valkyrie::Persistence::ObjectNotFoundError",
 "Hyrax::ObjectNotFoundError",
 "Riiif::ImageNotFoundError",
 "I18n::InvalidLocale"]

In reviewing the Sentry logs, I'm seeing
`Blacklight::Exceptions::RecordNotFound` exceptions
`I18n::InvalidLocale`.  My hope would be that we don't see those with
this change.

This configuration comes from the `excluded_exceptions`: https://docs.sentry.io/platforms/ruby/configuration/options/?original_referrer=https%3A%2F%2Fgithub.com%2Fgetsentry%2Fsentry-ruby