### PR TITLE
Resolving sushi error handling

### DIFF
--- a/app/controllers/api/sushi_controller.rb
+++ b/app/controllers/api/sushi_controller.rb
@@ -7,20 +7,12 @@ module API
       ##
       # We have encountered an error in their request, this might be an invalid date or a missing
       # required parameter.  The end user can adjust the request and try again.
-      def render_error_that_is_user_correctable(error)
-        render json: { error: error.message }, status: 422
-      end
-      rescue_from ActionController::ParameterMissing, Sushi::InvalidParameterValue, with: :render_error_that_is_user_correctable
-
-      ##
-      # We have encountered some semblance of missing data, we've thrown that via an exception, and we're
-      # handling that missing data by presenting the error to the end user.
-      # @param [Exception]
       #
-      def render_not_found(error)
-        render json: { error: error.message }, status: 404
+      # @param [Exception]
+      def render_sushi_exception(error)
+        render json: error, status: 422
       end
-      rescue_from Sushi::NotFoundError, with: :render_not_found
+      rescue_from Sushi::Error::Exception, with: :render_sushi_exception
 
     public
 

--- a/app/models/sushi/error.rb
+++ b/app/models/sushi/error.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+module Sushi
+  ##
+  # A name space for the various errors that we have.
+  #
+  # @note I'd love for this to be Sushi::Error::Errors, but Rails autoload might have other opinions.
+  module Error
+    ##
+    # @see https://countermetrics.stoplight.io/docs/counter-sushi-api/sgmqulr0emsi6-exception
+    #
+    # @see .as_json
+    class Exception < StandardError
+      class_attribute :code, default: nil
+      class_attribute :help_url, default: nil
+      class_attribute :default_message, default: nil
+
+      attr_reader :data
+      def initialize(data: nil)
+        @data = data
+        super("#{default_message}: #{data}")
+      end
+
+      ##
+      # In Sushi's exception documentation there are two required properties:
+      #
+      # - Code :: an integer
+      # - Message :: the Message value is a terse string that "identifies" the conceptual
+      #
+      # The Data property is the further explanation of the Message.  And the Help_URL property
+      # is a URL that explains the exception.  By convention, we're setting the Help_URL to the
+      # Sushi documentation; this helps developers read more about what the details of the
+      # exceptions; and provides the end-user with further details about the Sushi "specification".
+      #
+      # @see https://countermetrics.stoplight.io/docs/counter-sushi-api/sgmqulr0emsi6-exception
+      def as_json(*)
+        hash = {
+          Code: code,
+          Message: default_message
+        }
+
+        hash[:Data] = data if data.present?
+        hash[:Help_URL] = help_url if help_url.present?
+        hash
+      end
+    end
+
+    class InsufficientInformationToProcessRequestError < Sushi::Error::Exception
+      self.code = 1030
+      self.help_url = "https://countermetrics.stoplight.io/docs/counter-sushi-api/sgise2c2tmbrq-exception-1030"
+      self.default_message = "Insufficient Information to Process Request"
+    end
+
+    class InvalidDateArgumentError < Sushi::Error::Exception
+      self.code = 3020
+      self.help_url = "https://countermetrics.stoplight.io/docs/counter-sushi-api/3anarphof7zh5-exception-3020"
+      self.default_message = "Invalid Date Arguments"
+    end
+
+    class NoUsageAvailableForRequestedDatesError < Sushi::Error::Exception
+      self.code = 3030
+      self.help_url = "https://countermetrics.stoplight.io/docs/counter-sushi-api/2fhcc5gkzzkg3-exception-3030"
+      self.default_message = "No Usage Available for Requested Dates"
+    end
+
+    # @todo This is likely a scenario we'll need to handle.
+    class UsageNotReadyForRequestedDatesError < Sushi::Error::Exception
+      self.code = 3031
+      self.help_url = "https://countermetrics.stoplight.io/docs/counter-sushi-api/6lfhilgndgpde-exception-3031"
+      self.default_message = "Usage Not Ready for Requested Dates"
+    end
+
+    # @todo This is likely a scenario we'll need to handle.
+    class UsageNoLongerAvailableForRequestedDatesError < Sushi::Error::Exception
+      self.code = 3032
+      self.help_url = "https://countermetrics.stoplight.io/docs/counter-sushi-api/x2o44d5p9kdp3-exception-3032"
+      self.default_message = "Usage No Longer Available for Requested Dates"
+    end
+
+    class InvalidReportFilterValueError < Sushi::Error::Exception
+      self.code = 3060
+      self.help_url = "https://countermetrics.stoplight.io/docs/counter-sushi-api/s2a2xb68jsnn6-exception-3060"
+      self.default_message = "Invalid Report Filter Value"
+
+      ##
+      # @param parameter_value [#to_s]
+      # @param parameter_name [#to_s]
+      # @param allowed_values [Array<#to_s>]
+      def self.given_value_does_not_match_allowed_values(parameter_value:, parameter_name:, allowed_values:)
+        new(data: "None of the given values in `#{parameter_name}=#{parameter_value}` are supported at this time." \
+                  "Please use an acceptable value, (#{allowed_values.join(', ')}) instead." \
+                  "(Or do not pass the parameter at all, which will default to the acceptable value(s))")
+      end
+    end
+  end
+end

