### PR TITLE
:gift: i740 -  local controlled vocabulary properties should display dropdown

### DIFF
--- a/app/helpers/blacklight/advanced_search_helper.rb
+++ b/app/helpers/blacklight/advanced_search_helper.rb
@@ -1,27 +1,50 @@
 # frozen_string_literal: true
 
 module Blacklight
+  # Helpers related to the advanced search functionality of Blacklight.
   module AdvancedSearchHelper
+    # Retrieves the first six search fields from a given collection.
+    #
+    # @param fields [Array] collection of search fields
+    # @return [Array] a subset of the input collection containing the first six fields
     def primary_search_fields_for(fields)
       fields.each_with_index.partition { |_, idx| idx < 6 }.first.map(&:first)
     end
 
+    # Retrieves all search fields from a given collection except the first six.
+    #
+    # @param fields [Array] collection of search fields
+    # @return [Array] a subset of the input collection excluding the first six fields
     def secondary_search_fields_for(fields)
       fields.each_with_index.partition { |_, idx| idx < 6 }.last.map(&:first)
     end
 
+    # Determines if the provided key represents a local authority.
+    #
+    # @param key [String] the key to be checked
+    # @return [Boolean] true if the key or its pluralized form is found in the local authorities list; false otherwise
     def local_authority?(key)
       local_qa_names = Qa::Authorities::Local.names
       local_qa_names.include?(key.pluralize) || local_qa_names.include?(key)
     end
 
+    # Gets the options for a QA select based on a given key.
+    #
+    # @param key [String] the key used to fetch the service and retrieve options
+    # @return [Array, nil] the options available for the select, or nil if the service does not provide any options
     def options_for_qa_select(key)
-        service = fetch_service_for(key)
-        service.try(:select_all_options) || service.try(:select_options) || service.new.select_all_options
+      service = fetch_service_for(key)
+      service.try(:select_all_options) || service.try(:select_options) || service.new.select_all_options
     end
 
-    def fetch_service_for(key)
-      "Hyrax::#{key.camelize}Service".safe_constantize || "Hyrax::#{key.pluralize.camelize}Service".safe_constantize
-    end
+    private
+
+      # Fetches the service for a given key.
+      #
+      # @param key [String] the key used to determine the service name
+      # @return [Class, nil] the service class based on the key, or nil if it does not exist
+      def fetch_service_for(key)
+        "Hyrax::#{key.camelize}Service".safe_constantize || "Hyrax::#{key.pluralize.camelize}Service".safe_constantize
+      end
   end
 end

--- a/app/helpers/blacklight/advanced_search_helper.rb
+++ b/app/helpers/blacklight/advanced_search_helper.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Blacklight
+  module AdvancedSearchHelper
+    def primary_search_fields_for(fields)
+      fields.each_with_index.partition { |_, idx| idx < 6 }.first.map(&:first)
+    end
+
+    def secondary_search_fields_for(fields)
+      fields.each_with_index.partition { |_, idx| idx < 6 }.last.map(&:first)
+    end
+
+    def local_authority?(key)
+      local_qa_names = Qa::Authorities::Local.names
+      local_qa_names.include?(key.pluralize) || local_qa_names.include?(key)
+    end
+
+    def options_for_qa_select(key)
+        service = fetch_service_for(key)
+        service.try(:select_all_options) || service.try(:select_options) || service.new.select_all_options
+    end
+
+    def fetch_service_for(key)
+      "Hyrax::#{key.camelize}Service".safe_constantize || "Hyrax::#{key.pluralize.camelize}Service".safe_constantize
+    end
+  end
+end

--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -427,5 +427,27 @@ module Blacklight
     def secondary_search_fields
       search_fields_for_advanced_search.each_with_index.partition { |_, idx| idx < 6 }.last.map(&:first)
     end
+
+    def subauthority?(key)
+      Qa::Authorities::Local.names.include?(key.pluralize || key)
+    end
+
+    def options_for_qa_select(key)
+      if "Hyrax::#{key.camelize}Service".safe_constantize
+        if "Hyrax::#{key.camelize}Service".constantize.respond_to?(:select_all_options)
+          "Hyrax::#{key.camelize}Service".constantize.select_all_options
+        else
+          "Hyrax::#{key.camelize}Service".constantize.new.select_all_options 
+        end
+      else
+        if "Hyrax::#{key.pluralize.camelize}Service".constantize.respond_to?(:select_all_options)
+          "Hyrax::#{key.pluralize.camelize}Service".constantize.select_all_options
+        elsif "Hyrax::#{key.pluralize.camelize}Service".constantize.respond_to?(:select_options)
+          "Hyrax::#{key.pluralize.camelize}Service".constantize.select_options
+        else
+          "Hyrax::#{key.pluralize.camelize}Service".constantize.new.select_all_options 
+        end 
+      end
+    end
   end
 end

