### PR TITLE
🧹 [i774] - Updating index type to bsi (boolean)

### DIFF
--- a/app/indexers/app_indexer.rb
+++ b/app/indexers/app_indexer.rb
@@ -16,6 +16,8 @@ class AppIndexer < Hyrax::WorkIndexer
       solr_doc['bulkrax_identifier_tesim'] = object.bulkrax_identifier
       solr_doc['account_cname_tesim'] = Site.instance&.account&.cname
       solr_doc['all_text_tsimv'] = full_text(object.file_sets.first&.id)
+      solr_doc['show_pdf_viewer_bsi'] = object.show_pdf_viewer || true
+      solr_doc['show_pdf_download_button_bsi'] = object.show_pdf_download_button || true
       add_date(solr_doc)
     end
   end

--- a/app/models/concerns/pdf_behavior.rb
+++ b/app/models/concerns/pdf_behavior.rb
@@ -27,10 +27,10 @@ module PdfBehavior
 
     # This is here so that the checkbox is checked by default
     def set_default_show_pdf_viewer
-      self.show_pdf_viewer ||= 'true'
+      self.show_pdf_viewer ||= true
     end
 
     def set_default_show_pdf_download_button
-      self.show_pdf_download_button ||= 'true'
+      self.show_pdf_download_button ||= true
     end
 end

--- a/app/models/concerns/pdf_behavior.rb
+++ b/app/models/concerns/pdf_behavior.rb
@@ -27,10 +27,10 @@ module PdfBehavior
 
     # This is here so that the checkbox is checked by default
     def set_default_show_pdf_viewer
-      self.show_pdf_viewer ||= '1'
+      self.show_pdf_viewer ||= 'true'
     end
 
     def set_default_show_pdf_download_button
-      self.show_pdf_download_button ||= '1'
+      self.show_pdf_download_button ||= 'true'
     end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -61,6 +61,8 @@ class SolrDocument
   attribute :library_catalog_identifier, Solr::String, 'library_catalog_identifier_tesim'
   attribute :chronology_note, Solr::String, 'chronology_note_tesim'
   attribute :based_near, Solr::Array, 'based_near_tesim'
+  attribute :show_pdf_viewer, Solr::String, 'show_pdf_viewer_bsi'
+  attribute :show_pdf_download_button, Solr::String, 'show_pdf_download_button_bsi'
 
   field_semantics.merge!(
     contributor: 'contributor_tesim',
@@ -78,10 +80,10 @@ class SolrDocument
   )
 
   def show_pdf_viewer
-    self['show_pdf_viewer_tesim']
+    self['show_pdf_viewer_bsi']
   end
 
   def show_pdf_download_button
-    self['show_pdf_download_button_tesim']
+    self['show_pdf_download_button_bsi']
   end
 end

--- a/app/presenters/hyku/work_show_presenter.rb
+++ b/app/presenters/hyku/work_show_presenter.rb
@@ -82,14 +82,14 @@ module Hyku
       return unless show_pdf_viewer
       return unless file_set_presenters.any?(&:pdf?)
 
-      show_pdf_viewer.first.to_i.positive?
+      show_pdf_viewer
     end
 
     def show_pdf_download_button?
       return unless file_set_presenters.any?(&:pdf?)
       return unless show_pdf_download_button
 
-      show_pdf_download_button.first.to_i.positive?
+      show_pdf_download_button
     end
 
     private

--- a/app/views/hyrax/base/_show_pdf_download_button.erb
+++ b/app/views/hyrax/base/_show_pdf_download_button.erb
@@ -1,4 +1,6 @@
+<% checked = ActiveModel::Type::Boolean.new.cast(f.object.show_pdf_download_button) %>
 <%= f.input :show_pdf_download_button,
             label: "Show Download PDF button",
             required: f.object.required?(:show_pdf_download_button),
-            as: :boolean %>
+            as: :boolean,
+            input_html: {checked: checked} %>

--- a/app/views/hyrax/base/_show_pdf_viewer.html.erb
+++ b/app/views/hyrax/base/_show_pdf_viewer.html.erb
@@ -1,4 +1,6 @@
+<% checked = ActiveModel::Type::Boolean.new.cast(f.object.show_pdf_viewer) %>
 <%= f.input :show_pdf_viewer,
             label: "Show PDF.js Viewer",
             required: f.object.required?(:show_pdf_viewer),
-            as: :boolean %>
+            as: :boolean,
+            input_html: {checked: checked} %>


### PR DESCRIPTION
This commit is a follow up for issue #774. show_pdf_viewer and show_pdf_download_button should store boolean values and have a solr index type as _bsi.

# Story

Refs #774 

# Expected Behavior Before Changes
![image](https://github.com/scientist-softserv/palni-palci/assets/10081604/26b2ac84-ae42-45c0-86d4-09dd1fa0989d)


# Expected Behavior After Changes
![Screenshot 2023-09-15 at 8 18 59 AM](https://github.com/scientist-softserv/palni-palci/assets/10081604/09391f11-b2a2-4909-b20f-ebfbb4009238)


