### PR TITLE
🐛 Account for IIIF Print logic

### DIFF
--- a/app/indexers/app_indexer.rb
+++ b/app/indexers/app_indexer.rb
@@ -21,7 +21,7 @@ class AppIndexer < Hyrax::WorkIndexer
   end
 
   def full_text(file_set_id)
-    return if file_set_id.blank?
+    return if !Flipflop.default_pdf_viewer? || file_set_id.blank?
 
     SolrDocument.find(file_set_id)['all_text_tsimv']
   end


### PR DESCRIPTION
This commit will guard the work indexing with a Flipflop check so we don't get stuck at the AttachFilesToWorkJob.

# Story

Refs #772 

# Expected Behavior Before Changes

If an admin switched to UV which uses IIIF Print logic, the works never get completely created.

# Expected Behavior After Changes

The works complete.
