### PR TITLE
:gift: Enable snippet highlighting for search

### DIFF
--- a/app/assets/stylesheets/hyrax.scss
+++ b/app/assets/stylesheets/hyrax.scss
@@ -20,3 +20,9 @@
 @import "blacklight_gallery/osd_viewer";
 
 @import "themes/*";
+
+// for catalog search result snippets
+.highlight {
+  background: yellow;
+  font-weight: 700;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -56,13 +56,13 @@ class ApplicationController < ActionController::Base
       snippets = options[:value]
       # rubocop:disable Rails/OutputSafety
       snippets_content = [ActionController::Base.helpers.content_tag('div',
-                                                                      "... #{snippets.first} ...".html_safe,
-                                                                      class: 'ocr_snippet first_snippet')]
+                                                                     "... #{snippets.first} ...".html_safe,
+                                                                     class: 'ocr_snippet first_snippet')]
       # rubocop:enable Rails/OutputSafety
       if snippets.length > 1
         snippets_content << render(partial: 'catalog/snippets_more',
-                                    locals: { snippets: snippets.drop(1),
-                                              options: options })
+                                   locals: { snippets: snippets.drop(1),
+                                             options: options })
       end
       # rubocop:disable Rails/OutputSafety
       snippets_content.join("\n").html_safe

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -63,7 +63,12 @@ class CatalogController < ApplicationController
     config.default_solr_params = {
       qt: "search",
       rows: 10,
-      qf: "admin_note_tesim title_tesim alternative_title_tesim description_tesim creator_tesim contributor_tesim related_url_tesim learning_resource_type_tesim education_level_tesim audience_tesim degree_name_tesim degree_discipline_tesim degree_grantor_tesim date_tesim table_of_contents_tesim rights_statement_tesim license_tesim rights_holder_tesim additional_information_tesim oer_size_tesim publisher_tesim identifier_tesim keyword_tesim subject_tesim language_tesim resource_type_tesim date_created_tesim date_uploaded_tesim date_modified_tesim accessibility_feature_tesim accessibility_hazard_tesim accessibility_summary_tesim format_tesim extent_tesim all_text_timv"
+      qf: "admin_note_tesim title_tesim alternative_title_tesim description_tesim creator_tesim contributor_tesim related_url_tesim learning_resource_type_tesim education_level_tesim audience_tesim degree_name_tesim degree_discipline_tesim degree_grantor_tesim date_tesim table_of_contents_tesim rights_statement_tesim license_tesim rights_holder_tesim additional_information_tesim oer_size_tesim publisher_tesim identifier_tesim keyword_tesim subject_tesim language_tesim resource_type_tesim date_created_tesim date_uploaded_tesim date_modified_tesim accessibility_feature_tesim accessibility_hazard_tesim accessibility_summary_tesim format_tesim extent_tesim all_text_timv",
+      "hl": true,
+      "hl.simple.pre": "<span class='highlight'>",
+      "hl.simple.post": "</span>",
+      "hl.snippets": 30,
+      "hl.fragsize": 100
     }
 
     # Specify which field to use in the tag cloud on the homepage.

--- a/app/indexers/app_indexer.rb
+++ b/app/indexers/app_indexer.rb
@@ -15,9 +15,15 @@ class AppIndexer < Hyrax::WorkIndexer
       solr_doc['title_ssi'] = SortTitle.new(object.title.first).alphabetical
       solr_doc['bulkrax_identifier_tesim'] = object.bulkrax_identifier
       solr_doc['account_cname_tesim'] = Site.instance&.account&.cname
-      solr_doc['all_text_tsimv'] = SolrDocument.find(object.file_sets.first.id)['all_text_tsimv']
+      solr_doc['all_text_tsimv'] = full_text(object.file_sets.first&.id)
       add_date(solr_doc)
     end
+  end
+
+  def full_text(file_set_id)
+    return if file_set_id.blank?
+
+    SolrDocument.find(file_set_id)['all_text_tsimv']
   end
 
   def add_date(solr_doc)

--- a/app/indexers/app_indexer.rb
+++ b/app/indexers/app_indexer.rb
@@ -15,6 +15,7 @@ class AppIndexer < Hyrax::WorkIndexer
       solr_doc['title_ssi'] = SortTitle.new(object.title.first).alphabetical
       solr_doc['bulkrax_identifier_tesim'] = object.bulkrax_identifier
       solr_doc['account_cname_tesim'] = Site.instance&.account&.cname
+      solr_doc['all_text_tsimv'] = SolrDocument.find(object.file_sets.first.id)['all_text_tsimv']
       add_date(solr_doc)
     end
   end


### PR DESCRIPTION
In this PR we are indexing the pdf text onto the parent record, adding a highlight to the matching search results and displaying the snippet in the search catalog. An index will be required when we deploy to the various environments. 

# Story

Refs #772 

# Expected Behavior Before Changes

Search results were not displaying as a highlight on the search catalog page. 

# Expected Behavior After Changes

![Screenshot 2023-09-11 at 3 39 55 PM](https://github.com/scientist-softserv/palni-palci/assets/10081604/443822ff-f51b-4a8d-896c-1c1b07fc610c)

