### PR TITLE
🧹 Fix cropper tool. It wasn't loading.

### DIFF
--- a/app/views/hyrax/admin/appearances/_banner_image_form.html.erb
+++ b/app/views/hyrax/admin/appearances/_banner_image_form.html.erb
@@ -41,7 +41,7 @@
     }
   });
 
-  var inputImage = document.querySelector('[name="form[banner_image]"]');
+  var inputImage = document.querySelector('[name="admin_appearance[banner_image]"]');
 
   inputImage.addEventListener('change', function(e) {
     var files = e.target.files;


### PR DESCRIPTION
# Story

We updated the reference to an element in a previous commit and forgot to do it in all the necessary places. Because of this, the banner image crop feature stopped working in staging and failed QA

![image](https://github.com/scientist-softserv/palni-palci/assets/10081604/b8a6b785-fe38-4092-96dd-d4836ce94516)

![image](https://github.com/scientist-softserv/palni-palci/assets/10081604/4c14312b-59cf-4cae-998c-cd177fc3c086)


