### PR TITLE
🐛 Handle `nil` passing to Markdown

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -38,6 +38,7 @@ module ApplicationHelper
       disable_indented_code_blocks strikethrough lax_spacing space_after_headers
       quote footnotes highlight underline
     ]
+    text ||= ""
     Markdown.new(text, *options).to_html.html_safe
   end
 end

--- a/app/views/hyrax/file_sets/media_display/_pdf.html.erb
+++ b/app/views/hyrax/file_sets/media_display/_pdf.html.erb
@@ -6,6 +6,13 @@
                     class: "representative-media",
                     alt: "",
                     role: "presentation" %>
+      <% if controller_name == 'file_sets' %>
+        <%= link_to t('hyrax.file_set.show.downloadable_content.pdf_link'),
+              hyrax.download_path(file_set),
+              target: :_blank,
+              id: "file_download",
+              data: { label: file_set.id } %>
+      <% end %>
     </div>
 <% else %>
     <div>


### PR DESCRIPTION
This commit will fix a bug relating to the ocr snippets.  Because we are using the the `markdown` helper, we need to make sure we are  not passing `nil` to it otherwise it'll break.  We are getting nil because we don't find any snippets and IIIF Print would return a nil so we don't display empty quotes on the search page.
