### PR TITLE
🎁 Add AuthN/AuthZ for CDL assets

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -103,11 +103,18 @@ class ApplicationController < ActionController::Base
     end
 
     ##
+    # Provides the prepare_for_conditional_work_authorization! (see #authenticate_if_needed)
+    include WorkAuthorization::StoreUrlForScope
+
+    ##
     # Extra authentication for palni-palci during development phase
     def authenticate_if_needed
       # Disable this extra authentication in test mode
       return true if Rails.env.test?
       if (is_hidden || is_staging) && !is_api_or_pdf
+        # Why capture this?  In my review of the params and scope for authorization, I had a blank
+        # value in some of the OmniAuth instantiations.
+        prepare_for_conditional_work_authorization!(request.original_url)
         authenticate_or_request_with_http_basic do |username, password|
           username == "pals" && password == "pals"
         end

--- a/app/controllers/devise_decorator.rb
+++ b/app/controllers/devise_decorator.rb
@@ -1,0 +1,18 @@
+##
+# OVERRIDE
+# This decorator splices into Devise to set the store URL for potential WorkAuthorization.
+module DeviseSessionDecorator
+  ##
+  # OVERRIDE
+  #
+  # @see OmniAuth::Strategies::OpenIDConnectDecorator#requested_work_url
+  # @see # https://github.com/scientist-softserv/palni-palci/issues/633
+  def new
+    prepare_for_conditional_work_authorization!
+
+    super
+  end
+end
+
+Devise::SessionsController.prepend(WorkAuthorization::StoreUrlForScope)
+Devise::SessionsController.prepend(DeviseSessionDecorator)

--- a/app/controllers/single_signon_controller.rb
+++ b/app/controllers/single_signon_controller.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 class SingleSignonController < DeviseController
+  include WorkAuthorization::StoreUrlForScope
+
   def index
+    prepare_for_conditional_work_authorization!
     @identity_providers = IdentityProvider.all
     render && return unless @identity_providers.count.zero?
     redirect_to main_app.new_user_session_path

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -23,14 +23,9 @@ module Users
 
         # We need to render a loading page here just to set the sesion properly
         # otherwise the logged in session gets lost during the redirect
-        if params[:action] == 'saml'
-          set_flash_message(:notice, :success, kind: params[:action]) if is_navigational_format?
-          sign_in @user, event: :authentication # this will throw if @user is not activated
-          render 'complete'
-        else
-          sign_in_and_redirect @user, event: :authentication # this will throw if @user is not activated
-          set_flash_message(:notice, :success, kind: params[:action]) if is_navigational_format?
-        end
+        set_flash_message(:notice, :success, kind: params[:action]) if is_navigational_format?
+        sign_in @user, event: :authentication # this will throw if @user is not activated
+        render 'complete'
       else
         session['devise.user_attributes'] = @user.attributes
         redirect_to new_user_registration_url

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -5,11 +5,22 @@ module Users
     skip_before_action :verify_authenticity_token
 
     def callback
-      logger.info("========== auth: #{request.env['omniauth.auth']}")
+      logger.info("=@=@=@=@  auth: #{request.env['omniauth.auth']}, params: #{params.inspect}")
 
       @user = User.from_omniauth(request.env['omniauth.auth'])
 
       if @user.persisted?
+        # https://github.com/scientist-softserv/palni-palci/issues/633
+        WorkAuthorization.handle_signin_for!(user: @user, scope: params[:scope])
+
+        # By default the sign_in_and_redirect method will look for a stored_location_for.  However,
+        # we're seeing that the stored location seems to get lost.  So we'll rely on the presence of
+        # the scope to handle this.
+        #
+        # Related to OmniAuth::Strategies::OpenIDConnectDecorator
+        url = WorkAuthorization.url_from(scope: params[:scope], request: request)
+        store_location_for(:user, url) if url
+
         # We need to render a loading page here just to set the sesion properly
         # otherwise the logged in session gets lost during the redirect
         if params[:action] == 'saml'

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -21,11 +21,14 @@ module Users
         url = WorkAuthorization.url_from(scope: params[:scope], request: request)
         store_location_for(:user, url) if url
 
