### PR TITLE
792 update exception messaging

### DIFF
--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -192,13 +192,13 @@ module Sushi
       earliest_date = Hyrax::CounterMetric.order(date: :asc).first.date
       if @begin_date < earliest_date
         # rubocop:disable Metrics/LineLength
-        raise Sushi::Error::UsageNoLongerAvailableForRequestedDatesError.new(data: "The requested begin_date of #{params[:begin_date]} is before the earliest metric date of #{earliest_date.iso8601}.")
+        raise Sushi::Error::UsageNoLongerAvailableForRequestedDatesError.new(data: "Unable to complete the request because the begin_date of #{params[:begin_date]} is for a month that has incomplete data.  That month's data starts on #{earliest_date.iso8601}.")
         # rubocop:enable Metrics/LineLength
       end
 
       latest_date = Hyrax::CounterMetric.order(date: :desc).first.date
       if @end_date > latest_date
-        raise Sushi::Error::UsageNotReadyForRequestedDatesError.new(data: "The requested end_date of #{params[:end_date]} is after the latest metric date of #{latest_date.iso8601}.")
+        raise Sushi::Error::UsageNotReadyForRequestedDatesError.new(data: "Unable to complete the request because the end_date of #{params[:end_date]} is for a month that has incomplete data.  That month's data ends on #{latest_date.iso8601}.")
       end
     rescue ActionController::ParameterMissing, KeyError => e
       raise Sushi::Error::InsufficientInformationToProcessRequestError.new(data: e.message)

--- a/app/models/sushi.rb
+++ b/app/models/sushi.rb
@@ -198,7 +198,9 @@ module Sushi
 
       latest_date = Hyrax::CounterMetric.order(date: :desc).first.date
       if @end_date > latest_date
+        # rubocop:disable Metrics/LineLength
         raise Sushi::Error::UsageNotReadyForRequestedDatesError.new(data: "Unable to complete the request because the end_date of #{params[:end_date]} is for a month that has incomplete data.  That month's data ends on #{latest_date.iso8601}.")
+        # rubocop:enable Metrics/LineLength
       end
     rescue ActionController::ParameterMissing, KeyError => e
       raise Sushi::Error::InsufficientInformationToProcessRequestError.new(data: e.message)

--- a/app/models/sushi/error.rb
+++ b/app/models/sushi/error.rb
@@ -93,8 +93,8 @@ module Sushi
       # @param parameter_name [#to_s]
       # @param allowed_values [Array<#to_s>]
       def self.given_value_does_not_match_allowed_values(parameter_value:, parameter_name:, allowed_values:)
-        new(data: "None of the given values in `#{parameter_name}=#{parameter_value}` are supported at this time." \
-                  "Please use an acceptable value, (#{allowed_values.join(', ')}) instead." \
+        new(data: "None of the given values in `#{parameter_name}=#{parameter_value}` are supported at this time. " \
+                  "Please use an acceptable value, (#{allowed_values.join(', ')}) instead. " \
                   "(Or do not pass the parameter at all, which will default to the acceptable value(s))")
       end
     end


### PR DESCRIPTION
# Story
#### b16d09ee
update the messaging for begin and end date exceptions when given dates that are before or after metric availability dates.

#### ac091303
add spaces in the error message for #given_value_does_not_match_allowed_values