### PR TITLE
:gift: i741 - add Text to resource types

### DIFF
--- a/config/authorities/resource_types.yml
+++ b/config/authorities/resource_types.yml
@@ -41,6 +41,8 @@ terms:
     term: Research Paper
   - id: Software or Program Code
     term: Software or Program Code
+  - id: Text
+    term: Text
   - id: Video
     term: Video
   - id: Other


### PR DESCRIPTION
Text should also be included in the authority file for resource_types

# Story

Refs #741 

related to https://github.com/scientist-softserv/palni-palci/pull/785

The client kicked this back because Text should be included too, per [this document](https://docs.google.com/spreadsheets/d/1iIzTikHdXKo8u1_Re_CuE_LhnI0o-62WqYdKYGAt1BE/edit#gid=519636467). Text was not part of the original ticket. 

# Expected Behavior Before Changes
Text was not a resource type

# Expected Behavior After Changes
Text is now a resource type and is in alphabetical order.

# Screenshots / Video

<details>
<summary>demo</summary>

edit form
![image](https://github.com/scientist-softserv/palni-palci/assets/10081604/914effb5-27c5-464f-967f-b3e5010c782c)

show page
![image](https://github.com/scientist-softserv/palni-palci/assets/10081604/4cccecb6-0c90-4de4-808c-c6e7f0e7a5cc)

</details>

# Notes
