### PR TITLE
🐛 Ensure filter date range honored

### DIFF
--- a/app/models/sushi/item_report.rb
+++ b/app/models/sushi/item_report.rb
@@ -136,8 +136,8 @@ module Sushi
                            -- We need to coerce the month from a single digit to two digits (e.g. August's "8" into "08")
                            CONCAT(DATE_PART('year', date_trunc('month', date)), '-', to_char(DATE_PART('month', date_trunc('month', date)), 'fm00')) AS year_month
                            FROM hyrax_counter_metrics AS aggr
-                           WHERE  aggr.work_id = hyrax_counter_metrics.work_id
-    	               GROUP BY date_trunc('month', date)) t) as performance))
+                           WHERE #{Hyrax::CounterMetric.sanitize_sql_for_conditions(['aggr.work_id = hyrax_counter_metrics.work_id AND date >= ? AND date <= ?', begin_date, end_date])}
+        	           GROUP BY date_trunc('month', date)) t) as performance))
                  .where("date >= ? AND date <= ?", begin_date, end_date)
                  .order(resource_type: :asc, work_id: :asc)
                  .group(:work_id, :resource_type, :worktype, :author)

--- a/app/models/sushi/platform_report.rb
+++ b/app/models/sushi/platform_report.rb
@@ -140,6 +140,7 @@ module Sushi
     #       month).
     # also, note that unique_item_requests and unique_item_investigations should be counted for Hyrax::CounterMetrics that have unique dates, and unique work IDs.
     # see the docs for counting unique items here: https://cop5.projectcounter.org/en/5.1/07-processing/03-counting-unique-items.html
+    # rubocop:disable Metrics/LineLength
     def data_for_resource_types
       # We're capturing this relation/query because in some cases, we need to chain another where
       # clause onto the relation.
@@ -156,16 +157,16 @@ module Sushi
                            -- We need to coerce the month from a single digit to two digits (e.g. August's "8" into "08")
                            CONCAT(DATE_PART('year', date_trunc('month', date)), '-', to_char(DATE_PART('month', date_trunc('month', date)), 'fm00')) AS year_month
                            FROM hyrax_counter_metrics AS aggr
-                           WHERE  aggr.resource_type = hyrax_counter_metrics.resource_type
+                           WHERE #{Hyrax::CounterMetric.sanitize_sql_for_conditions(['aggr.resource_type = hyrax_counter_metrics.resource_type AND date >= ? AND date <= ?', begin_date, end_date])}
 	               GROUP BY date_trunc('month', date)) t) as performance))
                  .where("date >= ? AND date <= ?", begin_date, end_date)
                  .order(resource_type: :asc)
                  .group(:resource_type, :worktype)
-
       return relation if data_types.blank?
 
       relation.where("LOWER(resource_type) IN (?)", data_types)
     end
+    # rubocop:enable Metrics/LineLength
 
     def data_for_platform
       Hyrax::CounterMetric

--- a/app/models/sushi/platform_usage_report.rb
+++ b/app/models/sushi/platform_usage_report.rb
@@ -91,6 +91,7 @@ module Sushi
     #       For example, if we had "2023-01-03T13:14" and asked for the date_trunc of month, the
     #       query result value would be "2023-01-01T00:00" (e.g. the first moment of the first of the
     #       month).
+    # rubocop:disable Metrics/LineLength
     def data_for_resource_types
       # We're capturing this relation/query because in some cases, we need to chain another where
       # clause onto the relation.
@@ -107,7 +108,7 @@ module Sushi
                            -- We need to coerce the month from a single digit to two digits (e.g. August's "8" into "08")
                            CONCAT(DATE_PART('year', date_trunc('month', date)), '-', to_char(DATE_PART('month', date_trunc('month', date)), 'fm00')) AS year_month
                            FROM hyrax_counter_metrics AS aggr
-                           WHERE  aggr.resource_type = hyrax_counter_metrics.resource_type
+                           WHERE #{Hyrax::CounterMetric.sanitize_sql_for_conditions(['aggr.resource_type = hyrax_counter_metrics.resource_type AND date >= ? AND date <= ?', begin_date, end_date])}
 	               GROUP BY date_trunc('month', date)) t) as performance))
                  .where("date >= ? AND date <= ?", begin_date, end_date)
                  .order(resource_type: :asc)
@@ -117,6 +118,7 @@ module Sushi
 
       relation.where("LOWER(resource_type) IN (?)", data_types)
     end
+    # rubocop:enable Metrics/LineLength
 
     def data_for_platform
       Hyrax::CounterMetric

--- a/spec/models/sushi/platform_report_spec.rb
+++ b/spec/models/sushi/platform_report_spec.rb
@@ -28,6 +28,8 @@ RSpec.describe Sushi::PlatformReport do
         expect(subject.dig('Report_Items', 'Attribute_Performance').first.dig('Performance', 'Unique_Item_Investigations', '2022-01')).to eq(3)
         expect(subject.dig('Report_Items', 'Attribute_Performance').first.dig('Performance', 'Unique_Item_Requests', '2022-01')).to eq(3)
         expect(subject.dig('Report_Items', 'Attribute_Performance').find { |o| o["Data_Type"] == "Platform" }.dig('Performance', 'Searches_Platform', '2022-01')).to eq(6)
+        # It should not include that 2021 data.
+        expect(subject.dig('Report_Items', 'Attribute_Performance', 0, 'Performance', 'Total_Item_Investigations')).to eq("2022-01" => 6)
       end
     end
 


### PR DESCRIPTION
Prior to this commit, the inner logic that built the array of data was
not using the begin and end date filter.

With this commit, those sub-queries are all limiting the queries to
those that are within the given date range.

Related to:

- https://github.com/scientist-softserv/palni-palci/issues/687