-        # We need to render a loading page here just to set the sesion properly
+        # We need to render a loading page here just to set the session properly
         # otherwise the logged in session gets lost during the redirect
         set_flash_message(:notice, :success, kind: params[:action]) if is_navigational_format?
         sign_in @user, event: :authentication # this will throw if @user is not activated
-        render 'complete'
+
+        # Given that we need to render the "complete" page, we need to inform that page about
+        # where we want a JS-based redirect to go.
+        render 'complete', locals: { redirect_to_url: url || hyrax.dashboard_path }
       else
         session['devise.user_attributes'] = @user.attributes
         redirect_to new_user_registration_url

--- a/app/models/work_authorization.rb
+++ b/app/models/work_authorization.rb
@@ -164,6 +164,7 @@ class WorkAuthorization < ActiveRecord::Base # rubocop:disable ApplicationRecord
     #
     # @param given_url [String,NilClass] when given, favor this URL instead of attempting to find
     #        the stored location.
+    # rubocop:disable Style/GuardClause
     def prepare_for_conditional_work_authorization!(given_url = nil)
       if given_url.nil?
         # Note: Accessing `stored_location_for` clears that location from the session; so we need to
@@ -182,11 +183,8 @@ class WorkAuthorization < ActiveRecord::Base # rubocop:disable ApplicationRecord
         url = request.env['rack.url_scheme'] + '://' + File.join(request.host_with_port, url) if url.start_with?('/')
         Rails.logger.info("=@=@=@=@ Called #{self.class}##{__method__} to set session['#{WorkAuthorization::StoreUrlForScope::CDL_SESSION_KEY}'] to #{url.inspect}.")
         session[WorkAuthorization::StoreUrlForScope::CDL_SESSION_KEY] = url
-      else
-        # Rails.logger.info("Called #{self.class}##{__method__} with stored location of #{url.inspect}; which is not matching as a work URL.")
-        # We don't have work URL, let's obliterate this.
-        # session.delete(WorkAuthorization::StoreUrlForScope::CDL_SESSION_KEY)
       end
     end
+    # rubocop:enable Style/GuardClause
   end
 end

--- a/app/models/work_authorization.rb
+++ b/app/models/work_authorization.rb
@@ -24,13 +24,25 @@ class WorkAuthorization < ActiveRecord::Base # rubocop:disable ApplicationRecord
   validates :work_pid, presence: true
 
   ##
+  # When a :user signs in, we want to re-authorize works that are part of their latest
+  # authentication.  We want to de-authorize access to any works that are not part of their recent
+  # authentication.
+  #
   # @param user [User]
   # @param authorize_until [Time] authorize the given work_pid(s) until this point in time.
   # @param revoke_expirations_before [Time] expire all authorizations that have expires_at less than or equal to this parameter.
   # @param work_pid [String, Array<String>]
-  def self.handle_signin_for!(user:, authorize_until: 1.day.from_now, work_pid: nil, revoke_expirations_before: Time.zone.now)
+  # @param scope [String] the OpenID scope string that might include additional works to authorize.
+  #
+  # @see OmniAuth::Strategies::OpenIDConnectDecorator
+  # @see .extract_pids_from
+  def self.handle_signin_for!(user:, authorize_until: 1.day.from_now, work_pid: nil, scope: nil, revoke_expirations_before: Time.zone.now)
+    Rails.logger.info("#{self.class}.#{__method__} granting authorization to work_pid: #{work_pid.inspect} and scope: #{scope.inspect}.")
+
+    pids = Array.wrap(work_pid) + extract_pids_from(scope: scope)
+
     # Maybe we get multiple pids; let's handle that accordingly
-    Array.wrap(work_pid).each do |pid|
+    pids.each do |pid|
       begin
         authorize!(user: user, work_pid: pid, expires_at: authorize_until)
       rescue WorkNotFoundError
@@ -38,10 +50,51 @@ class WorkAuthorization < ActiveRecord::Base # rubocop:disable ApplicationRecord
       end
     end
 