--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -419,25 +419,5 @@ module Blacklight
     def document_link_params(_doc, opts)
       opts.except(:label, :counter)
     end
-
-    def primary_search_fields
-      search_fields_for_advanced_search.each_with_index.partition { |_, idx| idx < 6 }.first.map(&:first)
-    end
-
-    def secondary_search_fields
-      search_fields_for_advanced_search.each_with_index.partition { |_, idx| idx < 6 }.last.map(&:first)
-    end
-
-    def subauthority?(key)
-      Qa::Authorities::Local.names.include?(key.pluralize || key)
-    end
-
-    def options_for_qa_select(key)
-        fetch_service_for(key).try(:select_all_options) || fetch_service_for(key).try(:select_options) || fetch_service_for(key).new.select_all_options
-    end
-
-    def fetch_service_for(key)
-      "Hyrax::#{key.camelize}Service".safe_constantize || "Hyrax::#{key.pluralize.camelize}Service".safe_constantize
-    end
   end
 end

--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -433,21 +433,11 @@ module Blacklight
     end
 
     def options_for_qa_select(key)
-      if "Hyrax::#{key.camelize}Service".safe_constantize
-        if "Hyrax::#{key.camelize}Service".constantize.respond_to?(:select_all_options)
-          "Hyrax::#{key.camelize}Service".constantize.select_all_options
-        else
-          "Hyrax::#{key.camelize}Service".constantize.new.select_all_options 
-        end
-      else
-        if "Hyrax::#{key.pluralize.camelize}Service".constantize.respond_to?(:select_all_options)
-          "Hyrax::#{key.pluralize.camelize}Service".constantize.select_all_options
-        elsif "Hyrax::#{key.pluralize.camelize}Service".constantize.respond_to?(:select_options)
-          "Hyrax::#{key.pluralize.camelize}Service".constantize.select_options
-        else
-          "Hyrax::#{key.pluralize.camelize}Service".constantize.new.select_all_options 
-        end 
-      end
+        fetch_service_for(key).try(:select_all_options) || fetch_service_for(key).try(:select_options) || fetch_service_for(key).new.select_all_options
+    end
+
+    def fetch_service_for(key)
+      "Hyrax::#{key.camelize}Service".safe_constantize || "Hyrax::#{key.pluralize.camelize}Service".safe_constantize
     end
   end
 end

--- a/app/views/advanced/_advanced_search_fields.html.erb
+++ b/app/views/advanced/_advanced_search_fields.html.erb
@@ -4,11 +4,11 @@
   # See: Blacklight::BlacklightHelperBehavior#primary_search_fields, #secondary_search_fields
   # Also using Bootstrap 3 classes to make the form resemble the Hyrax form behaviors
 %>
-<%- primary_search_fields.each do |key, field_def| -%>
+<%- primary_search_fields_for(search_fields_for_advanced_search).each do |key, field_def| -%>
   <div class="form-group advanced-search-field">
       <%= label_tag key, "#{field_def.label}", :class => "col-sm-3 control-label" %>
       <div class="col-sm-9">
-        <% if subauthority?(key) %>
+        <% if local_authority?(key) %>
           <%= render 'advanced_search_fields_qa', key: key %>
         <% else %>
           <%= text_field_tag key, label_tag_default_for(key), :class => 'form-control' %>
@@ -20,11 +20,11 @@
 <a class="btn btn-default additional-fields collapsed" data-toggle="collapse" role="button" aria-expanded="false" aria-controls="additionalFieldsDiv" href="#additionalFieldsDiv">Additional fields</a>
 
 <div id="additionalFieldsDiv" class="collapse" aria-expanded="false">
-  <%- secondary_search_fields.each do |key, field_def| -%>
+  <%- secondary_search_fields_for(search_fields_for_advanced_search).each do |key, field_def| -%>
     <div class="form-group advanced-search-field">
         <%= label_tag key, "#{field_def.label}", :class => "col-sm-3 control-label" %>
         <div class="col-sm-9">
-          <% if subauthority?(key) %>
+          <% if local_authority?(key) %>
             <%= render 'advanced_search_fields_qa', key: key %>
           <% else %>
             <%= text_field_tag key, label_tag_default_for(key), :class => 'form-control' %>

--- a/app/views/advanced/_advanced_search_fields.html.erb
+++ b/app/views/advanced/_advanced_search_fields.html.erb
@@ -6,9 +6,13 @@
 %>
 <%- primary_search_fields.each do |key, field_def| -%>
   <div class="form-group advanced-search-field">
