### PR TITLE
🐛 Ensure Hyku's view_path is first in list

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -123,7 +123,6 @@ module Hyku
       #
       # - https://github.com/samvera-labs/bulkrax/pull/855
       # - https://github.com/samvera-labs/allinson_flex/pull/122
-      # - https://github.com/samvera-labs/bulkrax/pull/855
       paths = ActionController::Base.view_paths.collect(&:to_s)
       ActionController::Base.view_paths = paths.unshift(Rails.root.join("app/views").to_s).uniq
     end

--- a/config/application.rb
+++ b/config/application.rb
@@ -111,6 +111,21 @@ module Hyku
       Hyrax::Actors::FileSetActor.prepend(IiifPrint::TenantConfig::FileSetActorDecorator)
 
       Hyrax::WorkShowPresenter.prepend(IiifPrint::TenantConfig::WorkShowPresenterDecorator)
+
+      ##
+      # What the what?  There are bugs in three gems (Bulkrax, Hyrax::DOI, and AllinsonFlex) in
+      # which the application's view path is not the first in the view paths.  The result is that
+      # those upstream engines's views could be rendered instead of those views defined in the
+      # application.
+      #
+      # TODO: Remove when we're on a version of Bulkrax and Hyrax::DOI that resolves the following
+      # PRs:
+      #
+      # - https://github.com/samvera-labs/bulkrax/pull/855
+      # - https://github.com/samvera-labs/allinson_flex/pull/122
+      # - https://github.com/samvera-labs/bulkrax/pull/855
+      paths = ActionController::Base.view_paths.collect(&:to_s)
+      ActionController::Base.view_paths = paths.unshift(Rails.root.join("app/views").to_s).uniq
     end
   end
 end

--- a/spec/features/application_config_spec.rb
+++ b/spec/features/application_config_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe "Application Configuration" do
+  describe 'ApplicationController#view_paths' do
+    subject(:view_paths) { ApplicationController.view_paths.map(&:to_s) }
+
+    it { is_expected.to be_a Array }
+
+    describe 'first element' do
+      subject { view_paths.first }
+
+      it { is_expected.to eq(Rails.root.join("app", "views").to_s) }
+    end
+  end
+end


### PR DESCRIPTION
Prior to this commit, and with three engines (e.g. Bulkrax, Hyrax::DOI,
and AllinsonFlex), we had a situation in which the first view path may
not have been the application.  The consequence being that the view
lookup would potentially behave in unexpected ways.

Below is the commit message on the patches submitted for the three
engines.  The message further details the problem:

> Prior to this commit, the logic for finding the Hyrax in the view path
> was assuming a version number (e.g. `hyrax-2.`); however if the we
> pinned Hyrax to a branch/sha then we might have `hyrax-a`.  The result
> being that we pre-prended the view path into the application.  That
> created the conditions where the `view_paths` first element might not
> have been the application but instead a gem/engine.
>
> Which means that the convention of overriding views in the application
> would not work.
>
> With this commit, we're using the Hyrax's engine's root to determine
> the view path suffix.  Further, if Hyrax is not in the view path, we
> don't again inject at the beginning of the list the Bulkrax engine
> into the view path.

Related to:

- https://github.com/scientist-softserv/palni-palci/pull/731
- https://github.com/samvera-labs/bulkrax/pull/855
- https://github.com/samvera-labs/allinson_flex/pull/122
- https://github.com/samvera-labs/bulkrax/pull/855