### PR TITLE
🐛 Add Date to allowed permitted columns

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -78,17 +78,25 @@ module Hyku
       if Settings.bulkrax.enabled
         Bundler.require('bulkrax')
       end
-
-      config.after_initialize do
-        # Psych Allow YAML Classes
-        config.active_record.yaml_column_permitted_classes = [Symbol, Hash, Array, ActiveSupport::HashWithIndifferentAccess, ActiveModel::Attribute.const_get(:FromDatabase), User, Time]
-      end
     end
 
 
     config.autoload_paths << "#{Rails.root}/app/controllers/api"
 
     config.after_initialize do
+
+      # Psych Allow YAML Classes
+      config.active_record.yaml_column_permitted_classes = [
+        ActiveModel::Attribute.const_get(:FromDatabase),
+        ActiveSupport::HashWithIndifferentAccess,
+        Array,
+        Date,
+        Hash,
+        Symbol,
+        Time,
+        User
+      ]
+
       ##
       # The first "#valid?" service is the one that we'll use for generating derivatives.
       Hyrax::DerivativeService.services = [


### PR DESCRIPTION
This commit does two things:

1. Moves the `config.active_record.yaml_column_permitted_classes` declaration into the `config.after_initialize` (instead of having a `config.after_initialize` within a `config.to_prepare` block)
2. Adds the Date class as an allowed permitted class.

The exception that I'm seeing in Sentry is:

```
Psych::DisallowedClass
Tried to load unspecified class: Date
```

Which is happening in: `lib/omni_auth/strategies/saml_decorator.rb`

There is a remote chance that this will resolve a flakey upstream spec.

Related to:

- https://scientist-inc.sentry.io/issues/4408566671/?project=6707374&query=is%3Aunresolved&referrer=issue-stream&stream_index=5