-      <%= label_tag key, "#{field_def.label }", :class => "col-sm-3 control-label" %>
+      <%= label_tag key, "#{field_def.label}", :class => "col-sm-3 control-label" %>
       <div class="col-sm-9">
-        <%= text_field_tag key, label_tag_default_for(key), :class => 'form-control' %>
+        <% if subauthority?(key) %>
+          <%= render 'advanced_search_fields_qa', key: key %>
+        <% else %>
+          <%= text_field_tag key, label_tag_default_for(key), :class => 'form-control' %>
+        <% end %>      
       </div>
   </div>
 <%- end -%>
@@ -18,9 +22,13 @@
 <div id="additionalFieldsDiv" class="collapse" aria-expanded="false">
   <%- secondary_search_fields.each do |key, field_def| -%>
     <div class="form-group advanced-search-field">
-        <%= label_tag key, "#{field_def.label }", :class => "col-sm-3 control-label" %>
+        <%= label_tag key, "#{field_def.label}", :class => "col-sm-3 control-label" %>
         <div class="col-sm-9">
-          <%= text_field_tag key, label_tag_default_for(key), :class => 'form-control' %>
+          <% if subauthority?(key) %>
+            <%= render 'advanced_search_fields_qa', key: key %>
+          <% else %>
+            <%= text_field_tag key, label_tag_default_for(key), :class => 'form-control' %>
+          <% end %>
         </div>
     </div>
   <%- end -%>

--- a/app/views/advanced/_advanced_search_fields_qa.html.erb
+++ b/app/views/advanced/_advanced_search_fields_qa.html.erb
@@ -1,0 +1,4 @@
+<%= select_tag key,
+               options_for_select(options_for_qa_select(key)),
+               class: 'form-control',
+               include_blank: true %>

--- a/spec/helpers/blacklight/advanced_search_helper_spec.rb
+++ b/spec/helpers/blacklight/advanced_search_helper_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Blacklight::AdvancedSearchHelper do
     end
 
     it "returns the client specified advanced search fields" do
-      expect(primary_search_fields_for(search_fields_for_advanced_search).map{|search| search.last.key}).to eq(["title", "creator", "date_created", "keyword", "license", "subject"])
+      expect(primary_search_fields_for(search_fields_for_advanced_search).map { |search| search.last.key }).to eq(["title", "creator", "date_created", "keyword", "license", "subject"])
     end
   end
 
@@ -27,20 +27,20 @@ RSpec.describe Blacklight::AdvancedSearchHelper do
     context 'when key is valid' do
       it "checks if the key exists in QA::Authorities::Local.names" do
         valid_local_authorities = search_fields_for_advanced_search.select { |key, _value| local_authority?(key) }
-        
+
         valid_local_authorities.each do |key, _value|
           expect(local_authority?(key)).to be true
-        end 
+        end
       end
     end
 
     context 'when the key is invalid' do
       it "checks if the key exists in QA::Authorities::Local.names" do
-        invalid_local_authorities = search_fields_for_advanced_search.select { |key, _value| !local_authority?(key) }
-        
+        invalid_local_authorities = search_fields_for_advanced_search.reject { |key, _value| local_authority?(key) }
+
         invalid_local_authorities.each do |key, _value|
           expect(local_authority?(key)).to be false
-        end 
+        end
       end
     end
   end
@@ -51,19 +51,17 @@ RSpec.describe Blacklight::AdvancedSearchHelper do
 
       valid_local_authority_keys.each do |key|
         local_authority_terms = fetch_local_yml(key)['terms'].map { |term| [term['term'], term['id']] }
-  
-        expect(options_for_qa_select(key)).to eq(local_authority_terms) 
+
+        expect(options_for_qa_select(key)).to eq(local_authority_terms)
       end
     end
   end
 
   # a utility method for finding the correct yml files because the naming is inconsistent, plural vs singular
   def fetch_local_yml(key)
-    begin
-      YAML.load_file("config/authorities/#{key}.yml")
-    rescue Errno::ENOENT
-      YAML.load_file("config/authorities/#{key.pluralize}.yml")
-    end
+    YAML.load_file("config/authorities/#{key}.yml")
+  rescue Errno::ENOENT
+    YAML.load_file("config/authorities/#{key.pluralize}.yml")
   end
 
   describe "#fetch_service_for" do

--- a/spec/helpers/blacklight/advanced_search_helper_spec.rb
+++ b/spec/helpers/blacklight/advanced_search_helper_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Blacklight::AdvancedSearchHelper do
       it "checks if the key exists in QA::Authorities::Local.names" do
         valid_local_authorities = search_fields_for_advanced_search.select { |key, _value| local_authority?(key) }
 
