### PR TITLE
🧹 Reorder advanced search fields

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -209,6 +209,12 @@ class CatalogController < ApplicationController
 
     # list of all the search_fields that will use the default configuration below.
     search_fields_without_customization = [
+      { name: 'title', label: 'Title' },
+      { name: 'creator', label: 'Creator' },
+      { name: 'date_created', label: 'Date or Date Created' },
+      { name: 'keyword', label: 'Keyword' },
+      { name: 'license', label: 'License' },
+      { name: 'subject', label: 'Subject' },
       { name: 'abstract', label: 'Abstract' },
       { name: 'advisor', label: 'Advisor' },
       { name: 'accessibility_feature', label: 'Accessibility Feature' },
@@ -220,8 +226,6 @@ class CatalogController < ApplicationController
       { name: 'bibliographic_citation', label: 'Bibliographic Citation' },
       { name: 'committee_member', label: 'Committee Member' },
       { name: 'contributor', label: 'Contributor' },
-      { name: 'creator', label: 'Creator' },
-      { name: 'date_created', label: 'Date or Date Created' },
       { name: 'department', label: 'Department' },
       { name: 'depositor', label: 'Depositor' },
       { name: 'description', label: 'Description' },
@@ -230,11 +234,9 @@ class CatalogController < ApplicationController
       { name: 'extent', label: 'Extent' },
       { name: 'degree_grantor', label: 'Grantor' },
       { name: 'identifier', label: 'Identifier' },
-      { name: 'keyword', label: 'Keyword' },
       { name: 'language', label: 'Language' },
       { name: 'learning_resource_type', label: 'Learning Resource Type' },
       { name: 'degree_level', label: 'Level' },
-      { name: 'license', label: 'License' },
       { name: 'publisher', label: 'Publisher' },
       { name: 'related_url', label: 'Related URL' },
       { name: 'rights_holder', label: 'Rights Holder' },
@@ -242,9 +244,7 @@ class CatalogController < ApplicationController
       { name: 'rights_statement', label: 'Rights or Rights Statement' },
       { name: 'size', label: 'Size' },
       { name: 'source', label: 'Source' },
-      { name: 'subject', label: 'Subject' },
       { name: 'table_of_contents', label: 'Table of Contents' },
-      { name: 'title', label: 'Title' },
       { name: 'resource_type', label: 'Type or Resource Type' }
     ]
 

--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -419,5 +419,13 @@ module Blacklight
     def document_link_params(_doc, opts)
       opts.except(:label, :counter)
     end
+
+    def primary_search_fields
+      search_fields_for_advanced_search.each_with_index.partition { |_, idx| idx < 6 }.first.map(&:first)
+    end
+
+    def secondary_search_fields
+      search_fields_for_advanced_search.each_with_index.partition { |_, idx| idx < 6 }.last.map(&:first)
+    end
   end
 end

--- a/app/views/advanced/_advanced_search_fields.html.erb
+++ b/app/views/advanced/_advanced_search_fields.html.erb
@@ -1,0 +1,8 @@
+<%- search_fields_for_advanced_search.each do |key, field_def| -%>
+  <div class="form-group advanced-search-field">
+      <%= label_tag key, "#{field_def.label }", :class => "col-sm-3 control-label" %>
+      <div class="col-sm-9">
+        <%= text_field_tag key, label_tag_default_for(key), :class => 'form-control' %>
+      </div>
+  </div>
+<%- end -%>

--- a/app/views/advanced/_advanced_search_fields.html.erb
+++ b/app/views/advanced/_advanced_search_fields.html.erb
@@ -1,4 +1,10 @@
-<%- search_fields_for_advanced_search.each do |key, field_def| -%>
+<%
+  # OVERRIDE blacklight_advanced_search v6.4.1 to split the first six fields
+  # See: CatalogController#search_fields_without_customization=
+  # See: Blacklight::BlacklightHelperBehavior#primary_search_fields, #secondary_search_fields
+  # Also using Bootstrap 3 classes to make the form resemble the Hyrax form behaviors
+%>
+<%- primary_search_fields.each do |key, field_def| -%>
   <div class="form-group advanced-search-field">
       <%= label_tag key, "#{field_def.label }", :class => "col-sm-3 control-label" %>
       <div class="col-sm-9">
@@ -6,3 +12,16 @@
       </div>
   </div>
 <%- end -%>
+
+<a class="btn btn-default additional-fields collapsed" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="additionalFieldsDiv" href="#additionalFieldsDiv">Additional fields</a>
+
+<div id="additionalFieldsDiv" class="collapse" aria-expanded="false">
+  <%- secondary_search_fields.each do |key, field_def| -%>
+    <div class="form-group advanced-search-field">
+        <%= label_tag key, "#{field_def.label }", :class => "col-sm-3 control-label" %>
+        <div class="col-sm-9">
+          <%= text_field_tag key, label_tag_default_for(key), :class => 'form-control' %>
+        </div>
+    </div>
+  <%- end -%>
+</div>


### PR DESCRIPTION
# Story

Since #738 and #739 were so closely related, I thought it would have been easier to address them in one PR.

This commit reorders the advanced search fields to match the preferred priority order:

`Title`
`Creator`
`Date or Date Created`
`Keyword`
`License`
`Subject`

Ref:
  - https://github.com/scientist-softserv/palni-palci/issues/738

---

This commit will only show the first six search fields in the advanced search form. The rest of the fields will be hidden behind an "Additional fields" button that mimics the Hyrax forms behavior.

Ref:
  - https://github.com/scientist-softserv/palni-palci/issues/739

# Expected Behavior Before Changes

<img width="946" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/19597776/38d2c01b-7cfa-4087-a21b-a96b088f1bcd">

# Expected Behavior After Changes

<img width="1001" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/19597776/667ea7a5-4af1-42a2-9301-1125f785ef00">

<img width="820" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/19597776/9f67cea3-509a-4a92-8dac-e279142b6521">
