### PR TITLE
Fix for a valid failing spec

### DIFF
--- a/app/views/hyrax/admin/appearances/_banner_image_form.html.erb
+++ b/app/views/hyrax/admin/appearances/_banner_image_form.html.erb
@@ -2,7 +2,7 @@
   <div class="panel-body">
     <% require_image = @form.banner_image? ? false : true %>
     <%# Upload Banner Image %>
-    <%= f.input :banner_image, as: :file, wrapper: :vertical_file_input, required: require_image, hint: t('hyrax.admin.appearances.show.forms.banner_image.hint').html_safe, input_html: { name: 'form[banner_image]' } %>
+    <%= f.input :banner_image, as: :file, wrapper: :vertical_file_input, required: require_image, hint: t('hyrax.admin.appearances.show.forms.banner_image.hint').html_safe, input_html: { name: 'admin_appearance[banner_image]' } %>
     <%= f.input :banner_image_text, required: true, as: :text, label: 'Banner image alt text' %>
 
     <!-- Image preview and cropping area -->

--- a/spec/views/hyrax/admin/appearances/show.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/appearances/show.html.erb_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "hyrax/admin/appearances/show", type: :view do
       # logo tab
       assert_select "input#admin_appearance_logo_image[name=?]", "admin_appearance[logo_image]"
       # banner image tab
-      assert_select "input#admin_appearance_banner_image[name=?]", "admin_appearance[banner_image]"
+      assert_select "input#admin_appearance_banner_image[name=?]", "form[banner_image]"
       assert_select "input#admin_appearance_banner_image[type=?]", "file"
       # directory image
       assert_select "input#admin_appearance_directory_image[name=?]", "admin_appearance[directory_image]"

--- a/spec/views/hyrax/admin/appearances/show.html.erb_spec.rb
+++ b/spec/views/hyrax/admin/appearances/show.html.erb_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "hyrax/admin/appearances/show", type: :view do
       # logo tab
       assert_select "input#admin_appearance_logo_image[name=?]", "admin_appearance[logo_image]"
       # banner image tab
-      assert_select "input#admin_appearance_banner_image[name=?]", "form[banner_image]"
+      assert_select "input#admin_appearance_banner_image[name=?]", "admin_appearance[banner_image]"
       assert_select "input#admin_appearance_banner_image[type=?]", "file"
       # directory image
       assert_select "input#admin_appearance_directory_image[name=?]", "admin_appearance[directory_image]"


### PR DESCRIPTION
 Failures from main:

  1) hyrax/admin/appearances/show renders the edit site form
     Failure/Error: assert_select "input#admin_appearance_banner_image[name=?]", "admin_appearance[banner_image]"

     Minitest::Assertion:
       Expected at least 1 element matching "input#admin_appearance_banner_image[name=\"admin_appearance[banner_image]\"]", found 0.
       Expected 0 to be >= 1.

# Story

While investigating the flaky pipeline I noticed this spec was consistently failing. it also would fail locally. It appears to be the only valid failing spec. 

Refs #
- https://github.com/scientist-softserv/palni-palci/issues/860
