### PR TITLE
📚 Add description to models that are abbreviations

### DIFF
--- a/app/models/cdl.rb
+++ b/app/models/cdl.rb
@@ -1,5 +1,10 @@
 # Generated via
 #  `rails generate hyrax:work Cdl`
+
+##
+# Controlled Digital Lending object.
+#
+# @see https://www.wikidata.org/wiki/Q61937323
 class Cdl < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
   include IiifPrint.model_configuration(

--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -1,5 +1,10 @@
 # Generated via
 #  `rails generate hyrax:work Etd`
+
+##
+# Electronic Thesis and Dissertation
+#
+# @see https://www.wikidata.org/wiki/Q115121540
 class Etd < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
   include IiifPrint.model_configuration(

--- a/app/models/oer.rb
+++ b/app/models/oer.rb
@@ -1,5 +1,10 @@
 # Generated via
 #  `rails generate hyrax:work Oer`
+
+##
+# Open Educational Resource
+#
+# @see https://www.wikidata.org/wiki/Q116781
 class Oer < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
   include IiifPrint.model_configuration(


### PR DESCRIPTION
The OER, CDL, and ETD models are all abbreviations.  This commit adds a human readable name to this as well as a link to the wikidata.org node that describes the resource.

This work is in part my read through of the models in an effort to find the appropriate properties for `year of publication` and `author`; both fields required for the ongoing Sushi work.

Tangentially related to:

- https://github.com/scientist-softserv/palni-palci/issues/721
- https://github.com/scientist-softserv/palni-palci/issues/720
