### PR TITLE
721 author filter

### DIFF
--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -30,6 +30,10 @@ module Sushi
       def invalid_yop(yop)
         new("The given parameter `yop=#{yop}` was malformed.  You can provide a range (e.g. 'YYYY-YYYY') or a single date (e.g. 'YYYY').  You can separate ranges/values with a '|'.")
       end
+
+      def invalid_author(author)
+        new("The given parameter `author=#{author}` was malformed. Please provide a value in 'Last,First' format, each being 2+ characters. (e.g. 'Tubman,Harriet')")
+      end
     end
     # rubocop:enable Metrics/LineLength
   end
@@ -209,17 +213,6 @@ module Sushi
     end
 
     ##
-    # # @param params [Hash, ActionController::Parameters]
-    # def validate_author(params)
-    #   # TODO
-    #   return true unless params.key?(:author) &&
-    #   # raise Sushi::InvalidParameterValue.invalid_author(params[:author]) unless
-
-    #   # @authors =
-    #   @author_in_params = true
-    # end
-
-    ##
     # @param params [Hash, ActionController::Parameters]
     def validate_item_id(params)
       return true unless params.key?(:item_id)
@@ -263,10 +256,22 @@ module Sushi
       attr_reader :author, :author_in_params
     end
 
-    def coerce_authors(params = {})
-      # author should be a string greater than 2 characters
-      @author_in_params = params[:author] && params[:author].length > 2
-      @author = params.fetch(:author, '')
+    AUTHOR_REGEXP = /^[a-zA-Z]{2,}+,[a-zA-Z]{2,}$/
+
+    ##
+    # Ensure the given param is in the correct Last,First format.
+    #
+    # @param params [Hash, ActionController::Parameters]
+    # @option params [String] :author the named parameter from which we'll extract the author.
+    #
+    # @note: Last and First must each be at least 2 characters long.
+    def coerce_author(params = {})
+      return true unless params.key?(:author)
+      match = AUTHOR_REGEXP.match(params[:author])
+      raise Sushi::InvalidParameterValue.invalid_author(params[:author]) unless match
+
+      @author = params[:author]
+      @author_in_params = true
     end
   end
 

--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -32,7 +32,7 @@ module Sushi
       end
 
       def invalid_author(author)
-        new("The given parameter `author=#{author}` was malformed. Please provide a value in 'Last,First' format, each being 2+ characters. (e.g. 'Tubman,Harriet')")
+        new("The given parameter `author=#{author}` was malformed. Please provide the first author's name exactly as it appears on the work.")
       end
     end
     # rubocop:enable Metrics/LineLength
@@ -256,19 +256,16 @@ module Sushi
       attr_reader :author, :author_in_params
     end
 
-    AUTHOR_REGEXP = /^[a-zA-Z]{2,}+,[a-zA-Z]{2,}$/
-
     ##
-    # Ensure the given param is in the correct Last,First format.
+    # Ensure the given param is valid.
     #
     # @param params [Hash, ActionController::Parameters]
-    # @option params [String] :author the named parameter from which we'll extract the author.
+    # @option params [String] :author the named parameter we'll use to filter the report items by.
     #
-    # @note: Last and First must each be at least 2 characters long.
+    # @note: The sushi spec states that this value must be >=2 characters. We're only enforcing that the value exactly matches whatever data we have in the database. Which presumably is >=2 characters, but may not be.
     def coerce_author(params = {})
       return true unless params.key?(:author)
-      match = AUTHOR_REGEXP.match(params[:author])
-      raise Sushi::InvalidParameterValue.invalid_author(params[:author]) unless match
+      raise Sushi::InvalidParameterValue.invalid_author(params[:author]) unless Hyrax::CounterMetric.exists?(author: params[:author])
 
       @author = params[:author]
       @author_in_params = true

--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -206,6 +206,17 @@ module Sushi
 
     ##
     # @param params [Hash, ActionController::Parameters]
