### PR TITLE
🧹 contact_email_to should be exposed to non-superadmins

### DIFF
--- a/app/models/account.rb
+++ b/app/models/account.rb
@@ -47,8 +47,8 @@ class Account < ApplicationRecord
                      unless: proc { |a| a.tenant == 'public' || a.tenant == 'single' }
 
   SUPERADMIN_SETTINGS = [:analytics_provider, :contact_email, :file_acl,
-                              :file_size_limit, :oai_prefix,
-                              :oai_sample_identifier, :s3_bucket].freeze
+                         :file_size_limit, :oai_prefix,
+                         :oai_sample_identifier, :s3_bucket].freeze
 
   def self.superadmin_settings
     SUPERADMIN_SETTINGS

--- a/app/models/concerns/account_settings.rb
+++ b/app/models/concerns/account_settings.rb
@@ -113,7 +113,7 @@ module AccountSettings
 
   def public_settings(is_superadmin: false)
     settings = all_settings
-    settings = superadmin_settings unless is_superadmin
+    settings = restricted_settings unless is_superadmin
     settings.reject { |k, v| Account.private_settings.include?(k.to_s) || v[:disabled] }
   end
 
@@ -239,7 +239,7 @@ module AccountSettings
       # rubocop:enable Style/RedundantSelf
     end
 
-    def superadmin_settings
+    def restricted_settings
       all_settings.reject { |k, _v| Account.superadmin_settings.include?(k.to_sym) }
     end
 end

--- a/spec/models/concerns/account_settings_spec.rb
+++ b/spec/models/concerns/account_settings_spec.rb
@@ -44,10 +44,11 @@ RSpec.describe AccountSettings do
     context 'when is_superadmin is false' do
       # rubocop:disable RSpec/ExampleLength
       it 'returns all settings except private, disabled, and superadmin settings' do
-        expect(Account::SUPERADMIN_SETTINGS_ONLY.size).to eq 8
+        expect(Account::SUPERADMIN_SETTINGS.size).to eq 7
         expect(account.public_settings(is_superadmin: false).keys.sort).to eq %i[allow_downloads
                                                                                  allow_signup
                                                                                  cache_api
+                                                                                 contact_email_to
                                                                                  doi_reader
                                                                                  doi_writer
                                                                                  email_domain
@@ -66,7 +67,7 @@ RSpec.describe AccountSettings do
                                                                                  smtp_settings
                                                                                  solr_collection_options
                                                                                  ssl_configured]
-        expect(account.public_settings(is_superadmin: false).size).to eq 21
+        expect(account.public_settings(is_superadmin: false).size).to eq 22
       end
       # rubocop:enable RSpec/ExampleLength
     end


### PR DESCRIPTION
This PR makes changes based on the client's clarifications: non super admins should have access to contact_email_to 

Issue:
- https://github.com/scientist-softserv/palni-palci/issues/841

# Expected Behavior Before Changes

<details> <summary> screenshot (non superadmin user) </summary>

![image](https://github.com/scientist-softserv/palni-palci/assets/10081604/d0babdb3-8b6a-4c1a-9b70-c8b8bc25a02e)

</details>

<details> <summary> screenshot (superadmin user) </summary>

![image](https://github.com/scientist-softserv/palni-palci/assets/10081604/1daf1618-9fc9-462f-8c46-4249294ef721)

</details>

# Expected Behavior After Changes
<details> <summary> screenshot (non superadmin user) </summary>

![image](https://github.com/scientist-softserv/palni-palci/assets/10081604/5029eb16-c3db-47a9-8324-ac3fe3a00e31)

</details>

<details> <summary> screenshot (superadmin user) </summary>

![image](https://github.com/scientist-softserv/palni-palci/assets/10081604/d1e3c47a-76fe-4fd3-ba1a-e5527cefb6e8)

</details>
