### PR TITLE
Use Application Name for repository

### DIFF
--- a/lib/oai/provider/metadata_format/hyku_dublin_core.rb
+++ b/lib/oai/provider/metadata_format/hyku_dublin_core.rb
@@ -20,7 +20,7 @@ module OAI
             education_level extent format has_model keyword language learning_resource_type license
             newer_version_id oer_size previous_version_id publisher related_item_id related_url
             resource_type rights_holder rights_notes rights_statement source subject table_of_contents
-            contributing_library library_catalog_identifier chronology_note repository
+            contributing_library library_catalog_identifier chronology_note
           ]
         end
 
@@ -41,6 +41,7 @@ module OAI
                 xml.tag! field.to_s, values
               end
             end
+            add_repository(xml, record)
             add_public_file_urls(xml, record)
             add_thumbnail_url(xml, record)
           end
@@ -71,6 +72,11 @@ module OAI
           return if record[:thumbnail_path_ss].blank?
           thumbnail_url = "https://#{Site.instance.account.cname}#{record[:thumbnail_path_ss]}"
           xml.tag! 'thumbnail_url', thumbnail_url
+        end
+
+        def add_repository(xml, record)
+          repo_name = Site.application_name || record[:account_cname_tesim].first
+          xml.tag! 'repository', repo_name
         end
 
         def header_specification

--- a/lib/oai/provider/model_decorator.rb
+++ b/lib/oai/provider/model_decorator.rb
@@ -49,7 +49,6 @@ module OAI
           publisher: :publisher,
           related_item_id: :related_item_id,
           related_url: :related_url,
-          repository: :account_cname,
           resource_type: :resource_type,
           rights_holder: :rights_holder,
           rights_notes: :rights_notes,


### PR DESCRIPTION
# Story

Default to account cname if Application Name label is not filled.
Refs https://github.com/scientist-softserv/palni-palci/issues/810

# Expected Behavior Before Changes

Repository value in OAI shows account tenant url.

# Expected Behavior After Changes

Repository value in OAI shows Application Name label if one is filled in, but otherwise defaults to account tenant url.

# Screenshots / Video

<details>
<summary>OAI getRecord</summary>

**Before:**
![Screenshot 2023-09-21 at 3 41 06 PM](https://github.com/scientist-softserv/palni-palci/assets/17851674/0b36c6d3-158d-4ef4-a7f1-77e2f504b27f)

**After:**
![Screenshot 2023-09-21 at 3 58 03 PM](https://github.com/scientist-softserv/palni-palci/assets/17851674/0d9653cf-db85-4a30-8515-a47c3dc5461e)

</details>

# Notes
