### PR TITLE
🎁 Limit settings to superadmins

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -46,6 +46,15 @@ class Account < ApplicationRecord
                      format: { with: /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/ },
                      unless: proc { |a| a.tenant == 'public' || a.tenant == 'single' }
 
+  SUPERADMIN_SETTINGS_ONLY = [:contact_email, :contact_email_to,
+                              :analytics_provider, :file_acl, :s3_bucket,
+                              :oai_prefix, :oai_sample_identifier,
+                              :file_size_limit].freeze
+
+  def self.superadmin_settings
+    SUPERADMIN_SETTINGS_ONLY
+  end
+
   def self.admin_host
     host = ENV.fetch('HYKU_ADMIN_HOST', nil)
     host ||= ENV['HOST']

--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -112,7 +112,7 @@ module AccountSettings
 
   def public_settings(is_superadmin: false)
     settings = all_settings
-    settings = superadmin_settings(is_superadmin) unless is_superadmin
+    settings = superadmin_settings unless is_superadmin
     settings.reject { |k, v| Account.private_settings.include?(k.to_s) || v[:disabled] }
   end
 
@@ -238,7 +238,7 @@ module AccountSettings
       # rubocop:enable Style/RedundantSelf
     end
 
-    def superadmin_settings(is_superadmin)
+    def superadmin_settings
       all_settings.reject { |k, _v| Account.superadmin_settings.include?(k.to_sym) }
     end
 end

--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -110,8 +110,10 @@ module AccountSettings
   end
   # rubocop:enable Metrics/BlockLength
 
-  def public_settings
-    all_settings.reject { |k, v| Account.private_settings.include?(k.to_s) || v[:disabled] }
+  def public_settings(is_superadmin: false)
+    settings = all_settings
+    settings = superadmin_settings(is_superadmin) unless is_superadmin
+    settings.reject { |k, v| Account.private_settings.include?(k.to_s) || v[:disabled] }
   end
 
   def live_settings
@@ -234,5 +236,9 @@ module AccountSettings
       # only show analytics partials if analytics are set on the tenant
       Hyrax.config.analytics = Hyrax::Analytics.config.valid?
       # rubocop:enable Style/RedundantSelf
+    end
+
+    def superadmin_settings(is_superadmin)
+      all_settings.reject { |k, _v| Account.superadmin_settings.include?(k.to_sym) }
     end
 end

--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -3,6 +3,7 @@
 # All settings have a precedence order as follows
 # Per Tenant Setting > ENV['HYKU_SETTING_NAME'] > ENV['HYRAX_SETTING_NAME'] > default
 
+# rubocop:disable Metrics/ModuleLength
 module AccountSettings
   extend ActiveSupport::Concern
   # rubocop:disable Metrics/BlockLength
@@ -242,3 +243,4 @@ module AccountSettings
       all_settings.reject { |k, _v| Account.superadmin_settings.include?(k.to_sym) }
     end
 end
+# rubocop:enable Metrics/ModuleLength

--- a/app/views/admin/accounts/edit.html.erb
+++ b/app/views/admin/accounts/edit.html.erb
@@ -23,7 +23,7 @@
             <%= f.text_field :tenant, class: 'form-control', readonly: @account.persisted? %>
           </div>
 
-          <% current_account.public_settings.each do |key, value| %>
+          <% current_account.public_settings(is_superadmin: current_user.is_superadmin).each do |key, value| %>
             <%= render 'shared/settings', f:f, key: key, value: value %>
           <% end %>
 

--- a/spec/models/concerns/account_settings_spec.rb
+++ b/spec/models/concerns/account_settings_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+RSpec.describe AccountSettings do
+  let(:account) { FactoryBot.create(:account) }
+
+  describe '#public_settings' do
+    context 'when is_superadmin is true' do
+      # rubocop:disable RSpec/ExampleLength
+      it 'returns all settings except private and disabled settings' do
+        expect(account.public_settings(is_superadmin: true).keys.sort).to eq %i[allow_downloads
+                                                                                allow_signup
+                                                                                analytics_provider
+                                                                                cache_api
+                                                                                contact_email
+                                                                                contact_email_to
+                                                                                doi_reader
+                                                                                doi_writer
+                                                                                email_domain
+                                                                                email_format
+                                                                                email_subject_prefix
+                                                                                file_acl
+                                                                                file_size_limit
+                                                                                geonames_username
+                                                                                google_analytics_id
+                                                                                google_oauth_app_name
+                                                                                google_oauth_app_version
+                                                                                google_oauth_client_email
+                                                                                google_oauth_private_key_path
+                                                                                google_oauth_private_key_secret
+                                                                                google_oauth_private_key_value
+                                                                                gtm_id
+                                                                                oai_admin_email
+                                                                                oai_prefix
+                                                                                oai_sample_identifier
+                                                                                s3_bucket
+                                                                                smtp_settings
+                                                                                solr_collection_options
+                                                                                ssl_configured]
+        expect(account.public_settings(is_superadmin: true).size).to eq 29
+      end
+      # rubocop:enable RSpec/ExampleLength
+    end
+
+    context 'when is_superadmin is false' do
+      # rubocop:disable RSpec/ExampleLength
+      it 'returns all settings except private, disabled, and superadmin settings' do
+        expect(Account::SUPERADMIN_SETTINGS_ONLY.size).to eq 8
+        expect(account.public_settings(is_superadmin: false).keys.sort).to eq %i[allow_downloads
+                                                                                 allow_signup
+                                                                                 cache_api
+                                                                                 doi_reader
+                                                                                 doi_writer
+                                                                                 email_domain
+                                                                                 email_format
+                                                                                 email_subject_prefix
+                                                                                 geonames_username
+                                                                                 google_analytics_id
+                                                                                 google_oauth_app_name
+                                                                                 google_oauth_app_version
+                                                                                 google_oauth_client_email
+                                                                                 google_oauth_private_key_path
+                                                                                 google_oauth_private_key_secret
+                                                                                 google_oauth_private_key_value
+                                                                                 gtm_id
+                                                                                 oai_admin_email
+                                                                                 smtp_settings
+                                                                                 solr_collection_options
+                                                                                 ssl_configured]
+        expect(account.public_settings(is_superadmin: false).size).to eq 21
+      end
+      # rubocop:enable RSpec/ExampleLength
+    end
+  end
+end


### PR DESCRIPTION
This commit will hide certain settings from non-superadmins on the Account settings dashboard page as prescribed by the client.

Ref:
  - https://github.com/scientist-softserv/palni-palci/issues/841

# Story

Refs #issuenumber

# Expected Behavior Before Changes

# Expected Behavior After Changes

# Screenshots / Video

<details>
<summary>As superadmin</summary>

![image](https://github.com/scientist-softserv/palni-palci/assets/19597776/882089b9-06a8-43ed-af35-3d21d0f0198a)

</details>

<details>
<summary>As non-superadmin</summary>

![image](https://github.com/scientist-softserv/palni-palci/assets/19597776/67bb0468-ff21-4858-b0fd-59f1d9fdb81a)

</details>
