### PR TITLE
🐛 Bring back missing download link on pdf

### DIFF
--- a/app/views/hyrax/file_sets/media_display/_pdf.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_pdf.html.erb
@@ -6,6 +6,13 @@
                     class: "representative-media",
                     alt: "",
                     role: "presentation" %>
+      <% if controller_name == 'file_sets' %>
+        <%= link_to t('hyrax.file_set.show.downloadable_content.pdf_link'),
+              hyrax.download_path(file_set),
+              target: :_blank,
+              id: "file_download",
+              data: { label: file_set.id } %>
+      <% end %>
     </div>
 <% else %>
     <div>


### PR DESCRIPTION
This commit will fix a bug where the Download PDF link was erroneously removed in a previous commit.  It was originally removed because it was rendering on the work show page but in doing so it was also removed from the file set show page.  We now bring it back with a conditional that only renders it on the file set show page.

Ref
  - https://github.com/scientist-softserv/palni-palci/issues/814
  - https://github.com/scientist-softserv/palni-palci/pull/788

<img width="720" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/19597776/649a0f56-c56c-4e93-85df-6684a7a5190e">
