### PR TITLE
🐛 Adjust download button styling

### DIFF
--- a/app/assets/stylesheets/hyku.scss
+++ b/app/assets/stylesheets/hyku.scss
@@ -595,10 +595,7 @@ span.constraint-value p, .facet-values p {
 }
 
 #download-pdf-button {
-  margin-top: 10px;
-  @media (min-width: 576px) {
-    max-width: 300px;
-  }
+  margin: 10px 0 10px 0;
 }
 
 .catalog_startOverLink {

--- a/app/views/hyrax/base/_download_pdf.html.erb
+++ b/app/views/hyrax/base/_download_pdf.html.erb
@@ -6,7 +6,6 @@
                      data: { label: @presenter.representative_presenter.id,
                              path: hyrax.download_path(presenter.representative_presenter) },
                      class: "btn btn-success btn-block download-pdf-button center-block",
-                     style: "margin: 10px 0 10px 0;",
                      onclick: "window.open(this.dataset.path, '_blank');" do %>
         Download PDF
       <% end %>


### PR DESCRIPTION
This commit will adjust the css to fix the download button so it would look the same on the cultural theme as it does on the other themes.

![image](https://github.com/scientist-softserv/palni-palci/assets/19597776/95ce7ec9-95ad-48f6-b3c5-72ff48e5bb35)