--- a/app/models/sushi/item_report.rb
+++ b/app/models/sushi/item_report.rb
@@ -76,7 +76,7 @@ module Sushi
         'Report_Items' => report_items
       }
 
-      raise Sushi::NotFoundError.no_records_within_date_range if report_items.blank?
+      raise Sushi::Error::NoUsageAvailableForRequestedDatesError.new(data: "No data within #{begin_date.iso8601} and #{end_date.iso8601} date range.") if report_items.blank?
 
       report_hash['Report_Header']['Report_Filters']['Access_Method'] = access_methods if access_method_in_params
       report_hash['Report_Header']['Report_Filters']['Author'] = author if author_in_params

--- a/app/models/sushi/report_list.rb
+++ b/app/models/sushi/report_list.rb
@@ -26,8 +26,8 @@ module Sushi
           "Release" => "5.1",
           "Report_Description" => "This resource returns COUNTER 'Platform Master Report' [PR]. A customizable report summarizing activity across a provider’s platforms that allows the user to apply filters and select other configuration options for the report.",
           "Path" => "/api/sushi/r51/reports/pr",
-          "First_Month_Available" => Sushi.first_month_available&.strftime("%Y-%m"),
-          "Last_Month_Available" => Sushi.last_month_available&.strftime("%Y-%m")
+          "First_Month_Available" => Sushi.rescued_first_month_available,
+          "Last_Month_Available" => Sushi.rescued_last_month_available
         },
         {
           "Report_Name" => "Platform Usage",
@@ -35,8 +35,8 @@ module Sushi
           "Release" => "5.1",
           "Report_Description" => "This resource returns COUNTER 'Platform Usage' [pr_p1]. This is a Standard View of the Package Master Report that presents usage for the overall Platform broken down by Metric_Type.",
           "Path" => "/api/sushi/r51/reports/pr_p1",
-          "First_Month_Available" => Sushi.first_month_available&.strftime("%Y-%m"),
-          "Last_Month_Available" => Sushi.last_month_available&.strftime("%Y-%m")
+          "First_Month_Available" => Sushi.rescued_first_month_available,
+          "Last_Month_Available" => Sushi.rescued_last_month_available
         },
         {
           "Report_Name" => "Item Report",
@@ -44,8 +44,8 @@ module Sushi
           "Release" => "5.1",
           "Report_Description" => "This resource returns COUNTER 'Item Master Report' [IR].",
           "Path" => "/api/sushi/r51/reports/ir",
-          "First_Month_Available" => Sushi.first_month_available&.strftime("%Y-%m"),
-          "Last_Month_Available" => Sushi.last_month_available&.strftime("%Y-%m")
+          "First_Month_Available" => Sushi.rescued_first_month_available,
+          "Last_Month_Available" => Sushi.rescued_last_month_available
         }
       ]
     end

--- a/spec/models/sushi/item_report_spec.rb
+++ b/spec/models/sushi/item_report_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Sushi::ItemReport do
       end
 
       it 'raises an error' do
