### PR TITLE
:bug: Remove bulkrax options from partials

### DIFF
--- a/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
@@ -13,14 +13,4 @@
   <span class="fa fa-file" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.works') %></span>
 <% end %>
 
-<% if ENV.fetch('HYKU_BULKRAX_ENABLED', 'true') == 'true' %>
-  <%= menu.nav_link(bulkrax.importers_path) do %>
-    <span class="fa fa-cloud-upload" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('bulkrax.admin.sidebar.importers') %></span>
-  <% end %>
-
-  <%= menu.nav_link(bulkrax.exporters_path) do %>
-    <span class="fa fa-cloud-download" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('bulkrax.admin.sidebar.exporters') %></span>
-  <% end %>
-<% end %>
-
 <%= render 'hyrax/dashboard/sidebar/menu_partials', menu: menu, section: :repository_content %>


### PR DESCRIPTION
The client reported double rendering of importer and exporter buttons. This is happening because we have the buttons rendering from a partial within PALS && bulkrax. This PR removes the code from the app since we're using the bulkrax gem and we know that bulkrax is enabled for this client. 

I am treating this as a hot fix. I realize I am not taking the time to understand WHY this is suddenly happening, since this code was introduced 4 years ago.

Issue:
- https://github.com/scientist-softserv/palni-palci/issues/767

# Story

Refs #767 

![image](https://github.com/scientist-softserv/palni-palci/assets/10081604/f50336e6-dbb7-47ca-b768-9ee08af439e4)

# Expected Behavior Before Changes

![image](https://github.com/scientist-softserv/palni-palci/assets/10081604/66314397-54af-4826-ac76-dcc10b8a186d)


# Expected Behavior After Changes

<img width="1339" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/10081604/b58d54b2-ba62-437e-bdee-ab8ab051a899">


