### PR TITLE
🎁 Adding year_of_publication filter to Sushi report

### DIFF
--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -26,6 +26,10 @@ module Sushi
       def invalid_access_method(access_method, acceptable_params)
         new("None of the given values in `access_method=#{access_method}` are supported at this time. Please use an acceptable value, (#{acceptable_params.join(', ')}) instead. (Or do not pass the parameter at all, which will default to the acceptable value(s))")
       end
+
+      def invalid_yop(yop)
+        new("The given parameter `yop=#{yop}` was malformed.  You can provide a range (e.g. 'YYYY-YYYY') or a single date (e.g. 'YYYY').  You can separate ranges/values with a '|'.")
+      end
     end
     # rubocop:enable Metrics/LineLength
   end
@@ -239,6 +243,56 @@ module Sushi
     def coerce_granularity(params = {})
       @granularity_in_params = ALLOWED_GRANULARITY.include?(params[:granularity].to_s.capitalize)
       @granularity = params.fetch(:granularity, "Month").capitalize
+    end
+  end
+
+  module YearOfPublicationCoercion
+    extend ActiveSupport::Concern
+    included do
+      attr_reader :yop_as_where_parameters, :yop_in_params
+    end
+
+    DATE_RANGE_REGEXP = /^(\d+)\s*-\s*(\d+)$/
+
+    ##
+    # Convert the given params to parameters suitable for {ActiveRecord::Base.where} calls.
+    #
+    # @param params [Hash]
+    # @option params [String] :yop the named parameter from which we'll extract integers.
+    #
+    # @return [Array<String,Integer>] when all of the parts are valid, we'll have an array with the
+    #         first element being a string (that has position "?"s for SQL query building) and the
+    #         remaining elements being integers.
+    # @raise [ArgumentError] when part of the given YOP could not be coerced to an integer.
+    #
+    # @note No special consideration is made for date ranges that start with a later date and end with
+    #       an earlier date (e.g. "1999-1994" will be "date >= 1999 AND date <= 1994"; which will
+    #       return no entries.)
+    def coerce_yop(params = {})
+      return unless params.key?(:yop)
+
+      # TODO: We might want to quote the column name and add the table name as well; this helps with
+      #       any potential field name collisions while we assemble the SQL statement.
+      field_name = 'year_of_publication'
+      where_clauses = []
+      where_values = []
+
+      params[:yop].split(/\s*\|\s*/).flat_map do |slug|
+        slug = slug.strip
+        match = DATE_RANGE_REGEXP.match(slug)
+        if match
+          where_clauses << "(#{field_name} >= ? AND #{field_name} <= ?)"
+          where_values << Integer(match[1])
+          where_values << Integer(match[2])
+        else
+          where_clauses << "(#{field_name} = ?)"
+          where_values << Integer(slug)
+        end
+      end
+
+      @yop_as_where_parameters = ["(#{where_clauses.join(' OR ')})"] + where_values
+    rescue ArgumentError
+      raise Sushi::InvalidParameterValue.invalid_yop(params.fetch(:yop))
     end
   end
 end

--- a/spec/models/sushi/item_report_spec.rb
+++ b/spec/models/sushi/item_report_spec.rb
@@ -79,6 +79,15 @@ RSpec.describe Sushi::ItemReport do
     end
   end
 
+  describe 'with a yop parameter' do
+    let(:params) { { yop: "2022", begin_date: '2022-01-03', end_date: '2022-12-31' } }
+
+    # NOTE: We're already bombarding the yop coercion; this is ensuring that the SQL is valid.
+    it 'filters based on that value' do
+      expect(subject).to be_a(Hash)
+    end
+  end
+
   describe 'with an item_id parameter' do
     context 'that is valid' do
       context 'and metrics during the dates specified for that id' do

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -34,6 +34,7 @@ def create_hyrax_countermetric_objects
     resource_type: 'Book',
     work_id: '12345',
     date: '2022-01-05',
+    year_of_publication: 2022,
     total_item_investigations: 1,
     total_item_requests: 10
   )
@@ -42,6 +43,7 @@ def create_hyrax_countermetric_objects
     resource_type: 'Book',
     work_id: '54321',
     date: '2022-01-05',
+    year_of_publication: 2022,
     total_item_investigations: 3,
     total_item_requests: 5
   )
@@ -51,6 +53,7 @@ def create_hyrax_countermetric_objects
     resource_type: 'Book',
     work_id: '54321',
     date: '2022-01-06',
+    year_of_publication: 2022,
     total_item_investigations: 2,
     total_item_requests: 4
   )
@@ -59,6 +62,7 @@ def create_hyrax_countermetric_objects
     resource_type: 'Article',
     work_id: '98765',
     date: '2023-08-09',
+    year_of_publication: 1999,
     total_item_investigations: 2,
     total_item_requests: 8
   )
@@ -67,6 +71,7 @@ def create_hyrax_countermetric_objects
     resource_type: 'Article',
     work_id: '99999',
     date: '2023-08-09',
+    year_of_publication: 1997,
     total_item_investigations: 4,
     total_item_requests: 3
   )


### PR DESCRIPTION
Before this commit, we were not handling the `:yop` query parameter.

With this commit, we're parsing the given `:yop` to build the date range
query over the `Hyrax::CounterMetric#year_of_publication` field.

Related to:

- https://github.com/scientist-softserv/palni-palci/issues/720
- https://github.com/scientist-softserv/palni-palci/issues/688