### PR TITLE
Remove button links on ReShare Theme

### DIFF
--- a/app/views/themes/reshare_show/hyrax/base/show.html.erb
+++ b/app/views/themes/reshare_show/hyrax/base/show.html.erb
@@ -21,16 +21,11 @@
           </div>
         </div>
         <div class="row py-4">
-          <div class="col-xs-12 col-sm-7">
+          <div class="col-xs-12">
             <%= render 'work_description', presenter: @presenter %>
             <dl class="work-show <%= dom_class(@presenter) %> mb-0" <%= @presenter.microdata_type_to_html %>>
               <%= render 'attribute_rows', presenter: @presenter %>
             </dl>
-          </div>
-          <div class='col-xs-12 col-sm-5'>
-            <button class='btn btn-default d-block ml-auto'>
-              See Additional Info on ReShare <%= "\u25B8" %>
-            </button>
           </div>
         </div>
       </div>
@@ -38,6 +33,4 @@
     <span class='hide analytics-event' data-category="work" data-action="work-view" data-name="<%= @presenter.id %>" >
   </div>
 </div>
-<button class='btn btn-default mb-5'>
-  <%= "\u25C2" %> Back to ReShare Search
-</button>
+


### PR DESCRIPTION
# Story

Refs #601

# Expected Behavior Before Changes
Buttons linking back to Reshare appeared in ReShare show page theme
# Expected Behavior After Changes
Buttons linnking back to ReShare on the ReShare show page theme are no longer there

# Screenshots / Video

<details>

<img width="900" alt="Screenshot 2023-09-26 at 2 51 45 PM" src="https://github.com/scientist-softserv/palni-palci/assets/18175797/ebb5f802-3f64-4eec-b6d6-9ceecb2cfaee">

</details>

# Notes