-    # We re-authorized the above work_pid, so it should not be in this query.
+    # We re-authorized the above pids, so it should not be in this query.
     where("user_id = :user_id AND expires_at <= :expires_at", user_id: user.id, expires_at: revoke_expirations_before).pluck(:work_pid).each do |pid|
       revoke!(user: user, work_pid: pid)
     end
+  end
+
+  ##
+  # A regular expression that identifies the :work_pid for Hyrax work.
+  #
+  # @see .extract_pids_from
+  REGEXP_TO_MATCH_PID = %r{/concern/(?<work_type>[^\/]+)/(?<work_pid>[^\?]+)(?<query_param>\?.*)?}
+
+  ##
+  # Extract the URL for a CDL object based on the given OAuth scope.
+  #
+  # @param scope [String]
+  # @param request [ActionDispatch::Request, #env, #host_with_port]
+  #
+  # @return [NilClass] when the scope does not include a work.
+  # @return [String] the URL of the provided scope.
+  def self.url_from(scope:, request:, with_regexp: REGEXP_TO_MATCH_PID)
+    return nil unless scope
+
+    scope.split(/\s+/).map do |scope_element|
+      next unless with_regexp.match(scope_element)
+      scope_element = request.env['rack.url_scheme'] + '://' + File.join(request.host_with_port, scope_element) if scope_element.start_with?("/")
+
+      scope_element
+    end.compact.first
+  end
+
+  ##
+  # From the given :scope string extract an array of potential work_ids.
+  #
+  # @param scope [String]
+  # @param with_regexp [Regexp]
+  #
+  # @return [Array<String>] work pid(s) that we found in the given :scope.
+  def self.extract_pids_from(scope:, with_regexp: REGEXP_TO_MATCH_PID)
+    return [] if scope.blank?
+
+    scope.split(/\s+/).map do |scope_element|
+      match = with_regexp.match(scope_element)
+      match[:work_pid] if match
+    end.compact
   end
 
   ##
@@ -91,4 +144,49 @@ class WorkAuthorization < ActiveRecord::Base # rubocop:disable ApplicationRecord
     end
   end
   # rubocop:enable Rails/FindBy
+
+  ##
+  # This module is a controller mixin that assumes access to a `session` object.
+  #
+  # Via {#prepare_for_conditional_work_authorization!} provide the logic for storing a URL to later
+  # be available in an authorization request.
+  #
+  # @example
+  #   class ApplicationController < ActionController::Base
+  #     include WorkAuthorization::StoreUrlForScope
+  #   end
+  module StoreUrlForScope
+    CDL_SESSION_KEY = 'cdl.requested_work_url'
+
+    ##
+    # Responsible for storing in the session the URL that is a candidate for Controlled Digital
+    # Lending (CDL) authorization.
+    #
+    # @param given_url [String,NilClass] when given, favor this URL instead of attempting to find
+    #        the stored location.
+    def prepare_for_conditional_work_authorization!(given_url = nil)
+      if given_url.nil?
+        # Note: Accessing `stored_location_for` clears that location from the session; so we need to
+        # grab it and then set it again.
+        url = stored_location_for(:user)
+        store_location_for(:user, url)
+      else
+        url = given_url
+      end
+
+      # If this could be a controlled digital lending (CDL) work, let's not rely on the
+      # stored_location (e.g. something that is part of devise and the value being subject to change).
+      # Instead, let's set the OmniAuth::Strategies::OpenIDConnectDecorator::CDL_SESSION_KEY key in
+      # the session.
+      if WorkAuthorization::REGEXP_TO_MATCH_PID.match(url)
+        url = request.env['rack.url_scheme'] + '://' + File.join(request.host_with_port,url) if url.start_with?('/')
+        Rails.logger.info("=@=@=@=@ Called #{self.class}##{__method__} to set session['#{WorkAuthorization::StoreUrlForScope::CDL_SESSION_KEY}'] to #{url.inspect}.")
+        session[WorkAuthorization::StoreUrlForScope::CDL_SESSION_KEY] = url
+      else
+        # Rails.logger.info("Called #{self.class}##{__method__} with stored location of #{url.inspect}; which is not matching as a work URL.")
+        # We don't have work URL, let's obliterate this.
+        # session.delete(WorkAuthorization::StoreUrlForScope::CDL_SESSION_KEY)
+      end
+    end
+  end
 end

--- a/app/models/work_authorization.rb
+++ b/app/models/work_authorization.rb
@@ -179,7 +179,7 @@ class WorkAuthorization < ActiveRecord::Base # rubocop:disable ApplicationRecord
       # Instead, let's set the OmniAuth::Strategies::OpenIDConnectDecorator::CDL_SESSION_KEY key in
       # the session.
       if WorkAuthorization::REGEXP_TO_MATCH_PID.match(url)
-        url = request.env['rack.url_scheme'] + '://' + File.join(request.host_with_port,url) if url.start_with?('/')
+        url = request.env['rack.url_scheme'] + '://' + File.join(request.host_with_port, url) if url.start_with?('/')
         Rails.logger.info("=@=@=@=@ Called #{self.class}##{__method__} to set session['#{WorkAuthorization::StoreUrlForScope::CDL_SESSION_KEY}'] to #{url.inspect}.")
         session[WorkAuthorization::StoreUrlForScope::CDL_SESSION_KEY] = url
       else

--- a/app/views/devise/omniauth_callbacks/complete.html.erb
+++ b/app/views/devise/omniauth_callbacks/complete.html.erb
@@ -3,7 +3,7 @@
 <script>
   Blacklight.onLoad(function() {
     window.setTimeout(function(){
-      window.location.href =  "<%= hyrax.dashboard_path %>"
+      window.location.href =  "<%= redirect_to_url %>"
     }, 1000)
   })
 </script>

--- a/app/views/hyrax/base/unauthorized.html.erb
+++ b/app/views/hyrax/base/unauthorized.html.erb
@@ -1,0 +1,8 @@
+<h1><%= t('.unauthorized') %></h1>
+<% if respond_to?(:curation_concern) && curation_concern %>
+  <p><%= t('.is_private', type: curation_concern.human_readable_type.downcase ) %><p>
+  <p><%= t('.id', id: curation_concern.id) %>
+<% else %>
+  <p><%= t('.page_is_private') %><p>
+  <p>You may need to <%= link_to "re-authorize to access this resource", '#' %>.<p>
+<% end %>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -330,3 +330,7 @@ Devise.setup do |config|
   # so you need to do it manually. For the users scope, it would be:
   # config.omniauth_path_prefix = '/my_engine/users/auth'
 end
+
+OmniAuth.config do |c|
+  c.logger = Rails.logger
+end

--- a/lib/omni_auth/strategies/open_id_connect_decorator.rb
+++ b/lib/omni_auth/strategies/open_id_connect_decorator.rb
@@ -1,0 +1,55 @@
+module OmniAuth
+  module Strategies
+    ##
+    # OVERRIDE to provide openid {#scope} based on the current session.
+    #
+    # @see https://github.com/scientist-softserv/palni-palci/issues/633
+    module OpenIDConnectDecorator
+      ##
+      # In OmniAuth, the options are a tenant wide configuration.  However, per
+      # the client's controlled digitial lending (CDL) system, in the options we
+      # use for authentication we must inclue the URL of the work that the
+      # authenticating user wants to access.
+      #
+      # @note In testing, when the scope did not include the sample noted in the
+      #       {#requested_work_url} method, the openid provider would return the
+      #       status 200 (e.g. Success) and a body "Failed to get response from
+      #       patron API"
+      #
+      # @return [Hash<Symbol,Object>]
+      def options
+        # If we don't include this, we keep adding to the `options[:scope]`
+        return @decorated_options if defined? @decorated_options
+
+        opts = super
+
+        url = requested_work_url
+        opts[:scope] += [url] if url.present? && !opts[:scope].include?(url)
+
+        Rails.logger.info("=@=@=@=@ #{self.class}#options scope value is #{opts[:scope].inspect}")
+
+        @decorated_options = opts
+      end
+
+      ##
+      # @return [String] The URL of the work that was requested by the
+      #         authenticating user.
+      #
+      # @note {#session} method is `@env['rack.session']`
+      # @note {#env} method is the hash representation of the Rack environment.
+      # @note {#request} method is the {#env} as a Rack::Request object
+      #
+      # @note The following URL is known to be acceptable for the reshare.commons-archive.org tenant:
+      #
+      #       https://reshare.palni-palci-staging.notch8.cloud/concern/cdls/74ebfc53-ee7c-4dc9-9dd7-693e4d840745
+      def requested_work_url
+        Rails.logger.info("=@=@=@=@ #{self.class}#session['#{WorkAuthorization::StoreUrlForScope::CDL_SESSION_KEY}'] is #{session[WorkAuthorization::StoreUrlForScope::CDL_SESSION_KEY].inspect}")
+        Rails.logger.info("=@=@=@=@ #{self.class}#params['scope'] is #{params['scope'].inspect}")
+        session[WorkAuthorization::StoreUrlForScope::CDL_SESSION_KEY] ||
+          WorkAuthorization.url_from(scope: params['scope'])
+      end
+    end
+  end
+end
+
+OmniAuth::Strategies::OpenIDConnect.prepend(OmniAuth::Strategies::OpenIDConnectDecorator)