-        expect { described_class.new(params, created: created, account: account).as_json }.to raise_error(Sushi::InvalidParameterValue)
+        expect { described_class.new(params, created: created, account: account).as_json }.to raise_error(Sushi::Error::InvalidReportFilterValueError)
       end
     end
   end
@@ -136,7 +136,7 @@ RSpec.describe Sushi::ItemReport do
         end
 
         it 'raises an error' do
-          expect { described_class.new(params, created: created, account: account).as_json }.to raise_error(Sushi::NotFoundError)
+          expect { described_class.new(params, created: created, account: account).as_json }.to raise_error(Sushi::Error::NoUsageAvailableForRequestedDatesError)
         end
       end
     end
@@ -151,7 +151,7 @@ RSpec.describe Sushi::ItemReport do
       end
 
       it 'raises an error' do
-        expect { described_class.new(params, created: created, account: account).as_json }.to raise_error(Sushi::NotFoundError)
+        expect { described_class.new(params, created: created, account: account).as_json }.to raise_error(Sushi::Error::InvalidReportFilterValueError)
       end
     end
   end
@@ -179,7 +179,7 @@ RSpec.describe Sushi::ItemReport do
       end
 
       it 'raises an error' do
-        expect { described_class.new(params, created: created, account: account).as_json }.to raise_error(Sushi::InvalidParameterValue)
+        expect { described_class.new(params, created: created, account: account).as_json }.to raise_error(Sushi::Error::InvalidReportFilterValueError)
       end
     end
   end
@@ -207,7 +207,7 @@ RSpec.describe Sushi::ItemReport do
       end
 
       it 'raises an error' do
-        expect { described_class.new(params, created: created, account: account).as_json }.to raise_error(Sushi::InvalidParameterValue)
+        expect { described_class.new(params, created: created, account: account).as_json }.to raise_error(Sushi::Error::InvalidReportFilterValueError)
       end
     end
   end
@@ -236,7 +236,7 @@ RSpec.describe Sushi::ItemReport do
       end
 
       it 'raises an error' do
-        expect { described_class.new(params, created: created, account: account).as_json }.to raise_error(Sushi::InvalidParameterValue)
+        expect { described_class.new(params, created: created, account: account).as_json }.to raise_error(Sushi::Error::InvalidReportFilterValueError)
       end
     end
   end

--- a/spec/models/sushi/platform_report_spec.rb
+++ b/spec/models/sushi/platform_report_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe Sushi::PlatformReport do
       end
 
       it 'raises an error' do
-        expect { described_class.new(params, created: created, account: account).as_json }.to raise_error(Sushi::InvalidParameterValue)
+        expect { described_class.new(params, created: created, account: account).as_json }.to raise_error(Sushi::Error::InvalidReportFilterValueError)
       end
     end
   end
@@ -133,7 +133,7 @@ RSpec.describe Sushi::PlatformReport do
       end
 
       it 'raises an error' do
-        expect { described_class.new(params, created: created, account: account).as_json }.to raise_error(Sushi::InvalidParameterValue)
+        expect { described_class.new(params, created: created, account: account).as_json }.to raise_error(Sushi::Error::InvalidReportFilterValueError)
       end
     end
   end

--- a/spec/models/sushi_spec.rb
+++ b/spec/models/sushi_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Sushi do
       let(:given_date) { '2023' }
 
       it 'will raise an error' do
-        expect { subject }.to raise_exception(Sushi::InvalidParameterValue)
+        expect { subject }.to raise_exception(Sushi::Error::InvalidDateArgumentError)
       end
     end
   end
@@ -43,8 +43,8 @@ RSpec.describe Sushi do
 
       before { entry }
 
-      it 'will return nil (because we have less than one month of data)' do
-        expect(subject).to be_nil
+      it 'raises an error' do
+        expect { subject }.to raise_error(Sushi::Error::UsageNotReadyForRequestedDatesError)
       end
     end
 
@@ -60,7 +60,9 @@ RSpec.describe Sushi do
     end
 
     context 'when there are no entries' do
-      it { is_expected.to be_nil }
+      it 'raises an error' do
+        expect { subject }.to raise_error(Sushi::Error::UsageNotReadyForRequestedDatesError)
+      end
     end
   end
 
@@ -94,7 +96,10 @@ RSpec.describe Sushi do
       let(:entry_date) { 5.days.ago(Time.zone.today.end_of_month) }
 
       before { entry }
-      it { is_expected.to be_nil }
+
+      it 'raises an error' do
+        expect { subject }.to raise_error(Sushi::Error::UsageNotReadyForRequestedDatesError)
+      end
     end
 
     context 'when last entry date is middle of the month and current date is end of this month' do
@@ -139,7 +144,9 @@ RSpec.describe Sushi do
     end
 
     context 'when there are no entries' do
-      it { is_expected.to be_nil }
+      it 'raises an error' do
+        expect { subject }.to raise_error(Sushi::Error::UsageNotReadyForRequestedDatesError)
+      end
     end
   end
 
@@ -203,14 +210,14 @@ RSpec.describe Sushi do
     [
       ['2003', ["((year_of_publication = ?))", 2003]],
       ['2003-2005', ["((year_of_publication >= ? AND year_of_publication <= ?))", 2003, 2005]],
-      ['2003a-2005', Sushi::InvalidParameterValue],
+      ['2003a-2005', Sushi::Error::InvalidDateArgumentError],
       ['-1', ["((year_of_publication = ?))", -1]],
-      ['a-1', Sushi::InvalidParameterValue],
-      ['a1', Sushi::InvalidParameterValue],
-      ['1-2 3', Sushi::InvalidParameterValue],
-      ['1 2', Sushi::InvalidParameterValue],
+      ['a-1', Sushi::Error::InvalidDateArgumentError],
+      ['a1', Sushi::Error::InvalidDateArgumentError],
+      ['1-2 3', Sushi::Error::InvalidDateArgumentError],
+      ['1 2', Sushi::Error::InvalidDateArgumentError],
       ['1996-1994', ["((year_of_publication >= ? AND year_of_publication <= ?))", 1996, 1994]],
-      ['1996-1994 | 1999-2003|9a', Sushi::InvalidParameterValue],
+      ['1996-1994 | 1999-2003|9a', Sushi::Error::InvalidDateArgumentError],
       ['1996-1994 | 1299-2003|9-12', ["((year_of_publication >= ? AND year_of_publication <= ?) OR (year_of_publication >= ? AND year_of_publication <= ?) OR (year_of_publication >= ? AND year_of_publication <= ?))", 1996, 1994, 1299, 2003, 9, 12]],
       ['1994-1996 | 1989', ["((year_of_publication >= ? AND year_of_publication <= ?) OR (year_of_publication = ?))", 1994, 1996, 1989]]
     ].each do |given_yop, expected|

--- a/spec/requests/api/sushi_spec.rb
+++ b/spec/requests/api/sushi_spec.rb
@@ -39,9 +39,10 @@ RSpec.describe 'api/sushi/r51', type: :request, singletenant: true do
     context 'with an invalid item_id parameter' do
       it 'returns a 422 status report for the given item' do
         get '/api/sushi/r51/reports/ir', params: { **required_parameters, item_id: 'qwerty123' }
-        expect(response).to have_http_status(404)
+        expect(response).to have_http_status(422)
         parsed_body = JSON.parse(response.body)
-        expect(parsed_body['error']).not_to be_nil
+
+        expect(parsed_body['Code']).to eq(3060)
       end
     end
   end


### PR DESCRIPTION
The [spec defines numerous exceptions][1].  This refactor moves towards
conforming to those specifications.

This change also builds on raising exceptions when data is not yet
ready.  To then guard against those exceptions, we need to either rescue
in the JSON document (which would be rather gross) or wrap the Sushi
methods with a guarding function.  I chose the latter.

See the inline comments for further discussion/documentation on these
changes.

Related to:

- https://github.com/scientist-softserv/palni-palci/issues/688

[1]: https://countermetrics.stoplight.io/docs/counter-sushi-api/sgmqulr0emsi6-exception
