### PR TITLE
🧹 update description of contact_email and contact_to

### DIFF
--- a/.env
+++ b/.env
@@ -28,6 +28,7 @@ SOLR_COLLECTION_NAME=hydra-development
 SOLR_CONFIGSET_NAME=hyku-1
 SOLR_HOST=solr
 SOLR_PORT=8983
+SOLR_TAG=latest
 SOLR_URL=http://solr:SolrRocks@solr:8983/solr/
 
 # Comment out these 5 for single tenancy / Uncomment for multi

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -11,7 +11,7 @@ Hyrax.config do |config|
   config.register_curation_concern :etd
   # Injected via `rails g hyrax:work Cdl`
   config.register_curation_concern :cdl
-  # Email recipient of messages sent via the contact form
+  # The email address that messages submitted via the contact page are sent to
   # This is set by account settings
   # config.contact_email = 'changeme@example.com'
 

--- a/config/locales/simple_form.de.yml
+++ b/config/locales/simple_form.de.yml
@@ -1,84 +1,83 @@
 ---
 de:
   simple_form:
-    cancel: Stornieren
+    cancel: Abbrechen
     error_notification:
-      default_message: 'Bitte überprüfen Sie die folgenden Probleme:'
+      default_message: 'Bitte überprüfen Sie die untenstehenden Probleme:'
     hints:
       account:
         admin_emails: Geben Sie jeweils eine E-Mail-Adresse ein
-        allow_signup: Erlauben Sie Benutzern, sich bei Ihrem Repository anzumelden
-        cache_api: Aktiviert den Cache für API-Endpunkte. Experimental
-        contact_email: E-Mail-Empfänger von Nachrichten, die über das Kontaktformular gesendet werden
-        contact_email_to: E-Mail-Adresse, die Kontakt-E-Mails erhalten soll
-        doi_reader: Zeigen Sie die Fähigkeit, aus Datacite zu lesen, um Datensätze zu füllen. WIP nicht verwenden
-        doi_writer: Schreiben Sie DOIs für Datensätze. WIP nicht verwenden
-        email_format: Legen Sie eine Liste von E-Mail-Domains fest, die sich bei diesem Repository anmelden dürfen, z. B. (@ubiquitypress.com @gmail.com). Lassen Sie zwischen jeder Domäne ein einzelnes Leerzeichen.
-        email_subjet_prefix: Zeichenfolge, die den System-E-Mail-Betreffs vorangestellt werden soll.
-        enable_oai_metadata: OAI-Link aktivieren oder deaktivieren
+        is_public: 'Können Benutzer Ihre Seite auf der Startseite entdecken oder auf Ihre Seiten zugreifen, ohne einen speziellen Benutzernamen / Passwort?'
         fcrepo_endpoint:
-          base_path: Fedora-Basispfad sollte mit einem Schrägstrich beginnen und nicht mit einem Schrägstrich enden
-          url: Fedora-URL sollte nicht mit einem Schrägstrich enden
-        file_acl: Deaktivieren Sie diese Option, wenn Sie ein Dateisystem wie Samba oder NFS verwenden, das das Festlegen von Zugriffssteuerungslisten nicht unterstützt
-        file_size_limit: Dieser sollte mindestens auf 536870912000 eingestellt sein
-        geonames_username: Registrieren Sie sich unter http://www.geonames.org/manageaccount
+          base_path: Der Fedora-Basispfad sollte mit einem Schrägstrich beginnen UND nicht mit einem Schrägstrich enden
+          url: Die Fedora-URL sollte nicht mit einem Schrägstrich enden
+        name: Ein einzelner oder mit Bindestrichen versehener Name, der für technische Aspekte des Repositories verwendet wird (z.B. "acme" oder "acme-bibliothek").
+        gtm_id: Die ID Ihres Google Tag Manager-Kontos
         google_analytics_id: Die ID Ihres Google Analytics-Kontos
         google_oauth_app_name: Der Name der Google-Anwendung in der Google API-Konsole
         google_oauth_app_version: Die Version der Google-Anwendung in der Google API-Konsole
-        google_oauth_client_email: E-Mail-Adresse des OAuth-Clients
-        google_oauth_private_key_path: Der vollständige Pfad zu Ihrer p12-Schlüsseldatei. (Sie können den privaten Schlüsselwert ODER den Pfad verwenden; der Wert hat Vorrang)
-        google_oauth_private_key_secret: Das Geheimnis, das Sie bei der Erstellung des p12-Schlüssels angegeben haben
         google_oauth_private_key_value: Der Wert der p12-Datei mit Base64-Verschlüsselung. (Sie können den privaten Schlüsselwert ODER den Pfad verwenden; der Wert hat Vorrang)