--- a/lib/omni_auth/strategies/open_id_connect_decorator.rb
+++ b/lib/omni_auth/strategies/open_id_connect_decorator.rb
@@ -5,6 +5,43 @@ module OmniAuth
     #
     # @see https://github.com/scientist-softserv/palni-palci/issues/633
     module OpenIDConnectDecorator
+
+      ##
+      # override callback phase to fix issue where state is not required.
+      # if require_state is false, it doesn't matter what is in the state param
+      def callback_phase
+        error = params['error_reason'] || params['error']
+        error_description = params['error_description'] || params['error_reason']
+        invalid_state = false unless options.require_state
+        invalid_state = true if invalid_state.nil? && params['state'].to_s.empty?
+        invalid_state = params['state'] != stored_state if invalid_state.nil?
+
+        raise OmniAuth::Strategies::OpenIDConnect::CallbackError, error: params['error'], reason: error_description, uri: params['error_uri'] if error
+        raise OmniAuth::Strategies::OpenIDConnect::CallbackError, error: :csrf_detected, reason: "Invalid 'state' parameter" if invalid_state
+
+        return unless valid_response_type?
+
+        options.issuer = issuer if options.issuer.nil? || options.issuer.empty?
+
+        verify_id_token!(params['id_token']) if configured_response_type == 'id_token'
+        discover!
+        client.redirect_uri = redirect_uri
+
+        return id_token_callback_phase if configured_response_type == 'id_token'
+
+        client.authorization_code = authorization_code
+        access_token
+        super
+      rescue OmniAuth::Strategies::OpenIDConnect::CallbackError => e
+        fail!(e.error, e)
+      rescue ::Rack::OAuth2::Client::Error => e
+        fail!(e.response[:error], e)
+      rescue ::Timeout::Error, ::Errno::ETIMEDOUT => e
+        fail!(:timeout, e)
+      rescue ::SocketError => e
+        fail!(:failed_to_connect, e)
+      end
+
       ##
       # In OmniAuth, the options are a tenant wide configuration.  However, per
       # the client's controlled digitial lending (CDL) system, in the options we
@@ -43,7 +80,8 @@ module OmniAuth
       #
       #       https://reshare.palni-palci-staging.notch8.cloud/concern/cdls/74ebfc53-ee7c-4dc9-9dd7-693e4d840745
       def requested_work_url
-        Rails.logger.info("=@=@=@=@ #{self.class}#session['#{WorkAuthorization::StoreUrlForScope::CDL_SESSION_KEY}'] is #{session[WorkAuthorization::StoreUrlForScope::CDL_SESSION_KEY].inspect}")
+        cdl_key = WorkAuthorization::StoreUrlForScope::CDL_SESSION_KEY
+        Rails.logger.info("=@=@=@=@ #{self.class}#session['#{cdl_key}'] is #{session[cdl_key].inspect}")
         Rails.logger.info("=@=@=@=@ #{self.class}#params['scope'] is #{params['scope'].inspect}")
         session[WorkAuthorization::StoreUrlForScope::CDL_SESSION_KEY] ||
           WorkAuthorization.url_from(scope: params['scope'])

