### PR TITLE
🧹 rework: A user should see the parent work link if they can

### DIFF
--- a/app/presenters/hyku/work_show_presenter.rb
+++ b/app/presenters/hyku/work_show_presenter.rb
@@ -92,9 +92,18 @@ module Hyku
       show_pdf_download_button.first.to_i.positive?
     end
 
-    def parent_works
-      @parent_works ||= solr_document.load_parent_docs
+    def parent_works(current_user = nil)
+      @parent_works ||= begin
+        docs = solr_document.load_parent_docs
+    
+        if current_user
+          docs.select { |doc| current_user.ability.can?(:read, doc) }
+        else
+          docs.select(&:public?)
+        end
+      end
     end
+    
 
     private
 

--- a/app/views/hyrax/base/_relationships.html.erb
+++ b/app/views/hyrax/base/_relationships.html.erb
@@ -5,13 +5,8 @@
     <h2><%= t('hyrax.base.show.relationships') %></h2>
     <%= render 'relationships_parent_rows', presenter: presenter %>
   </div>
-<% elsif !current_user %>
-  <%# Parent Work %>
-  <%# Render a link back to its parent works %>
-  <% if presenter.parent_works(current_user).present? %>
-    <%= render 'relationships_parent_works_rows', presenter: presenter %>
-  <% end %>
 <% end %>
+
 <% if current_user %>
   <div class="work-show">
     <h2><%= t('hyrax.base.show.relationships') %></h2>
@@ -35,4 +30,10 @@
       <%= render 'relationships_parent_works_rows', presenter: presenter %>
     <% end %>
   </div>
+<% else %>
+  <%# Parent Work %>
+  <%# Render a link back to its parent works %>
+  <% if presenter.parent_works(current_user).present? %>
+    <%= render 'relationships_parent_works_rows', presenter: presenter %>
+  <% end %>
 <% end %>

--- a/app/views/hyrax/base/_relationships.html.erb
+++ b/app/views/hyrax/base/_relationships.html.erb
@@ -1,18 +1,24 @@
 <%# OVERRIDE Hyrax 2.9 to make relationships only show if they exist %>
 <% if !current_user && presenter.grouped_presenters.present? %>
+  <%# Collection %>
   <div class="work-show">
     <h2><%= t('hyrax.base.show.relationships') %></h2>
     <%= render 'relationships_parent_rows', presenter: presenter %>
-    <%# Render a link back to its parent works %>
-    <% if presenter.parent_works.present? %>
-      <%= render 'relationships_parent_works_rows', presenter: presenter %>
-    <% end %>
   </div>
+<% elsif !current_user %>
+  <%# Parent Work %>
+  <%# Render a link back to its parent works %>
+  <% if presenter.parent_works(current_user).present? %>
+    <%= render 'relationships_parent_works_rows', presenter: presenter %>
+  <% end %>
 <% end %>
 <% if current_user %>
   <div class="work-show">
     <h2><%= t('hyrax.base.show.relationships') %></h2>
+    <%# Admin Set %>
     <%= presenter.attribute_to_html(:admin_set, render_as: :faceted, html_dl: true) %>
+
+    <%# Collection %>
     <% presenter.grouped_presenters(except: presenter.presenter_types).each_pair do |model_name, items| %>
       <%= render 'relationships_parent_row', type: model_name, items: items, presenter: presenter %>
     <% end %>
@@ -22,8 +28,10 @@
         <%= render 'relationships_parent_row', type: type, items: items, presenter: presenter %>
       <% end %>
     <% end %>
+
+    <%# Parent Work %>
     <%# Render a link back to its parent works %>
-    <% if presenter.parent_works.present? %>
+    <% if presenter.parent_works(current_user).present? %>
       <%= render 'relationships_parent_works_rows', presenter: presenter %>
     <% end %>
   </div>

--- a/app/views/hyrax/base/_relationships_parent_works_rows.html.erb
+++ b/app/views/hyrax/base/_relationships_parent_works_rows.html.erb
@@ -2,7 +2,7 @@
 <dd>
   <td>
     <ul class="tabular">
-      <% presenter.parent_works.each do |parent_doc| %>
+      <% presenter.parent_works(current_user).each do |parent_doc| %>
         <li class='attribute attribute-title'>
           <%= link_to parent_doc.title.first, parent_path(parent_doc) %>
         </li>

--- a/app/views/themes/cultural_show/hyrax/base/_relationships.html.erb
+++ b/app/views/themes/cultural_show/hyrax/base/_relationships.html.erb
@@ -4,13 +4,8 @@
     <h4><%= t('hyrax.base.show.relationships') %></h4>
     <%= render 'relationships_parent_rows', presenter: presenter %>
   </div>
