### PR TITLE
I748 sort works and collections on dashboard

### DIFF
--- a/app/controllers/hyrax/my/works_controller_decorator.rb
+++ b/app/controllers/hyrax/my/works_controller_decorator.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module My
+    module WorksControllerDecorator
+      def configure_facets
+        configure_blacklight do |config|
+          config.sort_fields.each_key do |key|
+            config.sort_fields.delete(key)
+          end
+
+          config.add_sort_field "date_uploaded_dtsi desc", label: "date uploaded \u25BC"
+          config.add_sort_field "date_uploaded_dtsi asc", label: "date uploaded \u25B2"
+          config.add_sort_field "date_modified_dtsi desc", label: "date modified \u25BC"
+          config.add_sort_field "date_modified_dtsi asc", label: "date modified \u25B2"
+          config.add_sort_field "system_create_dtsi desc", label: "date created \u25BC"
+          config.add_sort_field "system_create_dtsi asc", label: "date created \u25B2"
+          config.add_sort_field "depositor_ssi asc, title_ssi asc", label: "depositor (A-Z)"
+          config.add_sort_field "depositor_ssi desc, title_ssi desc", label: "depositor (Z-A)"
+          config.add_sort_field "creator_ssi asc, title_ssi asc", label: "creator (A-Z)"
+          config.add_sort_field "creator_ssi desc, title_ssi desc", label: "creator (Z-A)"
+        end
+      end
+    end
+  end
+end
+
+Hyrax::My::WorksController.singleton_class.send(:prepend, Hyrax::My::WorksControllerDecorator)
+Hyrax::My::WorksController.configure_facets

--- a/app/helpers/blacklight/configuration_helper_behavior_decorator.rb
+++ b/app/helpers/blacklight/configuration_helper_behavior_decorator.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# OVERRIDE Blacklight v6.25.0 to add custom sort fields while in the dashboard for both collections and works
+
+module Blacklight::ConfigurationHelperBehavior
+  def active_sort_fields
+    if dashboard_controller_and_index_action?
+      dashboard_sort_fields.sort_fields.select { |_sort_key, field_config| should_render_field?(field_config) }
+    else
+      blacklight_config.sort_fields.select { |_sort_key, field_config| should_render_field?(field_config) }
+    end
+  end
+
+  def dashboard_controller_and_index_action?
+    (params[:controller].include?('hyrax/my/collections') || params[:controller].include?('hyrax/dashboard/collections')) && action_name == 'index'
+  end
+
+  def dashboard_sort_fields
+    @dashboard_sort_fields = Blacklight::Configuration.new do |config|
+      config.sort_fields.each_key do |key|
+        config.sort_fields.delete(key)
+      end
+
+      # Collections don't seem to have a date_uploaded_dtsi nor date_modified_dtsi
+      # we can at least use the system_modified_dtsi instead of date_modified_dtsi
+      # but we will omit date_uploaded_dtsi
+      config.add_sort_field "system_modified_dtsi desc", label: "date modified \u25BC"
+      config.add_sort_field "system_modified_dtsi asc", label: "date modified \u25B2"
+      config.add_sort_field "system_create_dtsi desc", label: "date created \u25BC"
+      config.add_sort_field "system_create_dtsi asc", label: "date created \u25B2"
+      config.add_sort_field "depositor_ssi asc, title_ssi asc", label: "depositor (A-Z)"
+      config.add_sort_field "depositor_ssi desc, title_ssi desc", label: "depositor (Z-A)"
+      config.add_sort_field "creator_ssi asc, title_ssi asc", label: "creator (A-Z)"
+      config.add_sort_field "creator_ssi desc, title_ssi desc", label: "creator (Z-A)"
+    end
+  end
+
+  def sort_field_label(key)
+    field_config = if @dashboard_sort_fields
+                     @dashboard_sort_fields&.sort_fields[key]
+                   else
+                     blacklight_config.sort_fields[key]
+                   end
+    field_config ||= Blacklight::Configuration::NullField.new(key: key)
+
+    field_label(
+      :"blacklight.search.fields.sort.#{key}",
+      (field_config&.label),
+      key.to_s.humanize
+    )
+  end
+end

--- a/app/helpers/blacklight/configuration_helper_behavior_decorator.rb
+++ b/app/helpers/blacklight/configuration_helper_behavior_decorator.rb
@@ -2,51 +2,51 @@
 
 # OVERRIDE Blacklight v6.25.0 to add custom sort fields while in the dashboard for both collections and works
 
-module Blacklight::ConfigurationHelperBehavior
-  def active_sort_fields
-    if dashboard_controller_and_index_action?
-      dashboard_sort_fields.sort_fields.select { |_sort_key, field_config| should_render_field?(field_config) }
-    else
-      blacklight_config.sort_fields.select { |_sort_key, field_config| should_render_field?(field_config) }
+module Blacklight
+  module ConfigurationHelperBehavior
+    def active_sort_fields
+      config = if dashboard_controller_and_index_action?
+                 dashboard_config
+               else
+                 blacklight_config
+               end
+
+      config.sort_fields.select { |_sort_key, field_config| should_render_field?(field_config) }
     end
-  end
 
-  def dashboard_controller_and_index_action?
-    (params[:controller].include?('hyrax/my/collections') || params[:controller].include?('hyrax/dashboard/collections')) && action_name == 'index'
-  end
+    def dashboard_controller_and_index_action?
+      (params[:controller].include?('hyrax/my/collections') || params[:controller].include?('hyrax/dashboard/collections')) && action_name == 'index'
+    end
 
-  def dashboard_sort_fields
-    @dashboard_sort_fields = Blacklight::Configuration.new do |config|
-      config.sort_fields.each_key do |key|
-        config.sort_fields.delete(key)
+    def dashboard_config
+      @dashboard_config ||= Blacklight::Configuration.new do |config|
+        # Collections don't seem to have a date_uploaded_dtsi nor date_modified_dtsi
+        # we can at least use the system_modified_dtsi instead of date_modified_dtsi
+        # but we will omit date_uploaded_dtsi
+        config.add_sort_field "system_modified_dtsi desc", label: "date modified \u25BC"
+        config.add_sort_field "system_modified_dtsi asc", label: "date modified \u25B2"
+        config.add_sort_field "system_create_dtsi desc", label: "date created \u25BC"
+        config.add_sort_field "system_create_dtsi asc", label: "date created \u25B2"
+        config.add_sort_field "depositor_ssi asc, title_ssi asc", label: "depositor (A-Z)"
+        config.add_sort_field "depositor_ssi desc, title_ssi desc", label: "depositor (Z-A)"
+        config.add_sort_field "creator_ssi asc, title_ssi asc", label: "creator (A-Z)"
+        config.add_sort_field "creator_ssi desc, title_ssi desc", label: "creator (Z-A)"
       end
-
-      # Collections don't seem to have a date_uploaded_dtsi nor date_modified_dtsi
-      # we can at least use the system_modified_dtsi instead of date_modified_dtsi
-      # but we will omit date_uploaded_dtsi
-      config.add_sort_field "system_modified_dtsi desc", label: "date modified \u25BC"
-      config.add_sort_field "system_modified_dtsi asc", label: "date modified \u25B2"
-      config.add_sort_field "system_create_dtsi desc", label: "date created \u25BC"
-      config.add_sort_field "system_create_dtsi asc", label: "date created \u25B2"
-      config.add_sort_field "depositor_ssi asc, title_ssi asc", label: "depositor (A-Z)"
-      config.add_sort_field "depositor_ssi desc, title_ssi desc", label: "depositor (Z-A)"
-      config.add_sort_field "creator_ssi asc, title_ssi asc", label: "creator (A-Z)"
-      config.add_sort_field "creator_ssi desc, title_ssi desc", label: "creator (Z-A)"
     end
-  end
 
-  def sort_field_label(key)
-    field_config = if @dashboard_sort_fields
-                     @dashboard_sort_fields&.sort_fields[key]
-                   else
-                     blacklight_config.sort_fields[key]
-                   end
-    field_config ||= Blacklight::Configuration::NullField.new(key: key)
+    def sort_field_label(key)
+      field_config = if dashboard_controller_and_index_action?
+                       dashboard_config.sort_fields[key]
+                     else
+                       blacklight_config.sort_fields[key]
+                     end
+      field_config ||= Blacklight::Configuration::NullField.new(key: key)
 
-    field_label(
-      :"blacklight.search.fields.sort.#{key}",
-      (field_config&.label),
-      key.to_s.humanize
-    )
+      field_label(
+        :"blacklight.search.fields.sort.#{key}",
+        (field_config&.label),
+        key.to_s.humanize
+      )
+    end
   end
 end

--- a/app/indexers/app_indexer.rb
+++ b/app/indexers/app_indexer.rb
@@ -13,6 +13,8 @@ class AppIndexer < Hyrax::WorkIndexer
   def generate_solr_document
     super.tap do |solr_doc|
       solr_doc['title_ssi'] = SortTitle.new(object.title.first).alphabetical
+      solr_doc['depositer_ssi'] = object.depositor
+      solr_doc['creator_ssi'] = object.creator&.first
       solr_doc['bulkrax_identifier_tesim'] = object.bulkrax_identifier
       solr_doc['account_cname_tesim'] = Site.instance&.account&.cname
       solr_doc['all_text_tsimv'] = full_text(object.file_sets.first&.id)

