### PR TITLE
🎁 Add ability to control homepage button colors

### DIFF
--- a/app/forms/hyrax/forms/admin/appearance.rb
+++ b/app/forms/hyrax/forms/admin/appearance.rb
@@ -27,6 +27,7 @@ module Hyrax
           'header_and_footer_background_color' => '#3c3c3c',
           'header_and_footer_text_color'       => '#dcdcdc',
           'navbar_background_color'            => '#000000',
+          'navbar_link_background_color'       => '#375f8c',
           'navbar_link_background_hover_color' => '#ffffff',
           'navbar_link_text_color'             => '#eeeeee',
           'navbar_link_text_hover_color'       => '#eeeeee',
@@ -143,6 +144,14 @@ module Hyrax
 
         def navbar_background_color_active
           darken_color(navbar_background_color, 0.35)
+        end
+
+        def navbar_link_background_color
+          block_for('navbar_link_background_color')
+        end
+
+        def navbar_link_background_color_active
+          darken_color(navbar_link_background_color, 0.35)
         end
 
         def navbar_link_background_hover_color
@@ -388,6 +397,7 @@ module Hyrax
             facet_panel_background_color
             facet_panel_text_color
             navbar_background_color
+            navbar_link_background_color
             navbar_link_background_hover_color
             navbar_link_text_color
             navbar_link_text_hover_color

--- a/app/views/shared/_appearance_styles.html.erb
+++ b/app/views/shared/_appearance_styles.html.erb
@@ -43,7 +43,13 @@ body.public-facing .image-masthead .navbar .active > a:focus {
     background-color: <%= appearance.navbar_background_color_active %>;
     color: <%= appearance.navbar_link_text_color %>;
 }
+
+body.public-facing .image-masthead .navbar .navbar-nav li.active a {
+    background-color: <%= appearance.navbar_link_background_color_active %>;
+}
+
 body.public-facing .image-masthead .navbar .navbar-nav a {
+    background-color: <%= appearance.navbar_link_background_color %>;
     color: <%= appearance.navbar_link_text_color %>;
 }
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -217,6 +217,8 @@ de:
               hint: Um ein Bild als Logo zu verwenden, sollten Sie ein Bild (JPG, GIF oder PNG) verwenden, das nicht höher als der Header und nicht breiter als 400 Pixel ist.
             navbar_background_color:
               hint: Bei 40 % Deckkraft.
+            navbar_link_background_color:
+              hint: Gilt für die Hintergrundfarbe der Schaltflächen „Startseite“, „Info“, „Kontakt“ und „Hilfe“.
             navbar_link_background_hover_color:
               hint: Gilt nur für die Schaltflächen „Startseite“, „Info“, „Kontakt“ und „Hilfe“ auf diesen spezifischen Seiten (bei 15 % Deckkraft).
             primary_button_hover_color:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -214,6 +214,8 @@ en:
               hint: "Favicons need to be png files and must be square. The max size used is 228px x 228px."
             navbar_background_color:
               hint: 'At 40% opacity.'
+            navbar_link_background_color:
+              hint: 'Applies to the Home, About, Contact and Help button background color'
             navbar_link_background_hover_color:
               hint: 'Applies to the Home, About, Contact and Help buttons on those specific pages only (at 15% opacity).'
             link_color:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -218,6 +218,8 @@ es:
               hint: Para usar una imagen como logotipo, debe usar una imagen (JPG, GIF o PNG) que no sea más alta que el encabezado ni más ancha que 400 píxeles de ancho.
             navbar_background_color:
               hint: Al 40% de opacidad.
+            navbar_link_background_color:
+              hint: Se aplica al color de fondo de los botones Inicio, Acerca de, Contacto y Ayuda.
             navbar_link_background_hover_color:
               hint: Se aplica a los botones Inicio, Acerca de, Contacto y Ayuda solo en esas páginas específicas (al 15 % de opacidad).
             primary_button_hover_color:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -218,6 +218,8 @@ fr:
               hint: Pour utiliser une image comme logo, vous devez utiliser une image (JPG, GIF ou PNG) qui n'est pas plus haute que l'en-tête et pas plus large que 400 pixels de large.
             navbar_background_color:
               hint: À 40% d'opacité.
+            navbar_link_background_color:
+              hint: S'applique à la couleur d'arrière-plan des boutons Accueil, À propos, Contact et Aide.
             navbar_link_background_hover_color:
               hint: S'applique aux boutons Accueil, À propos, Contact et Aide de ces pages spécifiques uniquement (à 15 % d'opacité).
             primary_button_hover_color:

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -218,6 +218,8 @@ it:
               hint: Per utilizzare un'immagine come logo, è necessario utilizzare un'immagine (JPG, GIF o PNG) non più alta dell'intestazione e non più larga di 400 pixel.
             navbar_background_color:
               hint: Al 40% di opacità.
+            navbar_link_background_color:
+              hint: Si applica al colore di sfondo dei pulsanti Home, Informazioni, Contatti e Guida
             navbar_link_background_hover_color:
               hint: Si applica ai pulsanti Home, Informazioni, Contatti e Guida solo su quelle pagine specifiche (con un'opacità del 15%).
             primary_button_hover_color:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -218,6 +218,8 @@ pt-BR:
               hint: Para usar uma imagem como logotipo, use uma imagem (JPG, GIF ou PNG) que não seja mais alta que o cabeçalho e que não tenha mais que 400 pixels de largura.
             navbar_background_color:
               hint: Com 40% de opacidade.
+            navbar_link_background_color:
+              hint: Aplica-se à cor de fundo dos botões Página inicial, Sobre, Contato e Ajuda
             navbar_link_background_hover_color:
               hint: Aplica-se apenas aos botões Início, Sobre, Contato e Ajuda nessas páginas específicas (com 15% de opacidade).
             primary_button_hover_color:

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -218,6 +218,8 @@ zh:
               hint: 要将图像用作徽标，应使用不大于标题且宽度不超过400像素的图像（JPG，GIF或PNG）。
             navbar_background_color:
               hint: 不透明度为 40%。
+            navbar_link_background_color:
+              hint: 适用于“主页”、“关于”、“联系人”和“帮助”按钮背景颜色
             navbar_link_background_hover_color:
               hint: 仅适用于这些特定页面上的“主页”、“关于”、“联系方式”和“帮助”按钮（不透明度为 15%）。
             primary_button_hover_color:


### PR DESCRIPTION
# Story

This commit will add the ability to control the color of the homepage buttons from:

  Dashboard > Appearance > Colors > Navbar link background color

Ref:
  - https://github.com/scientist-softserv/palni-palci/issues/742

# Expected Behavior Before Changes

The background color of the homepage links was not customizable.

# Expected Behavior After Changes

Added new option to customize the background color of the homepage links.

# Screenshots / Video

<img width="1485" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/19597776/87ebfd9c-8c34-4f04-94f9-ae61f2134b41">

<img width="571" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/19597776/cc59d0aa-d779-436d-8ff0-a2c3ba47ce32">
