### PR TITLE
🐛 Fix user despositing to specific admin sets

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -15,6 +15,7 @@ class Ability
     user_roles
     work_roles
     featured_collection_abilities
+    everyone_can_create_curation_concerns
   ]
   # If the Groups with Roles feature is disabled, allow registered users to create curation concerns
   # (Works, Collections, and FileSets). Otherwise, omit this ability logic as to not

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -35,10 +35,10 @@ RSpec.describe 'Creating a new Work', type: :feature, clean: true do
 
       before do
         create(:permission_template_access,
-          :deposit,
-          permission_template: create(:permission_template, source_id: admin_set_2.id, with_admin_set: true, with_active_workflow: true),
-          agent_type: 'user',
-          agent_id: user.user_key)
+               :deposit,
+               permission_template: create(:permission_template, source_id: admin_set_2.id, with_admin_set: true, with_active_workflow: true),
+               agent_type: 'user',
+               agent_id: user.user_key)
       end
 
       it 'can see the add new work button' do
@@ -56,10 +56,10 @@ RSpec.describe 'Creating a new Work', type: :feature, clean: true do
 
       before do
         create(:permission_template_access,
-          :deposit,
-          permission_template: create(:permission_template, source_id: admin_set_3.id, with_admin_set: true, with_active_workflow: true),
-          agent_type: 'group',
-          agent_id: depositors_group.name)
+               :deposit,
+               permission_template: create(:permission_template, source_id: admin_set_3.id, with_admin_set: true, with_active_workflow: true),
+               agent_type: 'group',
+               agent_id: depositors_group.name)
       end
 
       it 'can see the add new work button' do

--- a/spec/features/create_work_spec.rb
+++ b/spec/features/create_work_spec.rb
@@ -18,4 +18,54 @@ RSpec.describe 'Creating a new Work', type: :feature, clean: true do
     click_link "Share Your Work"
     expect(page).to have_button "Create work"
   end
+
+  context 'as a user with no roles' do
+    let(:user) { create(:user) }
+
+    it 'cannot see the add new work button' do
+      visit '/dashboard/my/works'
+      expect(page).not_to have_link "Add New Work"
+    end
+
+    context 'who has deposit access for a specific admin set' do
+      let(:admin_set_2) do
+        create(:admin_set, title: ["Another Admin Set"],
+                           description: ["A description"])
+      end
+
+      before do
+        create(:permission_template_access,
+          :deposit,
+          permission_template: create(:permission_template, source_id: admin_set_2.id, with_admin_set: true, with_active_workflow: true),
+          agent_type: 'user',
+          agent_id: user.user_key)
+      end
+
+      it 'can see the add new work button' do
+        visit '/dashboard/my/works'
+        expect(page).to have_link "Add New Work"
+      end
+    end
+
+    context 'who belongs to a group with deposit access for a specific admin set' do
+      let(:admin_set_3) do
+        create(:admin_set, title: ["Yet Another Admin Set"],
+                           description: ["A description"])
+      end
+      let(:depositors_group) { create(:depositors_group, name: 'deposit', member_users: [user]) }
+
+      before do
+        create(:permission_template_access,
+          :deposit,
+          permission_template: create(:permission_template, source_id: admin_set_3.id, with_admin_set: true, with_active_workflow: true),
+          agent_type: 'group',
+          agent_id: depositors_group.name)
+      end
+
+      it 'can see the add new work button' do
+        visit '/dashboard/my/works'
+        expect(page).to have_link "Add New Work"
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Story

This commit will add back the ability for everyone to be able to create a work.  This is one of the conditionals that need to be met for a user to deposit a work to an admin set.  The other is already being met, which is that the user has to have either a depositor role for that specific admin set or in a group that has a depositor role for that specific admin set.

Ref:
  - https://github.com/scientist-softserv/palni-palci/issues/864

# Expected Behavior Before Changes

Prior to this commit, even if a user was granted the role of depositor to an admin set, they could not add a work.  If they were added in a group that had the depositor role, they still were not able to create a work.

# Expected Behavior After Changes

Now, users who have the depositor role or in a group with the depositor role can deposit to admin sets.

# Screenshots / Video

https://github.com/scientist-softserv/palni-palci/assets/19597776/dcb324fa-02f5-4743-a804-ea18709bce73
