### PR TITLE
i760-devops-node-affinity

### DIFF
--- a/ops/demo-deploy.tmpl.yaml
+++ b/ops/demo-deploy.tmpl.yaml
@@ -168,6 +168,16 @@ extraEnvVars: &envVars
     value: http://admin:$SOLR_ADMIN_PASSWORD@solr-headless.solr:8983/solr/
 
 worker:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: name
+            operator: In
+            values:
+              - {{ include "hyrax.fullname" . }}-worker
+        topologyKey: "kubernetes.io/hostname"
   replicaCount: 1
   resources:
     limits:
@@ -219,6 +229,17 @@ externalSolrPassword: $SOLR_ADMIN_PASSWORD
 
 global:
   hyraxName: palni-palci-demo-pals
+
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+        matchExpressions:
+        - key: name
+          operator: In
+          values:
+            - {{ include "hyrax.fullname" . }}
+      topologyKey: "kubernetes.io/hostname"
 
 nginx:
   enabled: true

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -182,6 +182,16 @@ extraEnvVars: &envVars
     value: http://admin:$SOLR_ADMIN_PASSWORD@solr-headless.solr:8983/solr/
 
 worker:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: name
+            operator: In
+            values:
+              - {{ include "hyrax.fullname" . }}-worker
+        topologyKey: "kubernetes.io/hostname"
   replicaCount: 1
   resources:
     limits:
@@ -234,6 +244,18 @@ externalSolrPassword: $SOLR_ADMIN_PASSWORD
 
 global:
   hyraxName: palni-palci-production-pals
+
+
+affinity:
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+    - labelSelector:
+        matchExpressions:
+        - key: name
+          operator: In
+          values:
+            - {{ include "hyrax.fullname" . }}
+      topologyKey: "kubernetes.io/hostname"
 
 nginx:
   enabled: true


### PR DESCRIPTION
# Story
As a node goes down and the workloads are dumped onto other nodes, this will guarantee that the when there are 2 or more web pods and 2 or more worker pods they will not be spun up on the same node. (Note a worker and web pod CAN spin up on the same node, but no more than 1 worker or web pod will ever exist on the same node together)

- https://github.com/scientist-softserv/dev-ops/issues/760

# Expected Behavior Before Changes
When a node goes down a web or worker pods can then get dumped onto a node that already has a web or worker pods for that project causing additional increased load and increase additional node outages without manual intervention by redeploying the projects workload that is effected.

# Expected Behavior After Changes
When a node goes down the web or worker pods for that project will never exist on the same node.

# Notes
Glass Canvas has this implementation currently and we have modeled ours after this, but instead of using the item key par, we have used name, since the charts we inherit form hyrax do not contain that key value pair. https://github.com/glass-canvas/tilma/blob/53942b869ea38211c24abc4f176c2113b37bd0ea/chart/templates/rails-deploy.yaml#L36