### PR TITLE
🎁 Superadmins can activate users

### DIFF
--- a/.env
+++ b/.env
@@ -36,6 +36,7 @@ HYKU_ADMIN_ONLY_TENANT_CREATION=false
 HYKU_DEFAULT_HOST=%{tenant}.hyku.test
 HYKU_ROOT_HOST=hyku.test
 HYKU_MULTITENANT=true
+HYKU_USER_DEFAULT_PASSWORD=password
 # Comment out these 2 for multi tenancy / Uncomment for single
 # HYKU_ROOT_HOST=hyku.test
 # HYKU_MULTITENANT=false

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -11,7 +11,18 @@ module Admin
       if @user.present? && @user.roles.destroy_all
         redirect_to hyrax.admin_users_path, notice: t('hyrax.admin.users.destroy.success', user: @user)
       else
-        redirect_to hyrax.admin_users_path flash: { error: t('hyrax.admin.users.destroy.failure', user: @user) }
+        redirect_to hyrax.admin_users_path, flash: { error: t('hyrax.admin.users.destroy.failure', user: @user) }
+      end
+    end
+
+    def activate
+      user = User.find(params[:id])
+      user.password = ENV.fetch('HYKU_USER_DEFAULT_PASSWORD', 'password')
+
+      if user.save && user.accept_invitation!
+        redirect_to hyrax.admin_users_path, notice: t('hyrax.admin.users.activate.success', user: user)
+      else
+        redirect_to hyrax.admin_users_path, flash: { error: t('hyrax.admin.users.activate.failure', user: user) }
       end
     end
 

--- a/app/views/hyrax/admin/users/index.html.erb
+++ b/app/views/hyrax/admin/users/index.html.erb
@@ -25,7 +25,7 @@
                       @invite_roles_options.map { |r| [r.titleize, r ]},
                       { prompt: 'Select a role...' },
                       required: false,
-                      class: 'form-control' %> 
+                      class: 'form-control' %>
           <%= f.submit t('.add'), class: 'btn btn-primary' %>
         </div>
       <% end %>
@@ -87,7 +87,10 @@
               <td><%= user.accepted_or_not_invited? ? t('.status.active') : t('.status.pending') %></td>
               <% if can? :destroy, User %>
                 <td>
-                  <%= link_to t('.delete'),  main_app.admin_user_path(user), class: 'btn btn-danger btn-sm action-delete', method: :delete, data: { confirm: t('hyrax.admin.users.destroy.confirmation', user: user.email) } %>
+                  <%= link_to t('.delete'), main_app.admin_user_path(user), class: 'btn btn-danger btn-sm action-delete', method: :delete, data: { confirm: t('hyrax.admin.users.destroy.confirmation', user: user.email) } %>
+                  <% if user.invited_to_sign_up? %>
+                    <%= link_to t('.activate'), main_app.activate_admin_user_path(user.id), class: 'btn btn-primary btn-sm', method: :post, data: { confirm: t('hyrax.admin.users.activate.confirmation', user: user.email) } %>
+                  <% end %>
                 </td>
               <% end %>
             </tr>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -251,6 +251,10 @@ en:
         manage_groups: Manage Groups
         system_status: System Status
       users:
+        activate:
+          confirmation: Are you sure you want to activate the user "%{user}"?
+          failure: User "%{user}" could not be activated.
+          success: User "%{user}" has been successfully activated.
         destroy:
           confirmation: Are you sure you wish to delete the user "%{user}"? This action is irreversible.
           failure: User "%{user}" could not be deleted.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -123,7 +123,9 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
   namespace :admin do
     resource :account, only: %i[edit update]
     resource :work_types, only: %i[edit update]
-    resources :users, only: [:destroy]
+    resources :users, only: [:index, :destroy] do
+      post 'activate', on: :member
+    end
     resources :groups do
       member do
         get :remove

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -118,6 +118,8 @@ extraEnvVars: &envVars
     value: "true"
   - name: HYKU_ROOT_HOST
     value: hykucommons.org
+  - name: HYKU_USER_DEFAULT_PASSWORD
+    value: password
   - name: HYRAX_ACTIVE_JOB_QUEUE
     value: sidekiq
   - name: HYRAX_ANALYTICS

--- a/ops/staging-deploy.tmpl.yaml
+++ b/ops/staging-deploy.tmpl.yaml
@@ -106,6 +106,8 @@ extraEnvVars: &envVars
     value: "true"
   - name: HYKU_ROOT_HOST
     value: palni-palci-staging.notch8.cloud
+  - name: HYKU_USER_DEFAULT_PASSWORD
+    value: password
   - name: HYRAX_ACTIVE_JOB_QUEUE
     value: sidekiq
   - name: HYRAX_ANALYTICS_PROVIDER

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -39,4 +39,31 @@ RSpec.describe Admin::UsersController, type: :controller do
       end
     end
   end
+
+  context 'as an admin user' do
+    let(:user) { User.invite!(email: 'invited@example.com', skip_invitation: true) }
+
+    before do
+      sign_in create(:admin)
+    end
+
+    describe 'POST #activate' do
+      context 'when user is successfully activated' do
+        before do
+          post :activate, params: { id: user.id }
+        end
+
+        it 'accepts the invitation for the user' do
+          expect(user).not_to be_accepted_or_not_invited
+          user.reload
+          expect(user).to be_accepted_or_not_invited
+        end
+
+        it 'redirects to the admin users path with a success notice' do
+          expect(response).to redirect_to(admin_users_path)
+          expect(flash[:notice]).to eq "User \"#{user.email}\" has been successfully activated."
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Story

This commit will allow superadmins to activate users from the dashboard. The default password for an activated user is set to `password`.  The activate button shows up for users who have permissions to destroy users.  The assumption is that superadmins will be the only ones with this permission.

Ref:
  - https://github.com/scientist-softserv/palni-palci/issues/446

# Screenshots / Video

https://github.com/scientist-softserv/palni-palci/assets/19597776/8e797ee6-ff5e-421f-b29f-9d4ca61e8d36

# Notes
The default password `password` is configurable through env variables.