### PR TITLE
🎁 Add redirect back to review page

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -82,6 +82,12 @@ module Hyrax
     def show
       @user_collections = user_collections
 
+      # Ensures that the user does not get redirected back to /admin/workflows after approving or rejecting a work
+      # when they did not come from that route
+      # see: app/controllers/hyrax/admin/workflows_controller_decorator.rb
+      #      app/controllers/hyrax/workflow_actions_controller_decorator.rb
+      session.delete(:from_admin_workflows) unless request.referer&.include?(admin_workflows_path)
+
       respond_to do |wants|
         wants.html { presenter && parent_presenter }
         wants.json do

--- a/app/controllers/hyrax/admin/workflows_controller_decorator.rb
+++ b/app/controllers/hyrax/admin/workflows_controller_decorator.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+# OVERRIDE Hyrax 3.6.0 to redirect back to the review submissions page after approving or rejecting a work
+# when the user came from the review submissions page
+
+module Hyrax
+  module Admin
+    module WorkflowsControllerDecorator
+      def index
+        super
+        session[:from_admin_workflows] = true if request.fullpath.include?(admin_workflows_path)
+      end
+    end
+  end
+end
+
+Hyrax::Admin::WorkflowsController.prepend(Hyrax::Admin::WorkflowsControllerDecorator)

--- a/app/controllers/hyrax/workflow_actions_controller_decorator.rb
+++ b/app/controllers/hyrax/workflow_actions_controller_decorator.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# OVERRIDE Hyrax 3.6.0 to redirect back to the review submissions page after approving or rejecting a work
+# when the user came from the review submissions page
+
+module Hyrax
+  module WorkflowActionsControllerDecorator
+    private
+
+      def after_update_response
+        respond_to do |wants|
+          redirect_path = session[:from_admin_workflows] ? admin_workflows_path : [main_app, curation_concern]
+          wants.html { redirect_to redirect_path, notice: "The #{curation_concern.class.human_readable_type} has been updated." }
+          wants.json { render 'hyrax/base/show', status: :ok, location: polymorphic_path([main_app, curation_concern]) }
+        end
+      end
+  end
+end
+
+Hyrax::WorkflowActionsController.prepend(Hyrax::WorkflowActionsControllerDecorator)


### PR DESCRIPTION
# Story

This commit will add a redirect back to the review page after a user performs a workflow action from the work show page.  This will only occur if the user came from the review page.

Ref:
  - https://github.com/scientist-softserv/palni-palci/issues/443

# Screenshots / Video

https://github.com/scientist-softserv/palni-palci/assets/19597776/3fc42b98-d6fd-443e-a860-3e50894152fd