-        valid_local_authorities.each do |key, _value|
+        valid_local_authorities.each_key do |key|
           expect(local_authority?(key)).to be true
         end
       end
@@ -38,7 +38,7 @@ RSpec.describe Blacklight::AdvancedSearchHelper do
       it "checks if the key exists in QA::Authorities::Local.names" do
         invalid_local_authorities = search_fields_for_advanced_search.reject { |key, _value| local_authority?(key) }
 
-        invalid_local_authorities.each do |key, _value|
+        invalid_local_authorities.each_key do |key|
           expect(local_authority?(key)).to be false
         end
       end

--- a/spec/helpers/blacklight/advanced_search_helper_spec.rb
+++ b/spec/helpers/blacklight/advanced_search_helper_spec.rb
@@ -1,0 +1,82 @@
+require 'rails_helper'
+
+RSpec.describe Blacklight::AdvancedSearchHelper do
+  include described_class
+
+  let(:search_fields_for_advanced_search) { CatalogController.blacklight_config.search_fields.select { |_k, v| v.include_in_advanced_search || v.include_in_advanced_search.nil? } }
+
+  describe "#primary_search_fields" do
+    it "returns the first 6 advanced search fields" do
+      expect(primary_search_fields_for(search_fields_for_advanced_search).size).to eq(6)
+    end
+
+    it "returns the client specified advanced search fields" do
+      expect(primary_search_fields_for(search_fields_for_advanced_search).map{|search| search.last.key}).to eq(["title", "creator", "date_created", "keyword", "license", "subject"])
+    end
+  end
+
+  describe "#secondary_search_fields" do
+    it "returns the rest of the advanced search fields" do
+      second_search_fields_count = search_fields_for_advanced_search.size - 6
+
+      expect(secondary_search_fields_for(search_fields_for_advanced_search).size).to eq(second_search_fields_count)
+    end
+  end
+
+  describe "#local_authority?" do
+    context 'when key is valid' do
+      it "checks if the key exists in QA::Authorities::Local.names" do
+        valid_local_authorities = search_fields_for_advanced_search.select { |key, _value| local_authority?(key) }
+        
+        valid_local_authorities.each do |key, _value|
+          expect(local_authority?(key)).to be true
+        end 
+      end
+    end
+
+    context 'when the key is invalid' do
+      it "checks if the key exists in QA::Authorities::Local.names" do
+        invalid_local_authorities = search_fields_for_advanced_search.select { |key, _value| !local_authority?(key) }
+        
+        invalid_local_authorities.each do |key, _value|
+          expect(local_authority?(key)).to be false
+        end 
+      end
+    end
+  end
+
+  describe "#options_for_qa_select?" do
+    it "returns the values for a given key" do
+      valid_local_authority_keys = search_fields_for_advanced_search.select { |key, _value| local_authority?(key) }.keys
+
+      valid_local_authority_keys.each do |key|
+        local_authority_terms = fetch_local_yml(key)['terms'].map { |term| [term['term'], term['id']] }
+  
+        expect(options_for_qa_select(key)).to eq(local_authority_terms) 
+      end
+    end
+  end
+
+  # a utility method for finding the correct yml files because the naming is inconsistent, plural vs singular
+  def fetch_local_yml(key)
+    begin
+      YAML.load_file("config/authorities/#{key}.yml")
+    rescue Errno::ENOENT
+      YAML.load_file("config/authorities/#{key.pluralize}.yml")
+    end
+  end
+
+  describe "#fetch_service_for" do
+    it "returns the service class for a given a valid key" do
+      expect(fetch_service_for('accessibility_feature')).to eq(Hyrax::AccessibilityFeaturesService)
+    end
+
+    it "returns the service even if it should have been plural" do
+      expect(fetch_service_for('accessibility_features')).to eq(Hyrax::AccessibilityFeaturesService)
+    end
+
+    it "returns nil for an invalid key" do
+      expect(fetch_service_for('foo')).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
On the advanced search page, the controlled vocab properties currently allows the user to input whatever they want. Instead, the user should have to select an option from a dropdown.

# Story

Refs #740 

# Expected Behavior Before Changes
controlled vocab fields were inputs. the user could type in whatever they want. 

# Expected Behavior After Changes
the user must select an option provided by their local controlled vocab configuration.

![image](https://github.com/scientist-softserv/palni-palci/assets/10081604/82149472-e205-4379-ac82-f01449d8c162)


# Screenshots / Video

<details>
<summary>DEMO</summary>



https://github.com/scientist-softserv/palni-palci/assets/10081604/feda32f1-b31b-49c1-a327-f58860d42f3e


</details>

# Notes
