### PR TITLE
remove alerts from status report

### DIFF
--- a/app/models/sushi/server_status.rb
+++ b/app/models/sushi/server_status.rb
@@ -14,13 +14,7 @@ module Sushi
         {
           "Description" => "COUNTER Usage Reports for #{account.cname} platform.",
           "Service_Active" => true,
-          "Registry_Record" => "",
-          "Alerts" => [
-            {
-              "Date_Time" => "",
-              "Alert" => ""
-            }
-          ]
+          "Registry_Record" => ""
         }
       ]
     end

--- a/spec/models/sushi/server_status_spec.rb
+++ b/spec/models/sushi/server_status_spec.rb
@@ -15,17 +15,12 @@ RSpec.describe Sushi::ServerStatus do
       expect(subject.first).to have_key('Description')
       expect(subject.first).to have_key('Service_Active')
       expect(subject.first).to have_key('Registry_Record')
-      expect(subject.first).to have_key('Alerts')
-      expect(subject.dig(0, 'Alerts', 0)).to have_key('Date_Time')
-      expect(subject.dig(0, 'Alerts', 0)).to have_key('Alert')
     end
 
     it 'returns the expected values' do
       expect(subject.first['Description']).to eq("COUNTER Usage Reports for #{account.cname} platform.")
       expect(subject.first['Service_Active']).to eq(true)
       expect(subject.first['Registry_Record']).to eq("")
-      expect(subject.dig(0, 'Alerts', 0, 'Date_Time')).to eq("")
-      expect(subject.dig(0, 'Alerts', 0, 'Alert')).to eq("")
     end
   end
 end


### PR DESCRIPTION
# Story

Refs #653 

Client feedback is to remove the alerts section from the status report

# Expected Behavior Before Changes
An empty alert was part of the status report
# Expected Behavior After Changes
The alert section is removed from the status report
# Screenshots / Video

<details>

<img width="680" alt="Screenshot 2023-08-22 at 4 49 00 PM" src="https://github.com/scientist-softserv/palni-palci/assets/18175797/e3669120-469c-4924-a8fc-7310220a2767">




</details>

# Notes
