### PR TITLE
searches_platform sushi filter

### DIFF
--- a/app/models/sushi/platform_report.rb
+++ b/app/models/sushi/platform_report.rb
@@ -29,6 +29,7 @@ module Sushi
     ].freeze
 
     ALLOWED_METRIC_TYPES = [
+      "Searches_Platform",
       "Total_Item_Investigations",
       "Total_Item_Requests",
       "Unique_Item_Investigations",
@@ -115,6 +116,8 @@ module Sushi
     alias to_hash as_json
 
     def attribute_performance_for_resource_types
+      return [] if metric_type_in_params && metric_types.include?("Searches_Platform")
+
       data_for_resource_types.map do |record|
         {
           "Data_Type" => record.resource_type,
@@ -125,6 +128,8 @@ module Sushi
     end
 
     def attribute_performance_for_platform
+      return [] if metric_type_in_params && metric_types.exclude?("Searches_Platform")
+
       [{
         "Data_Type" => "Platform",
         "Access_Method" => "Regular",
@@ -144,6 +149,8 @@ module Sushi
 
     def performance(record)
       metric_types.each_with_object({}) do |metric_type, returning_hash|
+        next if metric_type == "Searches_Platform"
+
         returning_hash[metric_type] =
           if granularity == 'Totals'
             { "Totals" => record.performance.sum { |hash| hash.fetch(metric_type) } }

--- a/app/models/sushi/platform_usage_report.rb
+++ b/app/models/sushi/platform_usage_report.rb
@@ -12,6 +12,13 @@ module Sushi
     include Sushi::MetricTypeCoercion
     include Sushi::ParameterValidation
 
+    # the platform usage report only contains requests. see https://countermetrics.stoplight.io/docs/counter-sushi-api/mgu8ibcbgrwe0-pr-p1-performance-other for details
+    ALLOWED_METRIC_TYPES = [
+      "Searches_Platform",
+      "Total_Item_Requests",
+      "Unique_Item_Requests",
+    ].freeze
+
     ALLOWED_PARAMETERS = [
       'access_method',
       'api_key',
@@ -32,9 +39,6 @@ module Sushi
       @created = created
       @account = account
     end
-
-    # the platform usage report only contains requests. see https://countermetrics.stoplight.io/docs/counter-sushi-api/mgu8ibcbgrwe0-pr-p1-performance-other for details
-    ALLOWED_METRIC_TYPES = ["Unique_Item_Requests", "Total_Item_Requests"].freeze
 
     def as_json(_options = {})
       report_hash = {
@@ -67,6 +71,8 @@ module Sushi
     alias to_hash as_json
 
     def attribute_performance_for_resource_types
+      return [] if metric_type_in_params && metric_types.include?("Searches_Platform")
+
       data_for_resource_types.map do |record|
         {
           "Data_Type" => record.resource_type,
@@ -78,6 +84,8 @@ module Sushi
 
     def performance(record)
       metric_types.each_with_object({}) do |metric_type, returning_hash|
+        next if metric_type == "Searches_Platform"
+
         returning_hash[metric_type] = record.performance.each_with_object({}) do |cell, hash|
           hash[cell.fetch('year_month')] = cell.fetch(metric_type)
         end
@@ -85,6 +93,8 @@ module Sushi
     end
 
     def attribute_performance_for_platform
+      return [] if metric_type_in_params && metric_types.exclude?("Searches_Platform")
+
       [{
         "Data_Type" => "Platform",
         "Access_Method" => "Regular",

--- a/app/models/sushi/platform_usage_report.rb
+++ b/app/models/sushi/platform_usage_report.rb
@@ -16,7 +16,7 @@ module Sushi
     ALLOWED_METRIC_TYPES = [
       "Searches_Platform",
       "Total_Item_Requests",
-      "Unique_Item_Requests",
+      "Unique_Item_Requests"
     ].freeze
 
     ALLOWED_PARAMETERS = [


### PR DESCRIPTION
# Story
update filter handling for the platform and platform usage reports

`Searches_Platform` is a valid metric_type filter according to
https://countermetrics.stoplight.io/docs/counter-sushi-api/3wikuuhv4hnbv-pr-report-filters and https://countermetrics.stoplight.io/docs/counter-sushi-api/xggfvq5by3gx0-pr-p1-report-filters.

- https://github.com/scientist-softserv/palni-palci/issues/686#issuecomment-1707261846
- https://github.com/scientist-softserv/palni-palci/issues/687#issuecomment-1736117022

# Expected Behavior Before Changes
we were always returning `Searches_Platform`, despite whether a `metric_type` filter was being used.

# Expected Behavior After Changes
we only return `Searches_Platform` if the `metric_type` param includes it, or is not being passed at all.

# Screenshots / Video

<details>
<summary>platform report</summary>

**no `metric_type` param**
![Screenshot 2023-09-27 at 12 58 14 PM](https://github.com/scientist-softserv/palni-palci/assets/29032869/f66bb027-11dd-436f-aa4a-68d038acc6c2)

**with `metric_type=searches_platform` param**
![Screenshot 2023-09-27 at 12 42 59 PM](https://github.com/scientist-softserv/palni-palci/assets/29032869/7f0ab2a2-6f68-484c-9ab3-9b89295dd22e)

**with `metric_type=xxx` param**
![Screenshot 2023-09-27 at 12 43 30 PM](https://github.com/scientist-softserv/palni-palci/assets/29032869/53f056a4-d264-4f50-89a2-d09e8d7e0fc5)

</details>

<details>
<summary>platform usage report</summary>

**no `metric_type` param**
![Screenshot 2023-09-27 at 1 13 56 PM](https://github.com/scientist-softserv/palni-palci/assets/29032869/2b1b7ae3-b1b2-4375-84dc-a47f906ceef0)

**with `metric_type=searches_platform` param**
![image](https://github.com/scientist-softserv/palni-palci/assets/29032869/32aed5e6-e236-4b75-87da-7e9cfe513e70)

**with `metric_type=xxx` param**
![image](https://github.com/scientist-softserv/palni-palci/assets/29032869/d982997f-160b-4162-b444-fbccfc96e6e6)

</details>

# Notes