-<% elsif !current_user %>
-  <%# Parent Work %>
-  <%# Render a link back to its parent works %>
-  <% if presenter.parent_works(current_user).present? %>
-    <%= render 'relationships_parent_works_rows', presenter: presenter %>
-  <% end %>
 <% end %>
+
 <% if current_user %>
   <div class="work-show">
     <h4><%= t('hyrax.base.show.relationships') %></h4>
@@ -29,4 +24,10 @@
       <%= render 'relationships_parent_works_rows', presenter: presenter %>
     <% end %>
   </div>
+<% else %>
+  <%# Parent Work %>
+  <%# Render a link back to its parent works %>
+  <% if presenter.parent_works(current_user).present? %>
+    <%= render 'relationships_parent_works_rows', presenter: presenter %>
+  <% end %>
 <% end %>

--- a/app/views/themes/cultural_show/hyrax/base/_relationships.html.erb
+++ b/app/views/themes/cultural_show/hyrax/base/_relationships.html.erb
@@ -1,12 +1,15 @@
 <% if !current_user && presenter.grouped_presenters.present? %>
+  <%# Collection %>
   <div class="work-show">
     <h4><%= t('hyrax.base.show.relationships') %></h4>
     <%= render 'relationships_parent_rows', presenter: presenter %>
-    <%# Render a link back to its parent works %>
-    <% if presenter.parent_works.present? %>
-      <%= render 'relationships_parent_works_rows', presenter: presenter %>
-    <% end %>
   </div>
+<% elsif !current_user %>
+  <%# Parent Work %>
+  <%# Render a link back to its parent works %>
+  <% if presenter.parent_works(current_user).present? %>
+    <%= render 'relationships_parent_works_rows', presenter: presenter %>
+  <% end %>
 <% end %>
 <% if current_user %>
   <div class="work-show">
@@ -22,7 +25,7 @@
       <% end %>
     <% end %>
     <%# Render a link back to its parent works %>
-    <% if presenter.parent_works.present? %>
+    <% if presenter.parent_works(current_user).present? %>
       <%= render 'relationships_parent_works_rows', presenter: presenter %>
     <% end %>
   </div>


### PR DESCRIPTION
This is rework to address user abilities regarding the parent linked in a child work. It considers what should happen when a user is logged out and in. When logged it, it considers the user's abilities and the visibility type of the parent work.

Issue:
- https://github.com/scientist-softserv/palni-palci/issues/840

# Expected Behavior Before Changes
We misinterpreted the client's request. When logged out, the user could not see the parent link unless it also had a public collection 🙃 



# Expected Behavior After Changes

I created a parent work of all visibility types (public, private, institution and embargo)

## When a super admin is logged in 
- [ ] They should see all parent works
- [ ] The parent link should render without the presence of a collection

<details> <summary> works only </summary> 

![Screenshot 2023-10-18 at 09-50-50 child work private parent](https://github.com/scientist-softserv/palni-palci/assets/10081604/ad73fcc3-edbc-4c11-92a8-8a0b200f4427)

</details> 


<details> <summary> with collections </summary>

![Screenshot 2023-10-18 at 10-41-20 child work private parent](https://github.com/scientist-softserv/palni-palci/assets/10081604/cd5f2bae-a660-4683-a46c-d2af50af6d31)


</details>


## When a non admin user is logged in
- [ ] They should only see what they should be able to (institutional and public in this case)
- [ ] The parent link should render without the presence of a collection

<details> <summary> works only </summary> 

![Screenshot 2023-10-18 at 9 50 30 AM](https://github.com/scientist-softserv/palni-palci/assets/10081604/a3599185-d1c6-4b1b-8e33-9058a3b38381)

</details> 

<details> <summary> with collections </summary>

![image](https://github.com/scientist-softserv/palni-palci/assets/10081604/ee278bb6-0402-4e30-b2a5-2aa9fc71a8d8)



</details>

## When a user is logged out
- [ ] They should only see the parent link if the parent work is public
- [ ] The parent link should render without the presence of a collection
<details> <summary> works only </summary> 

![Screenshot 2023-10-18 at 9 50 46 AM](https://github.com/scientist-softserv/palni-palci/assets/10081604/2cb04ceb-10c7-49be-b08f-6bf86e4c74a4)

</details> 

<details> <summary> with collections </summary>

![Screenshot 2023-10-18 at 10 42 05 AM](https://github.com/scientist-softserv/palni-palci/assets/10081604/6c2b0ac5-1a50-4ae9-b63d-1d2348b8d88c)



</details>
