### PR TITLE
🐛 Fix duplicating slider icons in IR theme

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,6 +5,7 @@
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>
+  <%= yield :head %>
 </head>
 <body>
 

--- a/app/views/themes/institutional_repository/hyrax/homepage/_resource_type_slider.html.erb
+++ b/app/views/themes/institutional_repository/hyrax/homepage/_resource_type_slider.html.erb
@@ -1,3 +1,7 @@
+<%# Add content_for block to clear caching so IR icons don't duplicate unintentionally %>
+<% content_for :head do %>
+  <meta name="turbolinks-cache-control" content="no-cache">
+<% end %>
 <div class="carousel institutional-repository-carousel slide" id="carousel-tilenav" data-interval="false">
   <div class="carousel-inner">
     <% resource_types.each.with_index do |(k,v), i| %>


### PR DESCRIPTION
# Story

Before this commit, when the user is at the homepage, then navigating away from it, then back to it, the slider icons would duplicate.  This commit will disable turbolinks caching for the slider partial to fix it.

Ref:
  - https://github.com/scientist-softserv/palni-palci/issues/277

# Screenshots / Video



# Notes
This was only occurring when the carousel was activated by adding more icons in there.