### PR TITLE
🐛 Add YOP to Report_Header > Report_Filters when provided

### DIFF
--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -307,7 +307,7 @@ module Sushi
   module YearOfPublicationCoercion
     extend ActiveSupport::Concern
     included do
-      attr_reader :yop_as_where_parameters, :yop_in_params
+      attr_reader :yop_as_where_parameters, :yop
     end
 
     DATE_RANGE_REGEXP = /^(\d+)\s*-\s*(\d+)$/
@@ -347,7 +347,7 @@ module Sushi
           where_values << Integer(slug)
         end
       end
-
+      @yop = params[:yop]
       @yop_as_where_parameters = ["(#{where_clauses.join(' OR ')})"] + where_values
     rescue ArgumentError
       raise Sushi::InvalidParameterValue.invalid_yop(params.fetch(:yop))

--- a/app/models/sushi/item_report.rb
+++ b/app/models/sushi/item_report.rb
@@ -84,6 +84,7 @@ module Sushi
       report_hash['Report_Header']['Report_Filters']['Item_ID'] = item_id if item_id_in_params
       report_hash['Report_Header']['Report_Filters']['Metric_Type'] = metric_types if metric_type_in_params
       report_hash['Report_Header']['Report_Filters']['Platform'] = platform if platform_in_params
+      report_hash['Report_Header']['Report_Filters']['YOP'] = yop if yop
 
       report_hash
     end

--- a/spec/models/sushi/item_report_spec.rb
+++ b/spec/models/sushi/item_report_spec.rb
@@ -34,6 +34,27 @@ RSpec.describe Sushi::ItemReport do
       expect(subject.dig('Report_Items', 0, 'Items', 0, 'Attribute_Performance', 0, 'Performance', 'Unique_Item_Investigations', '2023-08')).to eq(1)
       expect(subject.dig('Report_Items', 2, 'Items', 0, 'Attribute_Performance', 0, 'Performance', 'Unique_Item_Investigations', '2022-01')).to eq(1)
     end
+
+    describe 'yop parameter' do
+      context 'when provided' do
+        let(:params) do
+          {
+            **required_parameters,
+            yop: '1900-2023'
+          }
+        end
+
+        it 'has a Report_Header > Report_Filters > YOP property' do
+          expect(subject.dig("Report_Header", "Report_Filters", "YOP")).to eq('1900-2023')
+        end
+      end
+
+      context 'when not provided' do
+        it 'does not have a Report_Header > Report_Filters > YOP property' do
+          expect(subject.dig("Report_Header", "Report_Filters")).not_to have_key("YOP")
+        end
+      end
+    end
   end
 
   describe 'with an access_method parameter' do

--- a/spec/models/sushi_spec.rb
+++ b/spec/models/sushi_spec.rb
@@ -182,6 +182,7 @@ RSpec.describe Sushi do
         let(:params) { { yop: given_yop } }
 
         if expected.is_a?(Array)
+          its(:yop) { is_expected.to eq(given_yop) }
           its(:yop_as_where_parameters) { is_expected.to match_array(expected) }
         else
           it "raises an #{expected}" do


### PR DESCRIPTION
Prior to this commit, when given a YOP we were not providing that value
as part of the response document.

With this commit, when we're provided a YOP, we include that as part of
the "Report_Header > Report_Filters".

Related to:

- https://github.com/scientist-softserv/palni-palci/issues/720
- https://github.com/scientist-softserv/palni-palci/issues/687