### PR TITLE
🐛 Raise 3060 Sushi Exception if | provide for author field

### DIFF
--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -367,6 +367,9 @@ module Sushi
       return true unless params.key?(:author)
       @author = params[:author]
 
+      # See https://github.com/scientist-softserv/palni-palci/issues/721#issuecomment-1734215004 for details of this little nuance
+      raise Sushi::Error::InvalidReportFilterValueError.new(data: "You may not query for multiple authors (as specified by the `#{DELIMITER}' delimiter.") if @author.include?(DELIMITER)
+
       # rubocop:disable Metrics/LineLength
       raise Sushi::Error::InvalidReportFilterValueError.new(data: "The given author #{author.inspect} was not found in the metrics.") unless Hyrax::CounterMetric.where(author_as_where_parameters).exists?
       # rubocop:enable Metrics/LineLength

--- a/spec/models/sushi_spec.rb
+++ b/spec/models/sushi_spec.rb
@@ -184,6 +184,21 @@ RSpec.describe Sushi do
         end
       end
     end
+
+    describe '#coerce_author' do
+      let(:klass) do
+        Class.new do
+          include Sushi::AuthorCoercion
+          def initialize(params = {})
+            coerce_author(params)
+          end
+        end
+      end
+
+      it "raises a 3060 error when given a #{Sushi::AuthorCoercion::DELIMITER} character" do
+        expect { klass.new(author: "Hello#{Sushi::AuthorCoercion::DELIMITER}World") }.to raise_error(Sushi::Error::InvalidReportFilterValueError)
+      end
+    end
   end
 
   describe "YearOfPublicationCoercion" do


### PR DESCRIPTION
According to the Sushi spec, the [Item Report][1] does not account for multiple authors.

> Identifier of a specific author usage is being requested for. If
> omitted, all items on the platform with usage for the customer will be
> returned.

Later, for `yop` there is language about how to encode multiple values.

Which, I believe means that if we include a `|` in the author we should
return a 3060.  So I'll set about working on that.  (That does assume a
person does not have a `|` in their name).  Note, the data encoding
we're doing is to have pipe separation of multiple authors in the
database.  The record you're seeing has `|Summer|Winter|` for a
multi-author file.  And there's a direct match.

Related to:

- https://github.com/scientist-softserv/palni-palci/issues/721

[1]: https://countermetrics.stoplight.io/docs/counter-sushi-api/5a6e9f5ddae3e-ir-item-report