### PR TITLE
Bibliographic Citation field not displaying

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -54,7 +54,7 @@ class SolrDocument
   attribute :department, Solr::Array, 'department_tesim'
   attribute :format, Solr::Array, 'format_tesim'
   attribute :title_ssi, Solr::Array, 'title_ssi_tesim'
-  attribute :bibliographic_citation, Solr::String, 'bibliographic_citation_tesi'
+  attribute :bibliographic_citation, Solr::String, 'bibliographic_citation_tesim'
   attribute :collection_subtitle, Solr::String, 'collection_subtitle_tesi'
   attribute :admin_note, Solr::String, 'admin_note_tesim'
   attribute :contributing_library, Solr::String, 'contributing_library_tesim'


### PR DESCRIPTION
re: scientist-softserv/palni-palci#832

# Story

Refs #832 

# Expected Behavior Before Changes
Bibliographic citation was not appearing on the work show page
# Expected Behavior After Changes
Bibliographic citation appears on the work show page
# Screenshots / Video
<img width="776" alt="Screenshot 2023-09-28 at 12 10 22 PM" src="https://github.com/scientist-softserv/palni-palci/assets/18175797/b5ff0f3c-4455-40b1-b83b-f9032b94b8da">



# Notes