+    def validate_author(params)
+      # TODO
+      return true unless params.key?(:author)
+      # raise Sushi::InvalidParameterValue.invalid_author(params[:author]) unless
+
+      # @authors =
+      @author_in_params = true
+    end
+
+    ##
+    # @param params [Hash, ActionController::Parameters]
     def validate_item_id(params)
       return true unless params.key?(:item_id)
       raise Sushi::NotFoundError.invalid_item_id(params[:item_id]) unless Hyrax::CounterMetric.exists?(work_id: params[:item_id])

--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -205,15 +205,15 @@ module Sushi
     end
 
     ##
-    # @param params [Hash, ActionController::Parameters]
-    def validate_author(params)
-      # TODO
-      return true unless params.key?(:author)
-      # raise Sushi::InvalidParameterValue.invalid_author(params[:author]) unless
+    # # @param params [Hash, ActionController::Parameters]
+    # def validate_author(params)
+    #   # TODO
+    #   return true unless params.key?(:author) &&
+    #   # raise Sushi::InvalidParameterValue.invalid_author(params[:author]) unless
 
-      # @authors =
-      @author_in_params = true
-    end
+    #   # @authors =
+    #   @author_in_params = true
+    # end
 
     ##
     # @param params [Hash, ActionController::Parameters]
@@ -250,6 +250,19 @@ module Sushi
     def coerce_granularity(params = {})
       @granularity_in_params = ALLOWED_GRANULARITY.include?(params[:granularity].to_s.capitalize)
       @granularity = params.fetch(:granularity, "Month").capitalize
+    end
+  end
+
+  module AuthorCoercion
+    extend ActiveSupport::Concern
+    included do
+      attr_reader :author, :author_in_params
+    end
+
+    def coerce_authors(params = {})
+      # author should be a string greater than 2 characters
+      @author_in_params = params[:author] && params[:author].length > 2
+      @author = params.fetch(:author, '')
     end
   end
 end

--- a/app/models/sushi/item_report.rb
+++ b/app/models/sushi/item_report.rb
@@ -7,10 +7,11 @@
 # any provided end_date will be moved to the end of the month
 module Sushi
   class ItemReport
-    attr_reader :account, :attributes_to_show, :created, :data_types
+    attr_reader :account, :attributes_to_show, :created
     include Sushi::DateCoercion
     include Sushi::DataTypeCoercion
     include Sushi::MetricTypeCoercion
+    include Sushi::AuthorCoercion
     include Sushi::QueryParameterValidation
     ALLOWED_REPORT_ATTRIBUTES_TO_SHOW = [
       'Access_Method',
@@ -34,6 +35,7 @@ module Sushi
     def initialize(params = {}, created: Time.zone.now, account:)
       coerce_dates(params)
       coerce_data_types(params)
+      coerce_authors(params)
       validate_item_report_parameters(params: params, account: account)
       @account = account
       @created = created
@@ -46,7 +48,7 @@ module Sushi
     def validate_item_report_parameters(params:, account:)
       coerce_metric_types(params, allowed_types: ALLOWED_METRIC_TYPES)
       validate_access_method(params)
-      validate_author(params)
+      # validate_author(params)
       validate_item_id(params)
       validate_platform(params, account)
     end
@@ -61,7 +63,8 @@ module Sushi
           'Institution_ID' => account.institution_id_data,
           'Report_Filters' => {
             'Begin_Date' => begin_date.iso8601,
-            'End_Date' => end_date.iso8601
+            'End_Date' => end_date.iso8601,
+            "Author" => author,
           },
           'Created' => created.rfc3339, # '2023-02-15T09:11:12Z'
           'Created_By' => account.institution_name,

--- a/app/models/sushi/item_report.rb
+++ b/app/models/sushi/item_report.rb
@@ -145,6 +145,7 @@ module Sushi
                  .group(:work_id, :resource_type, :worktype)
 
       relation = relation.where("(?) = work_id", item_id) if item_id
+      relation = relation.where("(?) = author", author) if author
       relation = relation.where(yop_as_where_parameters) if yop_as_where_parameters.present?
       return relation if data_types.blank?
 

--- a/app/models/sushi/item_report.rb
+++ b/app/models/sushi/item_report.rb
@@ -148,9 +148,9 @@ module Sushi
       relation = relation.where("(?) = work_id", item_id) if item_id
       relation = relation.where("(?) = author", author) if author
       relation = relation.where(yop_as_where_parameters) if yop_as_where_parameters.present?
-      return relation if data_types.blank?
+      relation = relation.where("LOWER(resource_type) IN (?)", data_types) if data_types.any?
 
-      relation.where("LOWER(resource_type) IN (?)", data_types)
+      relation
     end
   end
 end

--- a/app/models/sushi/item_report.rb
+++ b/app/models/sushi/item_report.rb
@@ -46,6 +46,7 @@ module Sushi
     def validate_item_report_parameters(params:, account:)
       coerce_metric_types(params, allowed_types: ALLOWED_METRIC_TYPES)
       validate_access_method(params)
+      validate_author(params)
       validate_item_id(params)
       validate_platform(params, account)
     end

--- a/app/models/sushi/item_report.rb
+++ b/app/models/sushi/item_report.rb
@@ -101,6 +101,7 @@ module Sushi
               'Access_Method' => 'Regular',
               'Performance' => attribute_performance_for_resource_types(performance: record.performance)
             }],
