### PR TITLE
🧹 Add contact_email_to to permitted params

### DIFF
--- a/app/controllers/admin/accounts_controller.rb
+++ b/app/controllers/admin/accounts_controller.rb
@@ -29,7 +29,10 @@ module Admin
     private
 
       def account_params
-        params.require(:account).permit(:name, :cname, :title, *@account.public_settings.keys)
+        params.require(:account).permit(:name, :cname, :title,
+                                        *@account.public_settings(
+                                          is_superadmin: current_user.is_superadmin
+                                        ).keys)
       end
 
       def set_current_account


### PR DESCRIPTION
We noticed in staging that we weren't able to save the form when filling out the contact to account field. This is because it was considered an unpermitted param.

related: https://github.com/scientist-softserv/palni-palci/issues/841

![Screen Recording 2023-10-17 at 11 39 56 AM](https://github.com/scientist-softserv/palni-palci/assets/10081604/67b24d7d-01c0-4bfd-bf6a-e254301ad1cb)