-        gtm_id: Die ID Ihres Google Tag Manager-Kontos
-        is_public: Können Benutzer Ihre Website auf der Homepage entdecken oder ohne einen speziellen Benutzernamen / ein spezielles Passwort auf Ihre Seiten zugreifen?
-        locale_name: 'Der Name des mandantenspezifischen Gebietsschema-Suffixes, das den locale.yml-Dateien hinzugefügt wurde. Es dürfen nur Buchstaben hinzugefügt werden, keine Symbole oder Zahlen, diese werden dann groß geschrieben.
-
-          '
-        monthly_email_list: Liste der E-Mail-Adressen, an die der Monatsbericht per E-Mail gesendet werden soll. Lassen Sie zwischen jeder E-Mail ein einzelnes Leerzeichen
-        name: Ein einzelner oder mit Bindestrich versehener Name, der für technische Aspekte des Repositorys verwendet wird (z. B. "acme" oder "acme-library").
-        oai_admin_email: Kontakt-E-Mail-Adresse des OAI-Endpunkts
-        shared_login: Aktivieren oder deaktivieren Sie die gemeinsame Anmeldung
-        ssl_configured: Setzen Sie es auf true, wenn Sie https verwenden
-        weekly_email_list: Liste der E-Mail-Adressen, an die der Wochenbericht per E-Mail gesendet werden soll. Lassen Sie zwischen jeder E-Mail ein einzelnes Leerzeichen
-        yearly_email_list: Liste der E-Mail-Adressen, an die der Jahresbericht per E-Mail gesendet werden soll. Lassen Sie zwischen jeder E-Mail ein einzelnes Leerzeichen
+        google_oauth_private_key_path: Der vollständige Pfad zu Ihrer p12-Schlüsseldatei. (Sie können den privaten Schlüsselwert ODER den Pfad verwenden; der Wert hat Vorrang)
+        google_oauth_private_key_secret: Das Geheimnis, das Sie beim Erstellen des p12-Schlüssels angegeben haben
+        google_oauth_client_email: OAuth-Client-E-Mail-Adresse
+        contact_email: Die E-Mail-Adresse, an die über die Kontaktseite gesendete Nachrichten gesendet werden
+        weekly_email_list: Liste von E-Mail-Adressen, an die der wöchentliche Bericht gesendet wird. Lassen Sie jeweils ein Leerzeichen zwischen den E-Mails
+        monthly_email_list: Liste von E-Mail-Adressen, an die der monatliche Bericht gesendet wird. Lassen Sie jeweils ein Leerzeichen zwischen den E-Mails
+        yearly_email_list: Liste von E-Mail-Adressen, an die der jährliche Bericht gesendet wird. Lassen Sie jeweils ein Leerzeichen zwischen den E-Mails
+        email_format: Legen Sie eine Liste von E-Mail-Domänen fest, die sich für dieses Repository anmelden dürfen, z. B. (@ubiquitypress.com @gmail.com). Lassen Sie jeweils ein Leerzeichen zwischen den Domänen.
+        allow_signup: Benutzern erlauben, sich für Ihr Repository anzumelden
+        enable_oai_metadata: OAI-Link aktivieren oder deaktivieren
+        shared_login: Gemeinsamen Login aktivieren oder deaktivieren
+        file_size_limit: Dies sollte mindestens auf 536870912000 eingestellt sein
+        locale_name: |
+          Der Name des mandantenspezifischen Gebietsschemasuffix, der ihren locale.yml-Dateien hinzugefügt wird. Es sollten nur alphabetische Zeichen hinzugefügt werden, keine Symbole oder Zahlen, diese werden dann großgeschrieben.
+        oai_admin_email: OAI-Endpunkt-Kontakt-E-Mail-Adresse
+        doi_reader: Zeigen Sie die Fähigkeit an, von Datacite zu lesen, um Datensätze zu füllen. WIP nicht verwenden
+        doi_writer: DOIs für Datensätze schreiben. WIP nicht verwenden
+        cache_api: Cache für API-Endpunkte aktivieren. Experimentell
+        email_subjet_prefix: Zeichenfolge, die vor System-E-Mail-Betreffs eingefügt wird.
+        contact_email_to: Die E-Mail-Adresse, von der Systembenachrichtigungen gesendet werden. Eine zusätzliche Konfiguration ist erforderlich, um eine Adresse von anderen Domänen als der Domäne der Website hinzuzufügen
+        geonames_username: Registrieren Sie sich unter http://www.geonames.org/manageaccount
+        file_acl: Deaktivieren Sie dies, wenn Sie ein Dateisystem wie Samba oder NFS verwenden, das das Festlegen von Zugriffssteuerungslisten nicht unterstützt
+        ssl_configured: Setzen Sie es auf wahr, wenn Sie https verwenden
       hyku_group:
         description: Eine kurze Zusammenfassung der Rolle der Gruppe
       user:
-        email: Geben Sie jeweils eine E-Mail-Adresse ein. Sie können eine Einladung auch über dieses Formular erneut senden.
+        email: Geben Sie jeweils eine E-Mail-Adresse ein. Sie können auch über dieses Formular erneut eine Einladung senden. Rollen gelten nur für diesen Mandanten.
     labels:
       account:
         admin_emails: Neuen Administrator hinzufügen oder einladen (per E-Mail)
-        cname: Mandanten CNAME
+        cname: Haupt-Domain-Name
         fcrepo_endpoint:
           base_path: Basispfad
           url: URL
-        gtm_id: Google-Tag-Manager
-        name: Kurzer Name
+        name: Kurzname
         solr_endpoint:
           url: URL
-        tenant: Mandanten UUID
+        tenant: Mandant UUID
+        gtm_id: Google Tag Manager
       add_user_to_group:
-        user_ids: Benutzeridentifikation
+        user_ids: Benutzer-ID
       defaults:
-        admin_note: Verwaltungshinweise
+        admin_note: Verwaltungsnotizen
       domain_names:
-        cname: Domänenname
+        cname: Domainname
       group_search:
         q: Suche
       hyku_group:
         description: Beschreibung
       page_size:
-        per: Show
+        per: Zeigen
       user:
-        display_name: Dein Name
-        email: E-Mail-Addresse
+        display_name: Ihr Name
+        email: E-Mail-Adresse
       user_search:
-        uq: Suche nach Benutzer
-    'no': Nein
+        uq: Benutzer suchen
+    'no': 'Nein'
     placeholders:
       user_search:
         uq: Name oder Benutzername
     required:
       mark: "*"
       text: erforderlich
-    'yes': Ja
+    'yes': 'Ja'

--- a/config/locales/simple_form.es.yml
+++ b/config/locales/simple_form.es.yml
@@ -3,62 +3,61 @@ es:
   simple_form:
     cancel: Cancelar
     error_notification:
-      default_message: 'Repase los problemas abajo, por favor:'
+      default_message: 'Por favor, revise los problemas a continuación:'
     hints:
       account:
-        admin_emails: Introduce una dirección de correo electrónico a la vez
-        allow_signup: Permita que los usuarios se registren en su repositorio
-        cache_api: Activa la memoria caché para los puntos finales de la API. Experimental
-        contact_email: Destinatario de correo electrónico de los mensajes enviados a través del formulario de contacto
-        contact_email_to: Dirección de correo electrónico que debe recibir correos electrónicos de contacto
-        doi_reader: Mostrar la capacidad de leer de Datacite para completar registros. WIP no usar
-        doi_writer: Escriba DOI para los registros. WIP no usar
-        email_format: Establezca una lista de dominios de correo electrónico que pueden registrarse en este repositorio, por ejemplo, (@ubiquitypress.com @gmail.com). Deje un solo espacio entre cada dominio.
-        email_subjet_prefix: Cadena para colocar delante de los asuntos de correo electrónico del sistema.
-        enable_oai_metadata: Habilitar o deshabilitar el enlace OAI
+        admin_emails: Introduzca una dirección de correo electrónico a la vez
+        is_public: '¿Pueden los usuarios descubrir su sitio en la página principal o acceder a sus páginas sin un nombre de usuario/contraseña especial?'
         fcrepo_endpoint:
-          base_path: Fedora base ruta debe comenzar con una barra y no terminar con una barra
+          base_path: La ruta base de Fedora debe comenzar con una barra y NO terminar con una barra
           url: La URL de Fedora no debe terminar con una barra
