### PR TITLE
🐛 Render description in scholarly theme

### DIFF
--- a/app/views/themes/scholarly_show/hyrax/base/show.html.erb
+++ b/app/views/themes/scholarly_show/hyrax/base/show.html.erb
@@ -29,6 +29,11 @@
             <div class="col-sm-12">
               <%= render 'pdf_js', file_set_presenter: @presenter.file_set_presenters.first %>
             </div>
+            <div class="col-sm-12">
+              <div class="image-show-description">
+                <%= render 'work_description', presenter: @presenter %>
+              </div>
+            </div>
           <% else %>
             <div class="col-sm-3 mb-1">
               <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.iiif_viewer? && @presenter.file_set_presenters.any?(&:pdf?) %>


### PR DESCRIPTION
The description was not being rendered in the scholarly theme. This commit will bring that logic in.

# Story

ref #823 

# Screenshots / Video

Before:
<img width="1317" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/19597776/99de5b32-3d20-40ed-b8d3-96b05d7c56fd">

After:
<img width="1273" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/19597776/ead3e9ea-80fc-410a-8b4c-7bd251c221a1">
