### PR TITLE
🎁 Default A-Z title sort for featured collections

### DIFF
--- a/app/models/featured_collection_list.rb
+++ b/app/models/featured_collection_list.rb
@@ -22,6 +22,8 @@ class FeaturedCollectionList
       collection.destroy if collection.presenter.blank?
       collection.presenter.blank?
     end
+    sort_by_title! unless manually_ordered?
+    @collections
   end
 
   delegate :empty?, to: :featured_collections
@@ -47,5 +49,13 @@ class FeaturedCollectionList
 
     def collection_with_id(id)
       @collections.find { |c| c.collection_id == id }
+    end
+
+    def manually_ordered?
+      !@collections.all? { |c| c.order == FeaturedCollection::FEATURE_LIMIT }
+    end
+
+    def sort_by_title!
+      @collections.sort_by! { |c| c.presenter.title.first.downcase }
     end
 end


### PR DESCRIPTION
This commit will add a default A-Z title sort to the featured collections section on the homepage.  If a featured collections list has been saved then it will no long sort by title but instead whatever the user set it to.

# Story

Refs #743 

# Expected Behavior Before Changes

By default, featured collections would be sorted by the last added.

# Expected Behavior After Changes

By default, featured collections would be sorted by title.

# Screenshots / Video

https://github.com/scientist-softserv/palni-palci/assets/19597776/04bb3109-ec5e-4de4-9e6b-b60510bbb605

# Notes
When the user saves a list, this functionality will stop working until the list has been cleared and new collections added.