--- a/lib/omni_auth/strategies/open_id_connect_decorator.rb
+++ b/lib/omni_auth/strategies/open_id_connect_decorator.rb
@@ -5,7 +5,6 @@ module OmniAuth
     #
     # @see https://github.com/scientist-softserv/palni-palci/issues/633
     module OpenIDConnectDecorator
-
       ##
       # override callback phase to fix issue where state is not required.
       # if require_state is false, it doesn't matter what is in the state param
@@ -21,7 +20,7 @@ module OmniAuth
 
         return unless valid_response_type?
 
-        options.issuer = issuer if options.issuer.nil? || options.issuer.empty?
+        options.issuer = issuer if options.issuer.blank?
 
         verify_id_token!(params['id_token']) if configured_response_type == 'id_token'
         discover!
@@ -84,7 +83,7 @@ module OmniAuth
         Rails.logger.info("=@=@=@=@ #{self.class}#session['#{cdl_key}'] is #{session[cdl_key].inspect}")
         Rails.logger.info("=@=@=@=@ #{self.class}#params['scope'] is #{params['scope'].inspect}")
         session[WorkAuthorization::StoreUrlForScope::CDL_SESSION_KEY] ||
-          WorkAuthorization.url_from(scope: params['scope'])
+          WorkAuthorization.url_from(scope: params['scope'], request: request)
       end
     end
   end

--- a/spec/models/work_authorization_spec.rb
+++ b/spec/models/work_authorization_spec.rb
@@ -26,9 +26,10 @@ RSpec.describe WorkAuthorization, type: :model do
     end
   end
 
+  # rubocop:disable Metrics/LineLength
   describe '.url_from' do
-
     subject { described_class.url_from(scope: given_test_scope, request: request) }
+
     let(:request) { double(ActionDispatch::Request, env: { 'rack.url_scheme' => "http" }, host_with_port: "pals.hyku.test") }
 
     [
@@ -39,10 +40,12 @@ RSpec.describe WorkAuthorization, type: :model do
     ].each do |given_scope, expected_value|
       context "with #{given_scope.inspect}" do
         let(:given_test_scope) { given_scope }
+
         it { is_expected.to eq(expected_value) }
       end
     end
   end
+  # rubocop:enable Metrics/LineLength
 
   describe '.handle_signin_for!' do
     context 'when given a work_pid and a scope' do

--- a/spec/omni_auth/strategies/open_id_connect_decorator_spec.rb
+++ b/spec/omni_auth/strategies/open_id_connect_decorator_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# rubocop:disable RSpec/MultipleDescribes
+RSpec.describe OmniAuth::Strategies::OpenIDConnectDecorator do
+  let(:strategy) do
+    Class.new do
+      def initialize(options: {}, session: {})
+        @options = options
+        @session = session
+      end
+      attr_reader :options, :session
+
+      # Include this after the attr_reader :options to leverage super method
+      prepend OmniAuth::Strategies::OpenIDConnectDecorator
+    end
+  end
+
+  let(:requested_work_url) { "https://hello.world/something-special" }
+  let(:options) { { scope: [:openid] } }
+  let(:session) { { "cdl.requested_work_url" => requested_work_url } }
+  let(:instance) { strategy.new(options: options, session: session) }
+
+  describe '#options' do
+    subject { instance.options }
+
+    it "has a :scope key that appends the #requested_work_url" do
+      expect(subject.fetch(:scope)).to match_array([:openid, requested_work_url])
+    end
+  end
+
+  describe '#requested_work_url' do
+    subject { instance.requested_work_url }
+
+    it "fetches the 'cdl.requested_work_url' session" do
+      expect(subject).to eq(requested_work_url)
+    end
+
+    describe "when the 'cdl.requested_work_url' key is missing" do
+      let(:session) { {} }
+
+      it { is_expected.to be_nil }
+    end
+  end
+end
+
+RSpec.describe OmniAuth::Strategies::OpenIDConnect do
+  describe '#options method' do
+    subject(:options_method) { described_class.instance_method(:options) }
+
+    context 'source_location' do
+      subject { options_method.source_location }
+
+      it { is_expected.to match_array([Rails.root.join('lib', 'omni_auth', 'strategies', 'open_id_connect_decorator.rb').to_s, Integer]) }
+    end
+
+    context 'super_method' do
+      subject { options_method.super_method }
+
+      it { is_expected.not_to be_nil }
+    end
+  end
+end
+# rubocop:enable RSpec/MultipleDescribes

