### PR TITLE
🎁 PDF file sets now selectable in file manager

### DIFF
--- a/app/helpers/pdf_js_helper.rb
+++ b/app/helpers/pdf_js_helper.rb
@@ -5,9 +5,13 @@ module PdfJsHelper
     "/pdf.js/viewer.html?file=#{path}##{query_param}"
   end
 
-  def pdf_file_set_presenter(file_set_presenters)
-    # currently only supports one pdf per work
-    file_set_presenters.select(&:pdf?).first
+  def pdf_file_set_presenter(presenter)
+    # currently only supports one pdf per work, falls back to the first pdf file set in ordered members
+    representative_presenter(presenter) || presenter.file_set_presenters.select(&:pdf?).first
+  end
+
+  def representative_presenter(presenter)
+    presenter.file_set_presenters.find { |file_set_presenter| file_set_presenter.id == presenter.representative_id }
   end
 
   def query_param

--- a/app/views/hyrax/base/_representative_media.html.erb
+++ b/app/views/hyrax/base/_representative_media.html.erb
@@ -2,7 +2,7 @@
   <% if defined?(viewer) && viewer && presenter.iiif_viewer?%>
     <%= iiif_viewer_display presenter %>
   <% elsif Flipflop.default_pdf_viewer? && presenter.show_pdf_viewer? && presenter.file_set_presenters.any?(&:pdf?) %>
-    <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter.file_set_presenters) %>
+    <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter) %>
   <% else %>
     <%= render media_display_partial(presenter.representative_presenter), file_set: presenter.representative_presenter %>
   <% end %>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -25,7 +25,7 @@
             </div>
           <% elsif @presenter.show_pdf_viewer? %>
             <div class="col-sm-12">
-              <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter.file_set_presenters) %>
+              <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter) %>
             </div>
           <% end %>
           <div class="col-sm-3 text-center">

--- a/app/views/themes/cultural_show/hyrax/base/show.html.erb
+++ b/app/views/themes/cultural_show/hyrax/base/show.html.erb
@@ -17,7 +17,7 @@
             </div>
           <% elsif Flipflop.default_pdf_viewer? && @presenter.show_pdf_viewer? && @presenter.file_set_presenters.any?(&:pdf?) %>
             <div class="col-sm-12">
-              <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter.file_set_presenters) %>
+              <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter) %>
             </div>
           <% end %>
           <div class="col-sm-12">

--- a/app/views/themes/cultural_show/hyrax/oers/show.html.erb
+++ b/app/views/themes/cultural_show/hyrax/oers/show.html.erb
@@ -17,7 +17,7 @@
             </div>
           <% elsif Flipflop.default_pdf_viewer? && @presenter.show_pdf_viewer? && @presenter.file_set_presenters.any?(&:pdf?) %>
             <div class="col-sm-12">
-              <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter.file_set_presenters) %>
+              <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter) %>
             </div>
           <% end %>
           <div class="col-sm-12">

--- a/app/views/themes/image_show/hyrax/base/show.html.erb
+++ b/app/views/themes/image_show/hyrax/base/show.html.erb
@@ -27,7 +27,7 @@
             </div>
           <% elsif Flipflop.default_pdf_viewer? && @presenter.show_pdf_viewer? && @presenter.file_set_presenters.any?(&:pdf?) %>
             <div class="col-sm-12">
-              <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter.file_set_presenters) %>
+              <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter) %>
             </div>
           <% else %>
             <div class="col-sm-3 mb-1">

--- a/app/views/themes/reshare_show/hyrax/base/show.html.erb
+++ b/app/views/themes/reshare_show/hyrax/base/show.html.erb
@@ -13,7 +13,7 @@
             </div>
           <% elsif Flipflop.default_pdf_viewer? && @presenter.show_pdf_viewer? && @presenter.file_set_presenters.any?(&:pdf?) %>
             <div class="col-sm-12">
-              <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter.file_set_presenters) %>
+              <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter) %>
             </div>
           <% end %>
           <div class="col-12 text-center">

--- a/app/views/themes/scholarly_show/hyrax/base/show.html.erb
+++ b/app/views/themes/scholarly_show/hyrax/base/show.html.erb
@@ -27,7 +27,7 @@
             </div>
           <% elsif Flipflop.default_pdf_viewer? && @presenter.show_pdf_viewer? && @presenter.file_set_presenters.any?(&:pdf?) %>
             <div class="col-sm-12">
-              <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter.file_set_presenters) %>
+              <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter) %>
             </div>
             <div class="col-sm-12">
               <div class="image-show-description">

--- a/app/views/themes/scholarly_show/hyrax/oers/show.html.erb
+++ b/app/views/themes/scholarly_show/hyrax/oers/show.html.erb
@@ -27,7 +27,7 @@
             </div>
           <% elsif Flipflop.default_pdf_viewer? && @presenter.show_pdf_viewer? && @presenter.file_set_presenters.any?(&:pdf?) %>
             <div class="col-sm-12">
-              <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter.file_set_presenters) %>
+              <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter) %>
             </div>
           <% else %>
             <div class="col-sm-3 mb-1">


### PR DESCRIPTION
# Story

Currently, the file manager isn't selecting between PDFs for display in the viewer.  If there are multiple PDFs, changing the representative media/thumbnail doesn't affect which one displays in the viewer.  This commit will add the ability for the user to change which PDF is being displayed through the file manager.

Ref:
  - https://github.com/scientist-softserv/palni-palci/issues/839

# Screenshots / Video

https://github.com/scientist-softserv/palni-palci/assets/19597776/a56bb856-de66-4e17-bafb-ef2d0ae632a1
