### PR TITLE
🐛 Fix link on the resource type icon

### DIFF
--- a/app/views/themes/institutional_repository/hyrax/homepage/_resource_type_stats.html.erb
+++ b/app/views/themes/institutional_repository/hyrax/homepage/_resource_type_stats.html.erb
@@ -1,11 +1,13 @@
 <div class="ir-stats hidden-xs">
-  <% resource_types.each.with_index do |(k,v), i| %>      
+  <% resource_types.each.with_index do |(k,v), i| %>
     <% next if v[0].zero? %>
     <div class="col-xs-12 col-sm-4 col-md-2">
       <div class="text-center">
-        <i class='<%= "#{v[1]}" %>' aria-hidden="true"></i>
-        <h5><%= k %></h5>
-        <p><%= v[0] %></p>
+        <%= link_to "/catalog?f[resource_type_sim][]=#{k}", style: "color: inherit;" do %>
+          <i class='<%= "#{v[1]}" %>' aria-hidden="true"></i>
+          <h5><%= k %></h5>
+          <p><%= v[0] %></p>
+        <% end %>
       </div>
     </div>
   <% end %>


### PR DESCRIPTION
This commit will fix the resource type link when it was less than 6 items.