-        file_acl: Desactívelo si usa un sistema de archivos como samba o nfs que no admita la configuración de listas de control de acceso
-        file_size_limit: Esto debe establecerse en al menos 536870912000
-        geonames_username: Regístrese en http://www.geonames.org/manageaccount
-        google_analytics_id: El ID de su cuenta de Google Analytics
-        google_oauth_app_name: El nombre de la aplicación de Google en la consola API de Google
-        google_oauth_app_version: La versión de la aplicación de Google en la consola API de Google
-        google_oauth_client_email: Dirección de correo electrónico del cliente de OAuth
-        google_oauth_private_key_path: La ruta completa a su p12, archivo clave. (Puede usar el valor de la clave privada O la ruta; el valor tiene prioridad)
+        name: Un nombre único o con guiones utilizado para aspectos técnicos del repositorio (por ejemplo, "acme" o "acme-biblioteca").
+        gtm_id: La ID de su cuenta de Google Tag Manager
+        google_analytics_id: La ID de su cuenta de Google Analytics
+        google_oauth_app_name: El nombre de la aplicación de Google en la consola de API de Google
+        google_oauth_app_version: La versión de la aplicación de Google en la consola de API de Google
+        google_oauth_private_key_value: El valor del archivo p12 con cifrado base64. (Puede usar el valor de la clave privada O el camino; el valor tiene prioridad)
+        google_oauth_private_key_path: La ruta completa a su archivo p12, archivo clave. (Puede usar el valor de la clave privada O el camino; el valor tiene prioridad)
         google_oauth_private_key_secret: El secreto proporcionado cuando creó la clave p12
-        google_oauth_private_key_value: El valor del archivo p12 con cifrado base64. (Puede usar el valor de la clave privada O la ruta; el valor tiene prioridad)
-        gtm_id: El ID de su cuenta de Google Tag Manager
-        is_public: "¿Los usuarios pueden descubrir su sitio en la página de inicio o acceder a sus páginas sin un nombre de usuario/contraseña especiales?"
-        locale_name: 'El nombre del sufijo de configuración regional específico del arrendatario agregado a sus archivos locale.yml. Solo se deben agregar caracteres alfabéticos, sin símbolos ni números, estos se escribirán en mayúscula.
-
-          '
-        monthly_email_list: Lista de direcciones de correo electrónico para enviar por correo electrónico el informe mensual. Deje un solo espacio entre cada correo electrónico
-        name: Un nombre único o con guión utilizado para los aspectos técnicos del repositorio (por ejemplo, "acme" o "acme-library").
-        oai_admin_email: Dirección de correo electrónico de contacto del terminal OAI
-        shared_login: Habilitar o deshabilitar el inicio de sesión compartido
-        ssl_configured: Establézcalo en verdadero si usa https
-        weekly_email_list: Lista de direcciones de correo electrónico para enviar por correo electrónico el informe semanal. Deje un solo espacio entre cada correo electrónico
-        yearly_email_list: Lista de direcciones de correo electrónico para enviar por correo electrónico el informe anual. Deje un solo espacio entre cada correo electrónico
+        google_oauth_client_email: Dirección de correo electrónico del cliente OAuth
+        contact_email: La dirección de correo electrónico a la que se envían los mensajes enviados a través de la página de contacto
+        weekly_email_list: Lista de direcciones de correo electrónico para enviar el informe semanal. Deje un espacio entre cada correo electrónico
+        monthly_email_list: Lista de direcciones de correo electrónico para enviar el informe mensual. Deje un espacio entre cada correo electrónico
+        yearly_email_list: Lista de direcciones de correo electrónico para enviar el informe anual. Deje un espacio entre cada correo electrónico
+        email_format: Establezca una lista de dominios de correo electrónico que pueden registrarse en este repositorio, por ejemplo (@ubiquitypress.com @gmail.com). Deje un espacio entre cada dominio.
+        allow_signup: Permitir a los usuarios registrarse en su repositorio
+        enable_oai_metadata: Habilitar o deshabilitar el enlace OAI
+        shared_login: Habilitar o deshabilitar inicio de sesión compartido
+        file_size_limit: Esto debe establecerse al menos en 536870912000
+        locale_name: |
+          El nombre del sufijo de configuración regional específico del inquilino añadido a sus archivos locale.yml. Solo se deben agregar caracteres alfabéticos, no símbolos o números, estos se capitalizarán.
+        oai_admin_email: Dirección de correo electrónico de contacto del punto final OAI
+        doi_reader: Mostrar la capacidad de leer de Datacite para rellenar registros. WIP no usar
+        doi_writer: Escribir DOIs para registros. WIP no usar
+        cache_api: Activa la caché para puntos finales de API. Experimental
+        email_subjet_prefix: Cadena para poner al frente de los asuntos de correo electrónico del sistema.
+        contact_email_to: La dirección de correo electrónico desde la que se enviarán las notificaciones del sistema. Se requiere una configuración adicional para agregar una dirección de dominios distintos al dominio del sitio
+        geonames_username: Regístrese en http://www.geonames.org/manageaccount
+        file_acl: Desactívelo si usa un sistema de archivos como samba o nfs que no admite listas de control de acceso
+        ssl_configured: Establézcalo como verdadero si está utilizando https
       hyku_group:
-        description: Un breve resumen de la función del grupo
+        description: Un breve resumen del papel del grupo
       user:
-        email: Introduzca una dirección de correo electrónico a la vez. También puede reenviar una invitación a través de este formulario.
+        email: Introduzca una dirección de correo electrónico a la vez. También puede reenviar una invitación a través de este formulario. Los roles solo se aplican a este inquilino.
     labels:
       account:
-        admin_emails: Agregar o invitar al nuevo administrador (por correo electrónico)
-        cname: Inquilino CNAME
+        admin_emails: Añadir o invitar a un nuevo administrador (por correo electrónico)
+        cname: Nombre de dominio principal
         fcrepo_endpoint:
           base_path: Ruta base
           url: URL
-        gtm_id: Administrador de etiquetas de Google
         name: Nombre corto
         solr_endpoint:
           url: URL
-        tenant: Inquilino UUID
+        tenant: UUID del inquilino
+        gtm_id: Google Tag Manager
       add_user_to_group:
-        user_ids: Identidad de usuario
+        user_ids: ID de usuario
       defaults:
         admin_note: Notas administrativas
       domain_names:
@@ -70,7 +69,7 @@ es:
       page_size:
         per: Mostrar
       user:
-        display_name: Tu nombre
+        display_name: Su nombre
         email: Dirección de correo electrónico
       user_search:
         uq: Buscar usuario
@@ -80,5 +79,5 @@ es:
         uq: Nombre o nombre de usuario
     required:
       mark: "*"
-      text: obligatorio
-    'yes': Sí
+      text: requerido
+    'yes': 'Sí'

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -3,82 +3,81 @@ fr:
   simple_form:
     cancel: Annuler
     error_notification:
-      default_message: 'Veuillez examiner les problèmes ci-dessous:'
+      default_message: 'Veuillez examiner les problèmes ci-dessous :'
     hints:
       account:
         admin_emails: Entrez une adresse e-mail à la fois
-        allow_signup: Autoriser les utilisateurs à s'inscrire à votre référentiel
-        cache_api: Active le cache pour les points de terminaison d'API. Expérimental
-        contact_email: Email destinataire des messages envoyés via le formulaire de contact
-        contact_email_to: Adresse e-mail qui doit recevoir les e-mails de contact
-        doi_reader: Afficher la possibilité de lire à partir de Datacite pour remplir les enregistrements. WIP ne pas utiliser
-        doi_writer: Rédigez des DOI pour les enregistrements. WIP ne pas utiliser
-        email_format: Définissez une liste de domaines de messagerie autorisés à s'inscrire à ce référentiel, par exemple (@ubiquitypress.com @gmail.com). Laissez un seul espace entre chaque domaine.
-        email_subjet_prefix: Chaîne à placer devant les sujets des e-mails système.
-        enable_oai_metadata: Activer ou désactiver le lien OAI
+        is_public: "Les utilisateurs peuvent-ils découvrir votre site sur la page d'accueil ou accéder à vos pages sans identifiant/mot de passe spécifique?"
         fcrepo_endpoint:
-          base_path: Le chemin de base de Fedora doit commencer par une barre oblique ET ne pas se terminer par une barre oblique
-          url: Fedora URL ne devrait pas se terminer par une barre oblique
-        file_acl: Désactiver si vous utilisez un système de fichiers comme samba ou nfs qui ne prend pas en charge la définition de listes de contrôle d'accès
-        file_size_limit: Il doit être défini sur au moins 536870912000
-        geonames_username: Inscrivez-vous sur http://www.geonames.org/manageaccount
-        google_analytics_id: L'identifiant de votre compte Google Analytics
-        google_oauth_app_name: Le nom de l'application Google dans la console de l'API Google
-        google_oauth_app_version: La version de l'application Google dans la console de l'API Google
+          base_path: Le chemin de base de Fedora doit commencer par un slash et ne PAS se terminer par un slash
+          url: L'URL de Fedora ne doit pas se terminer par un slash
+        name: Un nom simple ou avec des tirets utilisé pour les aspects techniques du dépôt (par exemple, "acme" ou "acme-bibliothèque").
+        gtm_id: L'ID de votre compte Google Tag Manager
+        google_analytics_id: L'ID de votre compte Google Analytics
+        google_oauth_app_name: Le nom de l'application Google dans la console API de Google
+        google_oauth_app_version: La version de l'application Google dans la console API de Google
+        google_oauth_private_key_value: La valeur du fichier p12 avec cryptage base64. (Vous pouvez utiliser la valeur de la clé privée OU le chemin ; la valeur prime)
+        google_oauth_private_key_path: Le chemin complet vers votre fichier p12, fichier clé. (Vous pouvez utiliser la valeur de la clé privée OU le chemin ; la valeur prime)
+        google_oauth_private_key_secret: Le secret fourni lorsque vous avez créé la clé p12
         google_oauth_client_email: Adresse e-mail du client OAuth
-        google_oauth_private_key_path: Le chemin complet vers votre p12, fichier clé. (Vous pouvez utiliser la valeur de la clé privée OU le chemin ; la valeur est prioritaire)
-        google_oauth_private_key_secret: Le secret fourni lors de la création de la clé p12
-        google_oauth_private_key_value: La valeur du fichier p12 avec le cryptage base64. (Vous pouvez utiliser la valeur de la clé privée OU le chemin ; la valeur est prioritaire)
-        gtm_id: L'identifiant de votre compte Google Tag Manager
-        is_public: Les utilisateurs peuvent-ils découvrir votre site sur la page d'accueil ou accéder à vos pages sans nom d'utilisateur/mot de passe particulier ?
-        locale_name: 'Le nom du suffixe de paramètres régionaux spécifiques au locataire ajouté à leurs fichiers locale.yml. Seuls les caractères alphabétiques doivent être ajoutés, pas de symboles ni de chiffres, ceux-ci seront alors en majuscules.
-
-          '
-        monthly_email_list: Liste des adresses e-mail pour envoyer le rapport mensuel. Laissez un seul espace entre chaque email
-        name: Nom unique ou un trait d'union utilisé pour les aspects techniques du référentiel (par exemple, "acme" ou "acme-bibliothèque").
-        oai_admin_email: Adresse e-mail de contact du point de terminaison OAI
+        contact_email: L'adresse e-mail à laquelle les messages soumis via la page de contact sont envoyés
+        weekly_email_list: Liste des adresses e-mail pour envoyer le rapport hebdomadaire. Laissez un espace entre chaque e-mail
+        monthly_email_list: Liste des adresses e-mail pour envoyer le rapport mensuel. Laissez un espace entre chaque e-mail
+        yearly_email_list: Liste des adresses e-mail pour envoyer le rapport annuel. Laissez un espace entre chaque e-mail
+        email_format: Définissez une liste de domaines de messagerie autorisés à s'inscrire à ce dépôt, par exemple (@ubiquitypress.com @gmail.com). Laissez un espace entre chaque domaine.
+        allow_signup: Autoriser les utilisateurs à s'inscrire à votre dépôt
+        enable_oai_metadata: Activer ou désactiver le lien OAI
         shared_login: Activer ou désactiver la connexion partagée
-        ssl_configured: Définissez-le sur vrai si vous utilisez https
-        weekly_email_list: Liste des adresses e-mail pour envoyer le rapport hebdomadaire. Laissez un seul espace entre chaque email
-        yearly_email_list: Liste des adresses e-mail pour envoyer le rapport annuel. Laissez un seul espace entre chaque email
+        file_size_limit: Ceci doit être réglé à au moins 536870912000
+        locale_name: |
+          Le nom du suffixe de locale spécifique au locataire ajouté à leurs fichiers locale.yml. Seuls les caractères alphabétiques doivent être ajoutés, pas de symboles ou de chiffres, ceux-ci seront alors mis en majuscule.
+        oai_admin_email: Adresse e-mail de contact du point d'accès OAI
+        doi_reader: Afficher la capacité à lire depuis Datacite pour remplir les enregistrements. WIP ne pas utiliser
+        doi_writer: Écrire des DOIs pour les enregistrements. WIP ne pas utiliser
+        cache_api: Active le cache pour les points d'accès API. Expérimental
+        email_subjet_prefix: Chaîne à mettre devant les sujets des e-mails système.
+        contact_email_to: L'adresse e-mail à partir de laquelle les notifications système seront envoyées. Une configuration supplémentaire est nécessaire pour ajouter une adresse provenant de domaines autres que le domaine du site
+        geonames_username: Inscrivez-vous sur http://www.geonames.org/manageaccount
+        file_acl: Désactivez si vous utilisez un système de fichiers comme samba ou nfs qui ne prend pas en charge les listes de contrôle d'accès
+        ssl_configured: Mettez-le sur vrai si vous utilisez https
       hyku_group:
         description: Un bref résumé du rôle du groupe
       user:
-        email: Entrez une adresse e-mail à la fois. Vous pouvez également renvoyer une invitation via ce formulaire.
+        email: Entrez une adresse e-mail à la fois. Vous pouvez également renvoyer une invitation via ce formulaire. Les rôles ne s'appliquent qu'à ce locataire.
     labels:
       account:
-        admin_emails: Ajouter ou inviter un nouvel administrateur (par courrier électronique)
-        cname: Locataire CNAME
+        admin_emails: Ajouter ou inviter un nouvel administrateur (par e-mail)
+        cname: Nom de domaine principal
         fcrepo_endpoint:
           base_path: Chemin de base
           url: URL
-        gtm_id: Gestionnaire de balises Google
         name: Nom court
         solr_endpoint:
           url: URL
         tenant: UUID du locataire
+        gtm_id: Google Tag Manager
       add_user_to_group:
-        user_ids: Identifiant d'utilisateur
+        user_ids: ID utilisateur
       defaults:
-        admin_note: Remarques administratives
+        admin_note: Notes administratives
       domain_names:
         cname: Nom de domaine
       group_search:
-        q: Chercher
+        q: Recherche
       hyku_group:
-        description: La description
+        description: Description
       page_size:
-        per: Montrer
+        per: Afficher
       user:
-        display_name: votre nom
-        email: Adresse électronique
+        display_name: Votre nom
+        email: Adresse e-mail
       user_search:
         uq: Recherche d'utilisateur
-    'no': Non
+    'no': 'Non'
     placeholders:
       user_search:
         uq: Nom ou nom d'utilisateur
     required:
       mark: "*"
-      text: Champs obligatoires
-    'yes': Oui
+      text: requis
+    'yes': 'Oui'

--- a/config/locales/simple_form.it.yml
+++ b/config/locales/simple_form.it.yml
@@ -3,82 +3,81 @@ it:
   simple_form:
     cancel: Annulla
     error_notification:
-      default_message: 'Leggi i seguenti problemi:'
+      default_message: 'Si prega di rivedere i problemi di seguito:'
     hints:
       account:
         admin_emails: Inserisci un indirizzo email alla volta
-        allow_signup: Consenti agli utenti di registrarsi al tuo repository
-        cache_api: Attiva la cache per gli endpoint API. Sperimentale
-        contact_email: Email destinatario dei messaggi inviati tramite il modulo di contatto
-        contact_email_to: Indirizzo e-mail che dovrebbe ricevere le e-mail di contatto
-        doi_reader: Mostra la capacità di leggere da Datacite per popolare i record. WIP non utilizzare
-        doi_writer: Scrivi DOI per i record. WIP non utilizzare
-        email_format: Impostare un elenco di domini di posta elettronica a cui è consentito registrarsi a questo repository, ad esempio (@ubiquitypress.com @gmail.com). Lascia un singolo spazio tra ogni dominio.
-        email_subjet_prefix: Stringa da mettere davanti agli oggetti delle email di sistema.
-        enable_oai_metadata: Abilita o disabilita il collegamento OAI
+        is_public: 'Gli utenti possono scoprire il tuo sito nella pagina principale o accedere alle tue pagine senza un nome utente/password speciale?'
         fcrepo_endpoint:
-          base_path: Il percorso base di Fedora dovrebbe iniziare con una barra E non finire con una barra
+          base_path: Il percorso base di Fedora dovrebbe iniziare con una barra e NON terminare con una barra
           url: L'URL di Fedora non dovrebbe terminare con una barra
-        file_acl: Disattivare se si utilizza un file system come samba o nfs che non supporta l'impostazione degli elenchi di controllo degli accessi
-        file_size_limit: Questo dovrebbe essere impostato almeno su 536870912000
-        geonames_username: Registrati su http://www.geonames.org/manageaccount
-        google_analytics_id: L'ID del tuo account Google Analytics
-        google_oauth_app_name: Il nome dell'applicazione Google nella console dell'API di Google
-        google_oauth_app_version: La versione dell'applicazione Google nella console dell'API di Google
-        google_oauth_client_email: Indirizzo e-mail del client OAuth
-        google_oauth_private_key_path: Il percorso completo del tuo file chiave p12. (Puoi utilizzare il valore della chiave privata OR path; il valore ha la precedenza)
-        google_oauth_private_key_secret: Il segreto fornito quando hai creato la chiave p12
-        google_oauth_private_key_value: Il valore del file p12 con crittografia base64. (Puoi utilizzare il valore della chiave privata OR path; il valore ha la precedenza)
+        name: Un nome singolo o con trattino usato per gli aspetti tecnici del repository (ad es., "acme" o "acme-biblioteca").
         gtm_id: L'ID del tuo account Google Tag Manager
-        is_public: Gli utenti possono scoprire il tuo sito sulla home page o accedere alle tue pagine senza un nome utente/password speciale?
-        locale_name: 'Il nome del suffisso locale specifico del tenant aggiunto ai relativi file locale.yml. Dovrebbero essere aggiunti solo caratteri alfabetici, nessun simbolo o numero, questi saranno poi scritti in maiuscolo.
-
-          '
-        monthly_email_list: Elenco di indirizzi e-mail a cui inviare il rapporto mensile. Lascia un singolo spazio tra ogni email
-        name: Un nome singolo o sillabato utilizzato per gli aspetti tecnici del repository (ad es. "Acme" o "acme-library").
-        oai_admin_email: Indirizzo e-mail di contatto dell'endpoint OAI
+        google_analytics_id: L'ID del tuo account Google Analytics
+        google_oauth_app_name: Il nome dell'applicazione Google nella console API di Google
+        google_oauth_app_version: La versione dell'applicazione Google nella console API di Google
+        google_oauth_private_key_value: Il valore del file p12 con crittografia base64. (Puoi utilizzare il valore della chiave privata OPPURE il percorso; il valore ha la precedenza)
+        google_oauth_private_key_path: Il percorso completo del tuo file p12, file chiave. (Puoi utilizzare il valore della chiave privata OPPURE il percorso; il valore ha la precedenza)
+        google_oauth_private_key_secret: Il segreto fornito quando hai creato la chiave p12
+        google_oauth_client_email: Indirizzo email del client OAuth
+        contact_email: L'indirizzo email al quale i messaggi inviati tramite la pagina di contatto sono inviati
+        weekly_email_list: Lista di indirizzi email ai quali inviare il rapporto settimanale. Lascia uno spazio tra ogni email
+        monthly_email_list: Lista di indirizzi email ai quali inviare il rapporto mensile. Lascia uno spazio tra ogni email
+        yearly_email_list: Lista di indirizzi email ai quali inviare il rapporto annuale. Lascia uno spazio tra ogni email
+        email_format: Imposta una lista di domini email che possono iscriversi a questo repository es. (@ubiquitypress.com @gmail.com). Lascia uno spazio tra ogni dominio.
+        allow_signup: Permetti agli utenti di iscriversi al tuo repository
+        enable_oai_metadata: Abilita o disabilita il link OAI
         shared_login: Abilita o disabilita l'accesso condiviso
-        ssl_configured: Impostalo su vero se usi https
-        weekly_email_list: Elenco di indirizzi email a cui inviare il report settimanale. Lascia un singolo spazio tra ogni email
-        yearly_email_list: Elenco di indirizzi e-mail a cui inviare il rapporto annuale. Lascia un singolo spazio tra ogni email
+        file_size_limit: Questo dovrebbe essere impostato almeno a 536870912000
+        locale_name: |
+          Il nome del suffisso specifico del tenant aggiunto ai loro file locale.yml. Aggiungi solo caratteri alfabetici, niente simboli o numeri, questi saranno poi capitalizzati.
+        oai_admin_email: Indirizzo email di contatto dell'endpoint OAI
+        doi_reader: Mostra la capacità di leggere da Datacite per popolare i record. Lavoro in corso, non utilizzare
+        doi_writer: Scrivi DOI per i record. Lavoro in corso, non utilizzare
+        cache_api: Abilita la cache per gli endpoint API. Sperimentale
+        email_subjet_prefix: Stringa da mettere davanti agli oggetti delle email di sistema.
+        contact_email_to: L'indirizzo email da cui saranno inviate le notifiche di sistema. È richiesta una configurazione aggiuntiva per aggiungere un indirizzo da domini diversi dal dominio del sito
+        geonames_username: Registrati su http://www.geonames.org/manageaccount
+        file_acl: Disattiva se stai utilizzando un sistema di file come samba o nfs che non supporta le liste di controllo degli accessi
+        ssl_configured: Impostalo su vero se stai utilizzando https
       hyku_group:
-        description: Un breve riepilogo del ruolo del gruppo
+        description: Un breve riassunto del ruolo del gruppo
       user:
-        email: Inserisci un indirizzo email alla volta. Puoi anche inviare nuovamente un invito tramite questo modulo.
+        email: Inserisci un indirizzo email alla volta. Puoi anche inviare nuovamente un invito tramite questo modulo. I ruoli si applicano solo a questo tenant.
     labels:
       account:
-        admin_emails: Aggiungi o invita un nuovo amministratore (via email)
-        cname: Locatario CNAME
+        admin_emails: Aggiungi o invita un nuovo amministratore (tramite email)
+        cname: Nome di dominio principale
         fcrepo_endpoint:
-          base_path: Percorso di base
+          base_path: Percorso base
           url: URL
-        gtm_id: Gestore dei tag di Google
-        name: Nome corto
+        name: Nome breve
         solr_endpoint:
           url: URL
-        tenant: UUID tenant
+        tenant: UUID del tenant
+        gtm_id: Google Tag Manager
       add_user_to_group:
         user_ids: ID utente
       defaults:
-        admin_note: Note Amministrative
+        admin_note: Note amministrative
       domain_names:
-        cname: Nome del dominio
+        cname: Nome di dominio
       group_search:
         q: Ricerca
       hyku_group:
         description: Descrizione
       page_size:
-        per: Mostrare
+        per: Mostra
       user:
         display_name: Il tuo nome
         email: Indirizzo email
       user_search:
-        uq: Cerca Utente
+        uq: Ricerca utente
     'no': 'No'
     placeholders:
       user_search:
         uq: Nome o nome utente
     required:
       mark: "*"
-      text: necessario
-    'yes': sì
+      text: richiesto
+    'yes': 'Sì'

--- a/config/locales/simple_form.pt-BR.yml
+++ b/config/locales/simple_form.pt-BR.yml
@@ -6,79 +6,78 @@ pt-BR:
       default_message: 'Por favor, reveja os problemas abaixo:'
     hints:
       account:
-        admin_emails: Digite um endereço de email de cada vez
-        allow_signup: Permitir que os usuários se inscrevam em seu repositório
-        cache_api: Ativa o cache para terminais de API. Experimental
-        contact_email: Destinatário de e-mail de mensagens enviadas por meio do formulário de contato
-        contact_email_to: Endereço de e-mail que deve receber e-mails de contato
-        doi_reader: Mostrar capacidade de ler do Datacite para preencher registros. WIP não use
-        doi_writer: Escreva DOIs para registros. WIP não use
-        email_format: Defina uma lista de domínios de e-mail que podem se inscrever neste repositório, por exemplo (@ubiquitypress.com @gmail.com). Deixe um único espaço entre cada domínio.
-        email_subjet_prefix: String a ser colocada antes dos assuntos do e-mail do sistema.
-        enable_oai_metadata: Ativar ou desativar o link OAI
+        admin_emails: Insira um endereço de e-mail por vez
+        is_public: 'Os usuários podem descobrir seu site na página inicial ou acessar suas páginas sem um nome de usuário/senha especial?'
         fcrepo_endpoint:
-          base_path: O caminho base do Fedora deve começar com uma barra E não terminar com uma barra
-          url: O URL do Fedora não deve terminar com uma barra
-        file_acl: Desligue se estiver usando um sistema de arquivos como samba ou nfs que não suporta a configuração de listas de controle de acesso
-        file_size_limit: Isso deve ser definido para pelo menos 536870912000
-        geonames_username: Registre-se em http://www.geonames.org/manageaccount
-        google_analytics_id: O ID da sua conta do Google Analytics
-        google_oauth_app_name: O nome do aplicativo do Google no console de API do Google
-        google_oauth_app_version: A versão do aplicativo do Google no console de API do Google
-        google_oauth_client_email: Endereço de e-mail do cliente OAuth
-        google_oauth_private_key_path: O caminho completo para o seu p12, arquivo de chave. (Você pode usar o valor OU caminho da chave privada; o valor tem precedência)
+          base_path: O caminho base do Fedora deve começar com uma barra e NÃO terminar com uma barra
+          url: A URL do Fedora não deve terminar com uma barra
+        name: Um nome simples ou hifenizado usado para aspectos técnicos do repositório (por exemplo, "acme" ou "acme-biblioteca").
+        gtm_id: O ID da sua conta no Google Tag Manager
+        google_analytics_id: O ID da sua conta no Google Analytics
+        google_oauth_app_name: O nome do aplicativo Google no console da API do Google
+        google_oauth_app_version: A versão do aplicativo Google no console da API do Google
+        google_oauth_private_key_value: O valor do arquivo p12 com criptografia base64. (Você pode usar o valor da chave privada OU o caminho; o valor tem precedência)
+        google_oauth_private_key_path: O caminho completo para o seu arquivo p12, arquivo de chave. (Você pode usar o valor da chave privada OU o caminho; o valor tem precedência)
         google_oauth_private_key_secret: O segredo fornecido quando você criou a chave p12
-        google_oauth_private_key_value: O valor do arquivo p12 com criptografia base64. (Você pode usar o valor OU caminho da chave privada; o valor tem precedência)
-        gtm_id: O ID da sua conta do Gerenciador de tags do Google
-        is_public: Os usuários podem descobrir seu site na página inicial ou acessar suas páginas sem um nome de usuário/senha especial?
-        locale_name: 'O nome do sufixo de localidade específico do locatário incluído em seus arquivos locale.yml. Apenas caracteres alfabéticos devem ser adicionados, sem símbolos ou números, estes serão então maiúsculos.
-
-          '
-        monthly_email_list: Lista de endereços de e-mail para enviar o relatório mensal por e-mail. Deixe um único espaço entre cada e-mail
-        name: Um nome único ou hifenizado usado para aspectos técnicos do repositório (por exemplo, "acme" ou "acme-library").
-        oai_admin_email: Endereço de e-mail de contato do terminal OAI
+        google_oauth_client_email: Endereço de e-mail do cliente OAuth
+        contact_email: O endereço de e-mail para o qual as mensagens enviadas via página de contato são enviadas
+        weekly_email_list: Lista de endereços de e-mail para enviar o relatório semanal. Deixe um espaço único entre cada e-mail
+        monthly_email_list: Lista de endereços de e-mail para enviar o relatório mensal. Deixe um espaço único entre cada e-mail
+        yearly_email_list: Lista de endereços de e-mail para enviar o relatório anual. Deixe um espaço único entre cada e-mail
+        email_format: Defina uma lista de domínios de e-mail que são permitidos para se inscrever neste repositório, por exemplo (@ubiquitypress.com @gmail.com). Deixe um espaço único entre cada domínio.
+        allow_signup: Permitir que usuários se inscrevam no seu repositório
+        enable_oai_metadata: Habilitar ou desabilitar link OAI
         shared_login: Habilitar ou desabilitar login compartilhado
+        file_size_limit: Isso deve ser configurado para pelo menos 536870912000
+        locale_name: |
+          O nome do sufixo específico do inquilino adicionado aos seus arquivos locale.yml. Apenas caracteres alfabéticos devem ser adicionados, sem símbolos ou números, estes serão então capitalizados.
+        oai_admin_email: Endereço de e-mail de contato do ponto final OAI
+        doi_reader: Mostrar capacidade de ler da Datacite para preencher registros. Em desenvolvimento, não use
+        doi_writer: Escrever DOIs para registros. Em desenvolvimento, não use
+        cache_api: Ativar cache para pontos finais de API. Experimental
+        email_subjet_prefix: String para colocar na frente dos assuntos dos e-mails do sistema.
+        contact_email_to: O endereço de e-mail do qual as notificações do sistema serão enviadas. Uma configuração adicional é necessária para adicionar um endereço de domínios diferentes do domínio do site
+        geonames_username: Registre-se em http://www.geonames.org/manageaccount
+        file_acl: Desative se estiver usando um sistema de arquivos como samba ou nfs que não suporta listas de controle de acesso
         ssl_configured: Defina como verdadeiro se estiver usando https
-        weekly_email_list: Lista de endereços de e-mail para enviar o relatório semanal. Deixe um único espaço entre cada e-mail
-        yearly_email_list: Lista de endereços de e-mail para enviar o relatório anual. Deixe um único espaço entre cada e-mail
       hyku_group:
         description: Um breve resumo do papel do grupo
       user:
-        email: Digite um endereço de e-mail por vez. Você também pode reenviar um convite por meio deste formulário.
+        email: Insira um endereço de e-mail por vez. Você também pode reenviar um convite por meio deste formulário. Funções aplicam-se apenas a este inquilino.
     labels:
       account:
-        admin_emails: Adicionar ou convidar novo administrador (via email)
-        cname: CNAME do inquilino
+        admin_emails: Adicionar ou convidar novo administrador (via e-mail)
+        cname: Nome de Domínio Primário
         fcrepo_endpoint:
-          base_path: Caminho base
+          base_path: Caminho Base
           url: URL
-        gtm_id: Gerenciador de tags do Google
         name: Nome curto
         solr_endpoint:
           url: URL
-        tenant: Inquilino UUID
+        tenant: UUID do inquilino
+        gtm_id: Google Tag Manager
       add_user_to_group:
         user_ids: ID do usuário
       defaults:
-        admin_note: Notas Administrativas
+        admin_note: Notas administrativas
       domain_names:
-        cname: Nome do domínio
+        cname: Nome de Domínio
       group_search:
-        q: Pesquisa
+        q: Pesquisar
       hyku_group:
         description: Descrição
       page_size:
-        per: exposição
+        per: Mostrar
       user:
         display_name: Seu nome
         email: Endereço de e-mail
       user_search:
-        uq: Pesquisar usuário
-    'no': Não
+        uq: Pesquisar por usuário
+    'no': 'Não'
     placeholders:
       user_search:
         uq: Nome ou nome de usuário
     required:
       mark: "*"
-      text: requeridos
-    'yes': sim
+      text: obrigatório
+    'yes': 'Sim'

--- a/config/locales/simple_form.zh.yml
+++ b/config/locales/simple_form.zh.yml
@@ -3,64 +3,63 @@ zh:
   simple_form:
     cancel: 取消
     error_notification:
-      default_message: 请查看以下问题：
+      default_message: '请检查以下问题：'
     hints:
       account:
         admin_emails: 一次输入一个电子邮件地址
-        allow_signup: 允许用户注册到您的存储库
-        cache_api: 为 API 端点打开缓存。实验性的
-        contact_email: 通过联系表发送的邮件的电子邮件收件人
-        contact_email_to: 应接收联系电子邮件的电子邮件地址
-        doi_reader: 显示从 Datacite 读取数据以填充记录的能力。 WIP 不使用
-        doi_writer: 为记录写 DOI。 WIP 不使用
-        email_format: 设置允许注册此存储库的电子邮件域列表，例如 (@ubiquitypress.com @gmail.com)。在每个域之间留一个空格。
-        email_subjet_prefix: 放在系统电子邮件主题前面的字符串。
-        enable_oai_metadata: 启用或禁用 OAI 链接
+        is_public: '用户可以在主页上发现您的网站，或者不需要特殊的用户名/密码就可以访问您的页面吗？'
         fcrepo_endpoint:
-          base_path: Fedora 基本路径应以斜线开始，而不是以斜杠结尾
-          url: Fedora 网址不应以斜线结尾
-        file_acl: 如果使用不支持设置访问控制列表的文件系统（如 samba 或 nfs），请关闭
-        file_size_limit: 这应该至少设置为 536870912000
-        geonames_username: 在 http://www.geonames.org/manageaccount 注册
-        google_analytics_id: 您的 Google Analytics 帐户的 ID
-        google_oauth_app_name: Google API 控制台中 Google 应用程序的名称
-        google_oauth_app_version: Google API 控制台中的 Google 应用程序版本
-        google_oauth_client_email: OAuth 客户端电子邮件地址
-        google_oauth_private_key_path: p12 密钥文件的完整路径。 （您可以使用私钥值或路径；值优先）
-        google_oauth_private_key_secret: 创建 p12 密钥时提供的秘密
-        google_oauth_private_key_value: base64加密的p12文件的值。 （您可以使用私钥值或路径；值优先）
-        gtm_id: 您的 Google 跟踪代码管理器帐户的 ID
-        is_public: 用户是否可以在主页上发现您的站点或在没有特殊用户名/密码的情况下访问您的页面？
-        locale_name: '添加到其 locale.yml 文件的租户特定区域设置后缀的名称。只能添加字母字符，不能添加符号或数字，这些将被大写。
-
-          '
-        monthly_email_list: 用于发送月度报告的电子邮件地址列表。在每封电子邮件之间留一个空格
-        name: 用于存储库技术方面的单个或连字符名称（例如“acme”或“acme-library”）。
-        oai_admin_email: OAI 端点联系人电子邮件地址
+          base_path: Fedora基本路径应该以斜杠开始且不应该以斜杠结束
+          url: Fedora URL不应该以斜杠结束
+        name: 用于存储技术方面的单一或连字符名称（例如，“acme”或“acme-library”）。
+        gtm_id: 您的Google标签管理器帐户ID
+        google_analytics_id: 您的Google Analytics帐户ID
+        google_oauth_app_name: Google API控制台中的Google应用程序名称
+        google_oauth_app_version: Google API控制台中的Google应用版本
+        google_oauth_private_key_value: 带有base64加密的p12文件的值。（您可以使用私钥值或路径；值优先）
+        google_oauth_private_key_path: 您的p12密钥文件的完整路径。（您可以使用私钥值或路径；值优先）
+        google_oauth_private_key_secret: 创建p12密钥时提供的秘密
+        google_oauth_client_email: OAuth客户电子邮件地址
+        contact_email: 通过联系页面提交的消息发送到的电子邮件地址
+        weekly_email_list: 每周报告的电子邮件地址列表。每个电子邮件之间留一个空格
+        monthly_email_list: 每月报告的电子邮件地址列表。每个电子邮件之间留一个空格
+        yearly_email_list: 每年报告的电子邮件地址列表。每个电子邮件之间留一个空格
+        email_format: 设置允许注册此存储库的电子邮件域的列表，例如(@ubiquitypress.com @gmail.com)。每个域之间留一个空格。
+        allow_signup: 允许用户注册您的存储库
+        enable_oai_metadata: 启用或禁用OAI链接
         shared_login: 启用或禁用共享登录
-        ssl_configured: 如果使用 https，请将其设置为 true
-        weekly_email_list: 用于发送每周报告的电子邮件地址列表。在每封电子邮件之间留一个空格
-        yearly_email_list: 通过电子邮件发送年度报告的电子邮件地址列表。在每封电子邮件之间留一个空格
+        file_size_limit: 此值应至少设置为536870912000
+        locale_name: |
+          添加到其locale.yml文件的租户特定语言环境后缀的名称。只应添加字母字符，不应添加符号或数字，这些将随后大写。
+        oai_admin_email: OAI端点联系电子邮件地址
+        doi_reader: 显示从Datacite读取以填充记录的能力。仍在进行中，请勿使用
+        doi_writer: 为记录编写DOIs。仍在进行中，请勿使用
+        cache_api: 打开API端点的缓存。实验性
+        email_subjet_prefix: 放在系统电子邮件主题前面的字符串。
+        contact_email_to: 系统通知将从其中发送的电子邮件地址。需要额外的配置才能从网站域以外的域添加地址
+        geonames_username: 在http://www.geonames.org/manageaccount上注册
+        file_acl: 如果使用不支持设置访问控制列表的文件系统（如samba或nfs），请关闭它
+        ssl_configured: 如果使用https，请将其设置为true
       hyku_group:
-        description: 小组角色的简要总结
+        description: 该组的角色简介
       user:
-        email: 一次输入一个电子邮件地址。您也可以通过此表单重新发送邀请。
+        email: 一次输入一个电子邮件地址。您也可以通过此表格重新发送邀请。角色仅适用于此租户。
     labels:
       account:
-        admin_emails: 添加或邀请新的管理员（通过电子邮件）
-        cname: 承租人 CNAME
+        admin_emails: 添加或邀请新管理员（通过电子邮件）
+        cname: 主域名
         fcrepo_endpoint:
           base_path: 基本路径
-          url: 网址
-        gtm_id: 谷歌标签管理器
+          url: URL
         name: 简称
         solr_endpoint:
-          url: 网址
-        tenant: 承租人 UUID
+          url: URL
+        tenant: 租户UUID
+        gtm_id: Google标签管理器
       add_user_to_group:
-        user_ids: 用户名
+        user_ids: 用户ID
       defaults:
-        admin_note: 行政笔记
+        admin_note: 管理员备注
       domain_names:
         cname: 域名
       group_search:
@@ -70,15 +69,15 @@ zh:
       page_size:
         per: 显示
       user:
-        display_name: 你的名字
+        display_name: 您的名字
         email: 电子邮件地址
       user_search:
-        uq: 搜索用户
-    'no': 没有
+        uq: 用户搜索
+    'no': '否'
     placeholders:
       user_search:
         uq: 名称或用户名
     required:
       mark: "*"
-      text: 需要
-    'yes': 是
+      text: 必填
+    'yes': '是'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       timeout: "8s"
 
   solr:
-    image: hyku/solr:8
+    image: ghcr.io/samvera/hyku/solr:${SOLR_TAG:-latest}
     build:
       context: solr
       dockerfile: Dockerfile
@@ -83,11 +83,11 @@ services:
     networks:
       internal:
     healthcheck:
-      test: curl -sf http://$$SOLR_ADMIN_USER:$$SOLR_ADMIN_PASSWORD@localhost:8983/solr/admin/cores?action=STATUS || exit 1
-      start_period: 30s
-      interval: 20s
+      test: curl -sf http://$$SOLR_ADMIN_USER:$$SOLR_ADMIN_PASSWORD@solr:8983/solr/admin/cores?action=STATUS || exit 1
+      start_period: 3s
+      interval: 5s
       timeout: 5s
-      retries: 3
+      retries: 6
     depends_on:
       zoo:
         condition: service_healthy


### PR DESCRIPTION
# Summary 
The account setting's descriptions for contact_email and contact_email_to are confusing. This commit adds clarity to these configuration options. c/o Palni-Palci

TODO: 
- run translations
- Update superadmin logic. contact_email and contact_email_to should be viewable to non super admins too. 

## BEFORE

<img width="549" alt="image" src="https://github.com/samvera/hyku/assets/10081604/6d02b9f2-eb68-42d6-ba14-d51939a627bc">


## AFTER

<img width="1071" alt="image" src="https://github.com/samvera/hyku/assets/10081604/02cabfc7-5f3c-43dc-92fe-c2f2e52b31a5">


ref: https://github.com/scientist-softserv/palni-palci/issues/841#issuecomment-1765451579