### PR TITLE
Update index.html.erb - Fix typo on Institute

### DIFF
--- a/app/views/splash/index.html.erb
+++ b/app/views/splash/index.html.erb
@@ -47,7 +47,7 @@
 
 <section class="splash-footer">
   <p>
-    This project was made possible in part by the Institue of Museum and Library Services, LG-36-19-0108, as well as other funding sources.
+    This project was made possible in part by the Institute of Museum and Library Services, LG-36-19-0108, as well as other funding sources.
   </p>
   <div class="imls-logo">
     <%= image_tag "imls.jpg", alt: "IMLS logo", class: "img-responsive imls-logo" %>


### PR DESCRIPTION
The footer section had a typo.  Fixes issue on this ticket: https://github.com/scientist-softserv/palni-palci/issues/677

# Story

Refs #issuenumber https://github.com/scientist-softserv/palni-palci/issues/677

# Expected Behavior Before Changes

# Expected Behavior After Changes

No more typo on word institute in the splash footer. 

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes
