### PR TITLE
721-missing-parens

### DIFF
--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -385,7 +385,7 @@ module Sushi
       @author = params[:author]
 
       # See https://github.com/scientist-softserv/palni-palci/issues/721#issuecomment-1734215004 for details of this little nuance
-      raise Sushi::Error::InvalidReportFilterValueError.new(data: "You may not query for multiple authors (as specified by the `#{DELIMITER}' delimiter.") if @author.include?(DELIMITER)
+      raise Sushi::Error::InvalidReportFilterValueError.new(data: "You may not query for multiple authors (as specified by the `#{DELIMITER}' delimiter.)") if @author.include?(DELIMITER)
 
       # rubocop:disable Metrics/LineLength
       raise Sushi::Error::InvalidReportFilterValueError.new(data: "The given author #{author.inspect} was not found in the metrics.") unless Hyrax::CounterMetric.where(author_as_where_parameters).exists?


### PR DESCRIPTION
# Story
add the closing parens to the message given to the
`Sushi::Error::InvalidReportFilterValueError` exception.

- https://github.com/scientist-softserv/palni-palci/issues/721#issuecomment-1736156017

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes
