### PR TITLE
687-platform-usage-updates

### DIFF
--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal:true
 
 module Sushi
+  mattr_accessor :info
+
   class << self
     ##
     # @param dates [Array<String>]
@@ -15,7 +17,12 @@ module Sushi
     #       params.fetch(:begin_date).to_date => Wed, 06 Sep 2023
     def validate_date_format(dates = [])
       dates.each do |date|
-        raise Sushi::Error::InvalidDateArgumentError.new(data: "The given date of \"#{date}\" is invalid. Please provide a date in YYYY-MM format") unless date.match(/(^\d{4}-\d{2}$)|(^\d{4}-\d{2}-\d{2}$)/)
+        match = date.match(/(^\d{4}-\d{2}$)|(^\d{4}-\d{2}-\d{2}$)/)
+        raise Sushi::Error::InvalidDateArgumentError.new(data: "The given date of \"#{date}\" is invalid. Please provide a date in YYYY-MM format") unless match
+
+        # rubocop:disable Metrics/LineLength
+        info << Sushi::Info.new(data: date.to_s, message: "The day of the month is not taken into consideration when providing metrics. The date provided was amended to account for the full month.").as_json if match[2]
+        # rubocop:enable Metrics/LineLength
       end
 
       true

--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -3,6 +3,25 @@
 module Sushi
   class << self
     ##
+    # @param dates [Array<String>]
+    # @raise [Sushi::InvalidParameterValue] when either of the given dates are not formatted correctly.
+    #
+    # @return [TrueClass]
+    #
+    # @note This is necessary because calling `to_date` on a string in 'MM-YYYY' format will assume that 'MM' is the day,
+    #       and will set the current month as 'MM' instead.
+    #
+    #       params.fetch(:begin_date) => "06-2023"
+    #       params.fetch(:begin_date).to_date => Wed, 06 Sep 2023
+    def validate_date_format(dates = [])
+      dates.each do |date|
+        raise Sushi::Error::InvalidDateArgumentError.new(data: "The given date of \"#{date}\" is invalid. Please provide a date in YYYY-MM format") unless date.match(/(^\d{4}-\d{2}$)|(^\d{4}-\d{2}-\d{2}$)/)
+      end
+
+      true
+    end
+
+    ##
     # @param value [String, #to_date]
     #
     # @return [Date]
@@ -154,7 +173,9 @@ module Sushi
     #        begin date is not given.
     def coerce_dates(params = {})
       # TODO: We should also be considering available dates as well.
-      #
+
+      Sushi.validate_date_format([params.fetch(:begin_date), params.fetch(:end_date)])
+
       # Because we're receiving user input that is likely strings, we need to do some coercion.
       @begin_date = Sushi.coerce_to_date(params.fetch(:begin_date)).beginning_of_month
       @end_date = Sushi.coerce_to_date(params.fetch(:end_date)).end_of_month

--- a/app/models/sushi/error.rb
+++ b/app/models/sushi/error.rb
@@ -99,4 +99,25 @@ module Sushi
       end
     end
   end
+
+  ##
+  # The Info exception differs from the Error exception in that it is returned in the Report_Header.
+  # The message nor data are standarized, and therefore are being required to be passed in.
+  class Info
+    attr_reader :data, :message
+
+    def initialize(data:, message:)
+      @data = data
+      @message = message
+    end
+
+    def as_json(*)
+      {
+        Code: 0,
+        Message: message,
+        Help_URL: "https://countermetrics.stoplight.io/docs/counter-sushi-api/jmelferytrixm-exception-0",
+        Data: data
+      }
+    end
+  end
 end

--- a/app/models/sushi/item_report.rb
+++ b/app/models/sushi/item_report.rb
@@ -8,6 +8,7 @@
 module Sushi
   class ItemReport
     attr_reader :account, :attributes_to_show, :created
+    include Sushi
     include Sushi::AccessMethodCoercion
     include Sushi::AuthorCoercion
     include Sushi::DateCoercion
@@ -62,6 +63,7 @@ module Sushi
     ].freeze
 
     def initialize(params = {}, created: Time.zone.now, account:)
+      Sushi.info = []
       validate_paramaters(params, allowed_parameters: ALLOWED_PARAMETERS)
       coerce_access_method(params)
       coerce_author(params)
@@ -110,6 +112,7 @@ module Sushi
       report_hash['Report_Header']['Report_Filters']['Metric_Type'] = metric_types if metric_type_in_params
       report_hash['Report_Header']['Report_Filters']['Platform'] = platform if platform_in_params
       report_hash['Report_Header']['Report_Filters']['YOP'] = yop if yop
+      report_hash["Report_Header"]["Exceptions"] = info if info.present?
 
       report_hash
     end

--- a/app/models/sushi/platform_report.rb
+++ b/app/models/sushi/platform_report.rb
@@ -8,6 +8,7 @@
 module Sushi
   class PlatformReport
     attr_reader :created, :account, :attributes_to_show
+    include Sushi
     include Sushi::AccessMethodCoercion
     include Sushi::DataTypeCoercion
     include Sushi::DateCoercion
@@ -65,6 +66,7 @@ module Sushi
     ].freeze
 
     def initialize(params = {}, created: Time.zone.now, account:)
+      Sushi.info = []
       validate_paramaters(params, allowed_parameters: ALLOWED_PARAMETERS)
       coerce_access_method(params)
       coerce_data_types(params)
@@ -110,6 +112,8 @@ module Sushi
       report_hash["Report_Header"]["Report_Attributes"]["Granularity"] = granularity if granularity_in_params
       report_hash["Report_Header"]["Report_Filters"]["Metric_Type"] = metric_types if metric_type_in_params
       report_hash["Report_Header"]["Report_Filters"]["Platform"] = platform if platform_in_params
+      report_hash["Report_Header"]["Exceptions"] = info if info.present?
+
       report_hash
     end
 

--- a/app/models/sushi/platform_usage_report.rb
+++ b/app/models/sushi/platform_usage_report.rb
@@ -7,6 +7,7 @@
 module Sushi
   class PlatformUsageReport
     attr_reader :created, :account
+    include Sushi
     include Sushi::DataTypeCoercion
     include Sushi::DateCoercion
     include Sushi::MetricTypeCoercion
@@ -31,6 +32,7 @@ module Sushi
     ].freeze
 
     def initialize(params = {}, created: Time.zone.now, account:)
+      Sushi.info = []
       validate_paramaters(params, allowed_parameters: ALLOWED_PARAMETERS)
       coerce_data_types(params)
       coerce_dates(params)
@@ -66,6 +68,8 @@ module Sushi
       }
       report_hash["Report_Header"]["Report_Filters"]["Data_Type"] = data_types if data_type_in_params
       report_hash["Report_Header"]["Report_Filters"]["Metric_Type"] = metric_types if metric_type_in_params
+      report_hash["Report_Header"]["Exceptions"] = info if info.present?
+
       report_hash
     end
     alias to_hash as_json

--- a/spec/models/sushi/item_report_spec.rb
+++ b/spec/models/sushi/item_report_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Sushi::ItemReport do
   let(:created) { Time.zone.now }
   let(:required_parameters) do
     {
-      begin_date: '2022-01-03',
-      end_date: '2023-08-09'
+      begin_date: '2022-01',
+      end_date: '2023-08'
     }
   end
 

--- a/spec/models/sushi/platform_report_spec.rb
+++ b/spec/models/sushi/platform_report_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Sushi::PlatformReport do
   let(:created) { Time.zone.now }
   let(:required_parameters) do
     {
-      begin_date: '2022-01-03',
-      end_date: '2022-02-05'
+      begin_date: '2022-01',
+      end_date: '2022-02'
     }
   end
 

--- a/spec/models/sushi/platform_usage_report_spec.rb
+++ b/spec/models/sushi/platform_usage_report_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Sushi::PlatformUsageReport do
   let(:created) { Time.zone.now }
   let(:required_parameters) do
     {
-      begin_date: '2022-01-03',
-      end_date: '2022-02-05'
+      begin_date: '2022-01',
+      end_date: '2022-02'
     }
   end
 

--- a/spec/models/sushi_spec.rb
+++ b/spec/models/sushi_spec.rb
@@ -150,6 +150,29 @@ RSpec.describe Sushi do
     end
   end
 
+  describe '#validate_date_format' do
+    context 'when the begin_date or end_date are in MM-YYYY format' do
+      let(:dates) { ['06-2023', '08-2023'] }
+
+      it 'raises an error' do
+        expect { subject.validate_date_format(dates) }.to raise_error(Sushi::Error::InvalidDateArgumentError)
+      end
+    end
+
+    context 'when the begin_date or end_date are in YYYY-MM-DD format' do
+      let(:dates) { ['2023-06-05', '2023-08-09'] }
+
+      before { Sushi.info = [] }
+
+      it 'stores the exception' do
+        expect(Sushi.info).to be_empty
+        subject.validate_date_format(dates)
+        expect(Sushi.info).not_to be_empty
+        expect(Sushi.info.first).to be_a(Hash)
+      end
+    end
+  end
+
   describe "AuthorCoercion" do
     describe '.deserialize' do
       subject { Sushi::AuthorCoercion.deserialize(string) }


### PR DESCRIPTION
# Story
### first issue
accounting for begin/end dates passed as `MM/YYYY`.

This is necessary because calling `to_date` on a string in `MM-YYYY` format will assume that `MM` is the day, and will set the current month as `MM` instead.

We are also still allowing for dates to use `MM-DD-YYYY` format.

```
params.fetch(:begin_date) => "06-2023"
params.fetch(:begin_date).to_date => Wed, 06 Sep 2023
```

- https://github.com/scientist-softserv/palni-palci/issues/687#issuecomment-1736117022

### second issue
accounting for exceptions in the report header

exception 0 is a special case, as it represents info or debugging messages.
when the query is successful, despite the exception, the exception is
to be returned as part of the report header.

ref: https://countermetrics.stoplight.io/docs/counter-sushi-api/jmelferytrixm-exception-0
ref: https://github.com/scientist-softserv/palni-palci/issues/687#issuecomment-1737901436

# Screenshots / Video
<details>
<summary>MM-YYYY format</summary>

![image](https://github.com/scientist-softserv/palni-palci/assets/29032869/6b58d4c9-0267-4b2e-81ac-efc2848d2fcd)
</details>

<details>
<summary>YYYY-MM-DD format</summary>

<img width="1218" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/29032869/edf0b5a2-ff1c-474d-8707-7295204a6903">
</details>