--- a/spec/omni_auth/strategies/open_id_connect_decorator_spec.rb
+++ b/spec/omni_auth/strategies/open_id_connect_decorator_spec.rb
@@ -44,9 +44,11 @@ RSpec.describe OmniAuth::Strategies::OpenIDConnectDecorator do
 
     describe "when the 'cdl.requested_work_url' key is missing" do
       let(:session) { {} }
+
       context "when request does not include scope" do
         it { is_expected.to be_nil }
       end
+
       context "when request includes a scope" do
         let(:params) { { 'scope' => requested_work_url } }
 


### PR DESCRIPTION
## 🎁 Add AuthN/AuthZ for CDL assets

58a5728d34193c6521258f1f6537a4bc701f315c

Prior to this commit, we had not wired in the logic for authorization to
controlled digital lending (CDL) assets.  With this change, we're adding
the logic for handling a user authenticating to access a work.

The logic flow is as follows:

An unauthenticated user goes to a CDL asset page.  They are neither
authorized nor authenticated, so we direct them to the new session
route.  There we capture we're the URL of the requested resource and
send them on their way to authenticate.

When we perform the handshake with OpenID, we provide (as scope and
client design decision) the URL of the CDL asset.  The OpenID provider
authenticates and returns to the OmniAuth callback.  We use the returned
scope to then grant authorization to the CDL asset (and revoke any
expired authorizations).

And once they login for the CDL asset, we redirect to that asset.

Related to:

- https://github.com/scientist-softserv/palni-palci/issues/633
- https://github.com/scientist-softserv/palni-palci/pull/647

## handle csrf issue with openid state. use the redirect pattern all the time since its hapazard which sso vendors need it

f39e0d38831dd216cef6872d94d81aabff3b20a7


## ♻️ Appease rubocop and fix parameter mismatch

0ed1777ab2a8c504c67798541db6372e81732076


## Appease rubocop

663ae641e3e5d08c3c08a5eaf5bf5ad3e867d23f


## ♻️ Specify redirect URL for CDL SSO

6de21f6021be6db66fc41efc4f4cf0b8cfaccf37

Prior to this commit, we rendered a page that used JS to change the
window's location.

With this commit, we pass to the rendered page the URL we want to use
for redirection.

## 🎁 Ensure non-admin user friendly routing for SSO

6c9a3eda0506cc073239d2613d04822d4bbde46b

We are trying to serve two types of users:

- Admins
- Not-admins

Given that admins are a small subset, we can train and document how they
can sign in.  In other words, favor workflows that impact the less
trained folk to help them accomplish their tasks.

Prior to this commit, given the site had an SSO provider, when I (an
unauthenticated user) went to a private work, then it would redirect me
to the `/user/sign_in` route.

At that route I had the following option:

1. Providing a username and password
2. Selecting one of the SSO providers to use for sign-in.

The problem with this behavior was that a user who was given a
Controlled Digital Lending (CDL) URL would see a username/password and
likely attempt to authenticate with their CDL username/password (which
was managed by the SSO provider).

The end result is that the authentication page most likely would create
confusion.

With this commit, I'm setting things up such that when the application
uses calls `new_user_session_path` we make a decision on what URL to
resolve.

Related to:

- https://github.com/scientist-softserv/palni-palci/pull/766
- https://github.com/scientist-softserv/palni-palci/pull/647
- https://github.com/scientist-softserv/palni-palci/issues/633

## 🐛 Ensure proper order for URL in scope

199268feae2fe979eeddec1206ca39b486021a7e

