### PR TITLE
🐛 Fix the rake task's reindex jobs

### DIFF
--- a/app/jobs/reindex_collections_job.rb
+++ b/app/jobs/reindex_collections_job.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 class ReindexCollectionsJob < ApplicationJob
-  def perform
-    Collection.find_each do |collection|
-      collection.try(:reindex_extent=, Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX)
+  def perform(collection = nil)
+    if collection.present?
       collection.update_index
+    else
+      Collection.find_each do |collection|
+        collection.try(:reindex_extent=, Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX)
+        collection.update_index
+      end
     end
   end
 end

--- a/app/jobs/reindex_works_job.rb
+++ b/app/jobs/reindex_works_job.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
 class ReindexWorksJob < ApplicationJob
-  def perform
-    Hyrax.config.registered_curation_concern_types.each do |work_type|
-      work_type.constantize.find_each(&:update_index)
+  def perform(work = nil)
+    if work.present?
+      work.update_index
+    else
+      Hyrax.config.registered_curation_concern_types.each do |work_type|
+        work_type.constantize.find_each(&:update_index)
+      end
     end
   end
 end


### PR DESCRIPTION
This commit will bring back a change to `ReindexWorksJob` and `ReindexCollectionsJob` because the rake task is calling them with an argument while the jobs' parameters were removed.

Ref:
  - https://github.com/scientist-softserv/palni-palci/commit/4285d0f4e2bd758562979730b29a1fa3b7a253e2
