### PR TITLE
I744 sort subcollections a z

### DIFF
--- a/app/controllers/concerns/hyrax/collections_controller_behavior_decorator.rb
+++ b/app/controllers/concerns/hyrax/collections_controller_behavior_decorator.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# OVERRIDE Hyrax v3.6.0 to sort subcollections by title
+
+module Hyrax
+  module CollectionsControllerBehaviorDecorator
+    def load_member_subcollections
+      super
+      return if @subcollection_docs.blank?
+
+      @subcollection_docs.sort_by! { |doc| doc.title.first&.downcase }
+    end
+  end
+end
+
+Hyrax::CollectionsControllerBehavior.prepend Hyrax::CollectionsControllerBehaviorDecorator


### PR DESCRIPTION
# Story

This commit will add a sort_by for the subcollections and make them sort by title.

Ref:
  - https://github.com/scientist-softserv/palni-palci/issues/744

# Expected Behavior Before Changes

![image](https://github.com/scientist-softserv/palni-palci/assets/19597776/7dd4b611-7654-43a1-ae82-75d2e5e7e86c)

# Expected Behavior After Changes

![image](https://github.com/scientist-softserv/palni-palci/assets/19597776/851f0b93-29e5-45f5-9eb4-14ca822e268b)
