### PR TITLE
i813 Add invited users to the registered group

### DIFF
--- a/app/controllers/hyku/invitations_controller.rb
+++ b/app/controllers/hyku/invitations_controller.rb
@@ -14,6 +14,7 @@ module Hyku
       authorize! :grant_admin_role, User if params[:user][:role] == ::RolesService::ADMIN_ROLE
       self.resource = User.find_by(email: params[:user][:email]) || invite_resource
 
+      resource.add_default_group_membership!
       resource.add_role(params[:user][:role], Site.instance) if params[:user][:role].present?
 
       yield resource if block_given?

--- a/spec/controllers/hyku/invitations_controller_spec.rb
+++ b/spec/controllers/hyku/invitations_controller_spec.rb
@@ -31,5 +31,31 @@ RSpec.describe Hyku::InvitationsController, type: :controller do
       expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.admin_users_path(locale: 'en')
       expect(flash[:notice]).to eq 'An invitation email has been sent to user@guest.org.'
     end
+
+    context 'when user already exists' do
+      let(:user) { create(:user) }
+
+      # Mimic the state of a user who is only active in other tenants;
+      # i.e. a user who has no roles in this tenant
+      before do
+        user.roles.destroy_all
+      end
+
+      it 'adds the user to the registered group' do
+        expect(user.roles).to be_empty
+        expect(user.groups).to be_empty
+
+        post :create, params: {
+          user: {
+            email: user.email,
+            role: ''
+          }
+        }
+
+        user.reload
+        expect(user.roles).not_to be_empty
+        expect(user.groups).to eq([Ability.registered_group_name])
+      end
+    end
   end
 end


### PR DESCRIPTION
# Story

Refs 
- #813 

Fixes a bug where users who were invited with no roles would not show up in the users list at all

# Expected Behavior Before Changes

When inviting an existing User account to a new tenant with no roles via the form in Dashboard > Manage Users (`/admin/users`), the user is not added to the tenant. 

# Expected Behavior After Changes

When inviting an existing User account to a new tenant with no roles via the form in Dashboard > Manage Users (`/admin/users`), the user is added to the tenant. 

# Screenshots / Video

<details>
<summary>With changes</summary>

https://github.com/scientist-softserv/palni-palci/assets/32469930/784e2b58-79d6-4274-9dfb-ecb1f9b5bb10

</details>