--- a/app/indexers/collection_indexer.rb
+++ b/app/indexers/collection_indexer.rb
@@ -10,6 +10,8 @@ class CollectionIndexer < Hyrax::CollectionIndexer
     super.tap do |solr_doc|
       solr_doc['bulkrax_identifier_tesim'] = object.bulkrax_identifier
       solr_doc['title_ssi'] = SortTitle.new(object.title.first).alphabetical
+      solr_doc['depositer_ssi'] = object.depositor
+      solr_doc['creator_ssi'] = object.creator&.first
       solr_doc["account_cname_tesim"] = Site.instance&.account&.cname
     end
   end

--- a/app/services/hyrax/search_service_decorator.rb
+++ b/app/services/hyrax/search_service_decorator.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# OVERRIDE Hyrax 3.6.0 to add custom sort fields
+
+module Hyrax
+  module SearchServiceDecorator
+    def search_results
+      builder = search_builder.with(user_params)
+      builder.page = user_params[:page] if user_params[:page]
+      builder.rows = (user_params[:per_page] || user_params[:rows]) if user_params[:per_page] || user_params[:rows]
+
+      builder = yield(builder) if block_given?
+      # OVERRIDE: without this merge, Blightlight seems to ignore the sort params on Collections
+      builder.merge(sort: user_params[:sort]) if user_params[:sort]
+      response = repository.search(builder)
+
+      if response.grouped? && grouped_key_for_results
+        [response.group(grouped_key_for_results), []]
+      elsif response.grouped? && response.grouped.length == 1
+        [response.grouped.first, []]
+      else
+        [response, response.documents]
+      end
+    end
+  end
+end
+
+Hyrax::SearchService.prepend Hyrax::SearchServiceDecorator

--- a/app/views/hyrax/my/_search_header.html.erb
+++ b/app/views/hyrax/my/_search_header.html.erb
@@ -1,0 +1,17 @@
+<%# OVERRIDE Hyrax 3.6.0 to add catalog/sort_widget %>
+<%= render 'did_you_mean' %>
+
+<%= render 'facets' %>
+<%= render 'constraints' %>
+
+<div class="row">
+  <div class="col-sm-5">
+    <%= render 'hyrax/my/sort_and_per_page' %>
+    <%= render 'catalog/sort_widget' %>
+  </div>
+  <div class="col-sm-7">
+    <%= render 'search_form' %>
+  </div>
+</div>
+
+<%= render 'batch_actions' %>

--- a/spec/controllers/hyrax/my/works_controller_spec.rb
+++ b/spec/controllers/hyrax/my/works_controller_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+RSpec.describe Hyrax::My::WorksController, type: :controller do
+  describe "#configure_facets" do
+    subject { controller.blacklight_config.sort_fields.keys }
+
+    let(:expected_sort_fields) do
+      [
+        "date_uploaded_dtsi desc",
+        "date_uploaded_dtsi asc",
+        "date_modified_dtsi desc",
+        "date_modified_dtsi asc",
+        "system_create_dtsi desc",
+        "system_create_dtsi asc",
+        "depositor_ssi asc, title_ssi asc",
+        "depositor_ssi desc, title_ssi desc",
+        "creator_ssi asc, title_ssi asc",
+        "creator_ssi desc, title_ssi desc"
+      ]
+    end
+
+    it "configures the custom sort fields" do
+      expect(subject).to match_array(expected_sort_fields)
+    end
+  end
+end


### PR DESCRIPTION
# Story

[🎁 Add sort on dashboard works](https://github.com/scientist-softserv/palni-palci/commit/3afa0dd01ed4f3acf252da95cd48e7aed070c2d8) 

This commit will add the ability to sort on the dashboard works pages,
to include dashboard works and my works.

[🎁 Add ability to sort dashboard collections](https://github.com/scientist-softserv/palni-palci/commit/03efb9038a43a694fc8f8e06c96e842b4a5ec8f7) 

This commit will add the ability to sort collections on the dashboard.
The collections work differently than the works so we have to make sure
the sort field is added to the search builder.  Because when you click
into a collection can view the works attached to the collection, we have
to approach it differently because otherwise the sort fields from the
dashboard index page will also be applied to the show page.  We decorate
Blacklight helpers to check the controller action name as our
conditional.

Ref:
  - https://github.com/scientist-softserv/palni-palci/issues/748

# Screenshots / Video

https://github.com/scientist-softserv/palni-palci/assets/19597776/36414e44-72a2-4617-b7ae-c28354efb587

# Note
Reindexing is needed to get sorting by depositor and creator working.