### PR TITLE
🐛 Fix PDF.js logic

### DIFF
--- a/app/helpers/pdf_js_helper.rb
+++ b/app/helpers/pdf_js_helper.rb
@@ -5,6 +5,11 @@ module PdfJsHelper
     "/pdf.js/viewer.html?file=#{path}##{query_param}"
   end
 
+  def pdf_file_set_presenter(file_set_presenters)
+    # currently only supports one pdf per work
+    file_set_presenters.select(&:pdf?).first
+  end
+
   def query_param
     return unless params[:q]
 

--- a/app/views/hyrax/base/_representative_media.html.erb
+++ b/app/views/hyrax/base/_representative_media.html.erb
@@ -2,7 +2,7 @@
   <% if defined?(viewer) && viewer && presenter.iiif_viewer?%>
     <%= iiif_viewer_display presenter %>
   <% elsif Flipflop.default_pdf_viewer? && presenter.show_pdf_viewer? && presenter.file_set_presenters.any?(&:pdf?) %>
-    <%= render 'pdf_js', file_set_presenter: presenter.file_set_presenters.first %>
+    <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter.file_set_presenters) %>
   <% else %>
     <%= render media_display_partial(presenter.representative_presenter), file_set: presenter.representative_presenter %>
   <% end %>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -25,7 +25,7 @@
             </div>
           <% elsif @presenter.show_pdf_viewer? %>
             <div class="col-sm-12">
-              <%= render 'pdf_js', file_set_presenter: @presenter.file_set_presenters.first %>
+              <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter.file_set_presenters) %>
             </div>
           <% end %>
           <div class="col-sm-3 text-center">

--- a/app/views/themes/cultural_show/hyrax/base/show.html.erb
+++ b/app/views/themes/cultural_show/hyrax/base/show.html.erb
@@ -17,7 +17,7 @@
             </div>
           <% elsif Flipflop.default_pdf_viewer? && @presenter.show_pdf_viewer? && @presenter.file_set_presenters.any?(&:pdf?) %>
             <div class="col-sm-12">
-              <%= render 'pdf_js', file_set_presenter: @presenter.file_set_presenters.first %>
+              <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter.file_set_presenters) %>
             </div>
           <% end %>
           <div class="col-sm-12">

--- a/app/views/themes/cultural_show/hyrax/oers/show.html.erb
+++ b/app/views/themes/cultural_show/hyrax/oers/show.html.erb
@@ -17,7 +17,7 @@
             </div>
           <% elsif Flipflop.default_pdf_viewer? && @presenter.show_pdf_viewer? && @presenter.file_set_presenters.any?(&:pdf?) %>
             <div class="col-sm-12">
-              <%= render 'pdf_js', file_set_presenter: @presenter.file_set_presenters.first %>
+              <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter.file_set_presenters) %>
             </div>
           <% end %>
           <div class="col-sm-12">

--- a/app/views/themes/image_show/hyrax/base/show.html.erb
+++ b/app/views/themes/image_show/hyrax/base/show.html.erb
@@ -27,7 +27,7 @@
             </div>
           <% elsif Flipflop.default_pdf_viewer? && @presenter.show_pdf_viewer? && @presenter.file_set_presenters.any?(&:pdf?) %>
             <div class="col-sm-12">
-              <%= render 'pdf_js', file_set_presenter: @presenter.file_set_presenters.first %>
+              <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter.file_set_presenters) %>
             </div>
           <% else %>
             <div class="col-sm-3 mb-1">

--- a/app/views/themes/reshare_show/hyrax/base/show.html.erb
+++ b/app/views/themes/reshare_show/hyrax/base/show.html.erb
@@ -13,7 +13,7 @@
             </div>
           <% elsif Flipflop.default_pdf_viewer? && @presenter.show_pdf_viewer? && @presenter.file_set_presenters.any?(&:pdf?) %>
             <div class="col-sm-12">
-              <%= render 'pdf_js', file_set_presenter: @presenter.file_set_presenters.first %>
+              <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter.file_set_presenters) %>
             </div>
           <% end %>
           <div class="col-12 text-center">
@@ -33,4 +33,3 @@
     <span class='hide analytics-event' data-category="work" data-action="work-view" data-name="<%= @presenter.id %>" >
   </div>
 </div>
-

--- a/app/views/themes/scholarly_show/hyrax/base/show.html.erb
+++ b/app/views/themes/scholarly_show/hyrax/base/show.html.erb
@@ -27,7 +27,7 @@
             </div>
           <% elsif Flipflop.default_pdf_viewer? && @presenter.show_pdf_viewer? && @presenter.file_set_presenters.any?(&:pdf?) %>
             <div class="col-sm-12">
-              <%= render 'pdf_js', file_set_presenter: @presenter.file_set_presenters.first %>
+              <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter.file_set_presenters) %>
             </div>
             <div class="col-sm-12">
               <div class="image-show-description">

--- a/app/views/themes/scholarly_show/hyrax/oers/show.html.erb
+++ b/app/views/themes/scholarly_show/hyrax/oers/show.html.erb
@@ -27,7 +27,7 @@
             </div>
           <% elsif Flipflop.default_pdf_viewer? && @presenter.show_pdf_viewer? && @presenter.file_set_presenters.any?(&:pdf?) %>
             <div class="col-sm-12">
-              <%= render 'pdf_js', file_set_presenter: @presenter.file_set_presenters.first %>
+              <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter.file_set_presenters) %>
             </div>
           <% else %>
             <div class="col-sm-3 mb-1">


### PR DESCRIPTION
This commit will fix the logic for PDF.js to work when the first file set presenter is not a PDF.  We first select all pdf file set presenters and then select the first one.