+            'Authors' => [{ 'Name:' => record.author }],
             'Item' => record.work_id.to_s,
             'Publisher' => '',
             'Platform' => account.cname,
@@ -126,7 +127,7 @@ module Sushi
 
     def data_for_resource_types
       relation = Hyrax::CounterMetric
-                 .select(:work_id, :resource_type, :worktype,
+                 .select(:work_id, :resource_type, :worktype, :author,
                          %((SELECT To_json(Array_agg(Row_to_json(t)))
                            FROM
                            (SELECT
@@ -142,7 +143,7 @@ module Sushi
     	               GROUP BY date_trunc('month', date)) t) as performance))
                  .where("date >= ? AND date <= ?", begin_date, end_date)
                  .order(resource_type: :asc, work_id: :asc)
-                 .group(:work_id, :resource_type, :worktype)
+                 .group(:work_id, :resource_type, :worktype, :author)
 
       relation = relation.where("(?) = work_id", item_id) if item_id
       relation = relation.where("(?) = author", author) if author

--- a/app/models/sushi/item_report.rb
+++ b/app/models/sushi/item_report.rb
@@ -37,7 +37,7 @@ module Sushi
     def initialize(params = {}, created: Time.zone.now, account:)
       coerce_dates(params)
       coerce_data_types(params)
-      coerce_authors(params)
+      coerce_author(params)
       coerce_yop(params)
       validate_item_report_parameters(params: params, account: account)
       @account = account
@@ -51,7 +51,6 @@ module Sushi
     def validate_item_report_parameters(params:, account:)
       coerce_metric_types(params, allowed_types: ALLOWED_METRIC_TYPES)
       validate_access_method(params)
-      # validate_author(params)
       validate_item_id(params)
       validate_platform(params, account)
     end
@@ -67,7 +66,6 @@ module Sushi
           'Report_Filters' => {
             'Begin_Date' => begin_date.iso8601,
             'End_Date' => end_date.iso8601,
-            "Author" => author,
           },
           'Created' => created.rfc3339, # '2023-02-15T09:11:12Z'
           'Created_By' => account.institution_name,
@@ -82,6 +80,7 @@ module Sushi
       raise Sushi::NotFoundError.no_records_within_date_range if report_items.blank?
 
       report_hash['Report_Header']['Report_Filters']['Access_Method'] = access_methods if access_method_in_params
+      report_hash['Report_Header']['Report_Filters']['Author'] = author if author_in_params
       report_hash['Report_Header']['Report_Filters']['Data_Type'] = data_types if data_type_in_params
       report_hash['Report_Header']['Report_Filters']['Item_ID'] = item_id if item_id_in_params
       report_hash['Report_Header']['Report_Filters']['Metric_Type'] = metric_types if metric_type_in_params


### PR DESCRIPTION
# Story
allow the report to be filtered by the `author` query param. it must match exactly what is in the `Hyrax::CounterMetric` table.

``` bash
Hyrax::CounterMetric.first.author = 'Hamilton, Carol V.'

/api/sushi/r51/reports/ir?author=Hamilton, Carol V.
```

Refs #issuenumber

# Expected Behavior Before Changes

# Expected Behavior After Changes

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes
