### PR TITLE
Add data to OAI feed for format oai_hyku

### DIFF
--- a/lib/oai/provider/metadata_format/hyku_dublin_core.rb
+++ b/lib/oai/provider/metadata_format/hyku_dublin_core.rb
@@ -42,6 +42,7 @@ module OAI
               end
             end
             add_public_file_urls(xml, record)
+            add_thumbnail_url(xml, record)
           end
           xml.target!
         end
@@ -64,6 +65,12 @@ module OAI
             file_download_path = "https://#{Site.instance.account.cname}/downloads/#{fs_id_hash['id']}"
             xml.tag! 'file_url', file_download_path
           end
+        end
+
+        def add_thumbnail_url(xml, record)
+          return if record[:thumbnail_path_ss].blank?
+          thumbnail_url = "https://#{Site.instance.account.cname}#{record[:thumbnail_path_ss]}"
+          xml.tag! 'thumbnail_url', thumbnail_url
         end
 
         def header_specification

--- a/lib/oai/provider/metadata_format/hyku_dublin_core.rb
+++ b/lib/oai/provider/metadata_format/hyku_dublin_core.rb
@@ -13,7 +13,7 @@ module OAI
           # Dublin Core Terms Fields
           # For new fields, add here first then add to #map_oai_hyku
           @fields = %i[
-            identifier title abstract access_right accessibility_feature accessibility_hazard
+            identifier oai_id title abstract access_right accessibility_feature accessibility_hazard
             accessibility_summary additional_information advisor alternate_version_id alternative_title
             audience based_near bibliographic_citation committee_member contributor creator date_created
             degree_discipline degree_grantor degree_level degree_name department description discipline

--- a/lib/oai/provider/metadata_format/hyku_dublin_core.rb
+++ b/lib/oai/provider/metadata_format/hyku_dublin_core.rb
@@ -20,7 +20,7 @@ module OAI
             education_level extent format has_model keyword language learning_resource_type license
             newer_version_id oer_size previous_version_id publisher related_item_id related_url
             resource_type rights_holder rights_notes rights_statement source subject table_of_contents
-            contributing_library library_catalog_identifier chronology_note
+            contributing_library library_catalog_identifier chronology_note repository
           ]
         end
 

--- a/lib/oai/provider/model_decorator.rb
+++ b/lib/oai/provider/model_decorator.rb
@@ -48,6 +48,7 @@ module OAI
           publisher: :publisher,
           related_item_id: :related_item_id,
           related_url: :related_url,
+          repository: :account_cname,
           resource_type: :resource_type,
           rights_holder: :rights_holder,
           rights_notes: :rights_notes,

--- a/lib/oai/provider/model_decorator.rb
+++ b/lib/oai/provider/model_decorator.rb
@@ -44,6 +44,7 @@ module OAI
           license: :license,
           newer_version_id: :newer_version_id,
           oer_size: :oer_size,
+          oai_id: :id,
           previous_version_id: :previous_version_id,
           publisher: :publisher,
           related_item_id: :related_item_id,

--- a/spec/features/oai_pmh_spec.rb
+++ b/spec/features/oai_pmh_spec.rb
@@ -6,6 +6,12 @@ RSpec.describe "OAI PMH Support", type: :feature, cohort: 'alpha' do
   let(:identifier) { work.id }
 
   before do
+    # We use Site.instance.account.cname to build the download links.
+    # In the test ENV, Site.instance.account is nil.
+    account = Account.create(name: 'test', cname: 'test.example.com')
+    account.sites << Site.instance
+    account.save
+
     login_as(user, scope: :user)
     work
   end
@@ -59,14 +65,6 @@ RSpec.describe "OAI PMH Support", type: :feature, cohort: 'alpha' do
     describe '#add_public_file_urls' do
       let(:record) { { file_set_ids_ssim: ['my-file-set-id-1', 'my-file-set-id-2'] } }
       let(:xml) { Builder::XmlMarkup.new }
-
-      # We use Site.instance.account.cname to build the download links.
-      # In the test ENV, Site.instance.account is nil.
-      before do
-        account = Account.create(name: 'test', cname: 'test.example.com')
-        account.sites << Site.instance
-        account.save
-      end
 
       context 'when the work has public file sets' do
         before do


### PR DESCRIPTION
# Story
Note that these ONLY show on the oai_hyku format, because the requested terms are not valid terms for oai_dc.

Refs:
#737   - Uses term "repository" to display the account cname 
#736  - Uses term "oai_id" to display the identifier
#733  - Uses term "thumbnail_url" to display the thumbnail

# Expected Behavior Before Changes

# Expected Behavior After Changes

Adds 3 new terms to oai_hyku section of xml

# Screenshots / Video

<details>
<summary>OAI response</summary>

![Screenshot 2023-09-19 at 1 41 40 PM](https://github.com/scientist-softserv/palni-palci/assets/17851674/e97380f6-8ab1-4ee1-9eab-590534421f25)

</details>

# Notes
