### PR TITLE
🐛 Remove PDF.js related fields from form

### DIFF
--- a/app/forms/hyrax/pdf_form_behavior.rb
+++ b/app/forms/hyrax/pdf_form_behavior.rb
@@ -5,7 +5,14 @@ module Hyrax
     extend ActiveSupport::Concern
 
     included do
+      class_attribute :hidden_terms
+
       self.terms += %i[show_pdf_viewer show_pdf_download_button]
+      self.hidden_terms = %i[show_pdf_viewer show_pdf_download_button]
+    end
+
+    def hidden?(key)
+      hidden_terms.include? key.to_sym
     end
   end
 end

--- a/app/views/records/edit_fields/_default.html.erb
+++ b/app/views/records/edit_fields/_default.html.erb
@@ -1,18 +1,19 @@
 <%# OVERRIDE: HydraEditor 5.0.5 support dynamic labels and hints for custom worktypes %>
 <%# Avoid NoMethod error when rendering partial in Collection or batch edit form %>
+<%# Hide unwanted fields from the form %>
+<% return if f.object.try(:hidden?, key) %>
 
-  <% record = f.object.model %>
-  <% if f.object.multiple? key %>
-    <%= f.input key,
-        as: :multi_value,
-        label: label_for(term: key, record_class: record.class),
-        hint: hint_for(term: key, record_class: record.class),
-        input_html: { class: 'form-control' },
-        required: f.object.required?(key) %>
-  <% else %>
-    <%= f.input key,
-        label: label_for(term: key, record_class: record.class),
-        hint: hint_for(term: key, record_class: record.class),
-        required: f.object.required?(key) %>
-  <% end %>
-
+<% record = f.object.model %>
+<% if f.object.multiple? key %>
+  <%= f.input key,
+      as: :multi_value,
+      label: label_for(term: key, record_class: record.class),
+      hint: hint_for(term: key, record_class: record.class),
+      input_html: { class: 'form-control' },
+      required: f.object.required?(key) %>
+<% else %>
+  <%= f.input key,
+      label: label_for(term: key, record_class: record.class),
+      hint: hint_for(term: key, record_class: record.class),
+      required: f.object.required?(key) %>
+<% end %>


### PR DESCRIPTION
The `show_pdf_viewer` and `show_pdf_download_button` fields were showing up on the form so this commit will remove them.

# Story

Refs #issuenumber

# Expected Behavior Before Changes
<img width="662" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/19597776/11b37a34-8cf8-4c91-a3e4-c8b23549a6c0">

# Expected Behavior After Changes
<img width="824" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/19597776/4728d5c6-2431-46ea-a03e-273b5aad75ee">
