### PR TITLE
Ensure that Bulkrax sidebar navigation appears.

### DIFF
--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -128,4 +128,9 @@ Bulkrax.setup do |config|
 
   # Properties that should not be used in imports/exports. They are reserved for use by Hyrax.
   # config.reserved_properties += ['my_field']
+
+  # Sidebar for hyrax 3+ support
+  if Object.const_defined?(:Hyrax) && ::Hyrax::DashboardController&.respond_to?(:sidebar_partials)
+    Hyrax::DashboardController.sidebar_partials[:repository_content] << "hyrax/dashboard/sidebar/bulkrax_sidebar_additions"
+  end
 end


### PR DESCRIPTION
# Story
The view paths for the application are a bit unexpected.

- /gems/hyrax-doi-d494a50ef8ce/app/views
- /gems/bulkrax-5.3.0/app/views
- /app/samvera/hyrax-webapp/app/views
- /gems/iiif_print-eb320b1c454f/app/views
- /gems/hyrax-doi-d494a50ef8ce/app/views
- /gems/qa-5.10.0/app/views
- /gems/hyrax-ab3185d3069f/app/views
- /gems/browse-everything-1.2.0/app/views
- /gems/hydra-editor-5.0.5/app/views
- /gems/blacklight-gallery-0.12.0/app/views
- /gems/mailboxer-0.15.1/app/views
- /gems/flipflop-2.7.1/app/views
- /gems/devise_invitable-1.7.5/app/views
- /gems/devise-i18n-1.10.2/app/views
- /gems/devise-4.8.1/app/views
- /gems/bulkrax-5.3.0/app/views
- /gems/blacklight_range_limit-7.0.1/app/views
- /gems/blacklight_advanced_search-6.4.1/app/views
- /gems/blacklight-6.25.0/app/views
- /gems/kaminari-core-1.2.2/app/views

note - hyrax-doi & bulkrax are above the webapp. This means whenever we look up views, whatever is in those 2 applications will take priority.

- https://github.com/samvera-labs/hyrax-doi/blob/d494a50ef8ce3eae594c7ed7148c33b3c977d4a7/lib/hyrax/doi/engine.rb#L29-L39
- https://github.com/samvera-labs/bulkrax/blob/e1d8a4e7f80074908991907b7aeaa38ba865258d/lib/bulkrax/engine.rb#L25-L35

The code we added comes from the Bulkrax generator. See link below

https://github.com/samvera-labs/bulkrax/blob/e1d8a4e7f80074908991907b7aeaa38ba865258d/lib/generators/bulkrax/templates/config/initializers/bulkrax.rb#L82-L85
