### PR TITLE
🎁 Add multiple author handling to Sushi report

### DIFF
--- a/app/models/sushi/item_report.rb
+++ b/app/models/sushi/item_report.rb
@@ -101,7 +101,7 @@ module Sushi
               'Access_Method' => 'Regular',
               'Performance' => performance(record)
             }],
-            'Authors' => [{ 'Name:' => record.author }],
+            'Authors' => Sushi::AuthorCoercion.deserialize(record.author).map { |author| { 'Name:' => author } },
             'Item' => record.work_id.to_s,
             'Publisher' => '',
             'Platform' => account.cname,
@@ -143,7 +143,7 @@ module Sushi
                  .group(:work_id, :resource_type, :worktype, :author)
 
       relation = relation.where("(?) = work_id", item_id) if item_id
-      relation = relation.where("(?) = author", author) if author
+      relation = relation.where(author_as_where_parameters) if author.present?
       relation = relation.where(yop_as_where_parameters) if yop_as_where_parameters.present?
       relation = relation.where("LOWER(resource_type) IN (?)", data_types) if data_types.any?
 

--- a/app/services/import_counter_metrics.rb
+++ b/app/services/import_counter_metrics.rb
@@ -14,7 +14,7 @@ class ImportCounterMetrics
       resource_type = work.resource_type&.first
       date = row['datestamp']
       year_of_publication = work.date
-      author = work.creator&.first
+      author = Sushi::AuthorCoercion.serialize(work.creator)
       publisher = work.publisher&.first
       title = work.title&.first
       total_item_investigations = row['count']
@@ -56,7 +56,7 @@ class ImportCounterMetrics
       resource_type = work.resource_type.first
       date = row['datestamp']
       year_of_publication = work.date
-      author = work.creator&.first
+      author = Sushi::AuthorCoercion.serialize(work.creator)
       publisher = work.publisher&.first
       title = work.title&.first
       total_item_requests = row['count']

--- a/spec/models/sushi_spec.rb
+++ b/spec/models/sushi_spec.rb
@@ -143,6 +143,42 @@ RSpec.describe Sushi do
     end
   end
 
+  describe "AuthorCoercion" do
+    describe '.deserialize' do
+      subject { Sushi::AuthorCoercion.deserialize(string) }
+
+      [
+        ["|Hello|World|", ["Hello", "World"]],
+        ["|Hello|", ["Hello"]],
+        ["||", []],
+        ["", []],
+        [nil, []]
+      ].each do |given_authors, expected_array|
+        context "with #{given_authors.inspect}" do
+          let(:string) { given_authors }
+
+          it { is_expected.to match_array(expected_array) }
+        end
+      end
+    end
+
+    describe '.serialize' do
+      subject { Sushi::AuthorCoercion.serialize(array) }
+
+      [
+        [["Hello", "World"], "|Hello|World|"],
+        [["Hello"], "|Hello|"],
+        [[], nil]
+      ].each do |given_authors, expected|
+        context "with #{given_authors.inspect}" do
+          let(:array) { given_authors }
+
+          it { is_expected.to eq(expected) }
+        end
+      end
+    end
+  end
+
   describe "YearOfPublicationCoercion" do
     subject(:instance) { klass.new(params) }
 

--- a/spec/support/helpers.rb
+++ b/spec/support/helpers.rb
@@ -34,7 +34,7 @@ def create_hyrax_countermetric_objects
     resource_type: 'Book',
     work_id: '12345',
     date: '2022-01-05',
-    author: 'Tubman, Harriet',
+    author: '|Tubman, Harriet|',
     year_of_publication: 2022,
     total_item_investigations: 1,
     total_item_requests: 10
@@ -44,7 +44,7 @@ def create_hyrax_countermetric_objects
     resource_type: 'Book',
     work_id: '54321',
     date: '2022-01-05',
-    author: 'X, Malcolm',
+    author: '|X, Malcolm|',
     year_of_publication: 2022,
     total_item_investigations: 3,
     total_item_requests: 5
@@ -55,7 +55,7 @@ def create_hyrax_countermetric_objects
     resource_type: 'Book',
     work_id: '54321',
     date: '2022-01-06',
-    author: 'X, Malcolm',
+    author: '|X, Malcolm|',
     year_of_publication: 2022,
     total_item_investigations: 2,
     total_item_requests: 4
@@ -65,7 +65,7 @@ def create_hyrax_countermetric_objects
     resource_type: 'Article',
     work_id: '98765',
     date: '2023-08-09',
-    author: 'Washington, Booker T.',
+    author: '|Washington, Booker T.|',
     year_of_publication: 1999,
     total_item_investigations: 2,
     total_item_requests: 8
@@ -75,7 +75,7 @@ def create_hyrax_countermetric_objects
     resource_type: 'Article',
     work_id: '99999',
     date: '2023-08-09',
-    author: 'Douglas, Frederick',
+    author: '|Douglas, Frederick|',
     year_of_publication: 1997,
     total_item_investigations: 4,
     total_item_requests: 3


### PR DESCRIPTION
Prior to this commit, we made the short-cut assumption that each work would have one author.

With this commit, we now serialize authors in the `author` field and then query accordingly.  The query is setup to be backwards compatible with already imported data.

Related to:

- https://github.com/scientist-softserv/palni-palci/issues/721