### PR TITLE
🐛 Switch contact_email and contact_email_to text

### DIFF
--- a/config/locales/simple_form.de.yml
+++ b/config/locales/simple_form.de.yml
@@ -20,7 +20,7 @@ de:
         google_oauth_private_key_path: Der vollständige Pfad zu Ihrer p12-Schlüsseldatei. (Sie können den privaten Schlüsselwert ODER den Pfad verwenden; der Wert hat Vorrang)
         google_oauth_private_key_secret: Das Geheimnis, das Sie beim Erstellen des p12-Schlüssels angegeben haben
         google_oauth_client_email: OAuth-Client-E-Mail-Adresse
-        contact_email: Die E-Mail-Adresse, an die über die Kontaktseite gesendete Nachrichten gesendet werden
+        contact_email_to: Die E-Mail-Adresse, an die über die Kontaktseite gesendete Nachrichten gesendet werden
         weekly_email_list: Liste von E-Mail-Adressen, an die der wöchentliche Bericht gesendet wird. Lassen Sie jeweils ein Leerzeichen zwischen den E-Mails
         monthly_email_list: Liste von E-Mail-Adressen, an die der monatliche Bericht gesendet wird. Lassen Sie jeweils ein Leerzeichen zwischen den E-Mails
         yearly_email_list: Liste von E-Mail-Adressen, an die der jährliche Bericht gesendet wird. Lassen Sie jeweils ein Leerzeichen zwischen den E-Mails
@@ -36,7 +36,7 @@ de:
         doi_writer: DOIs für Datensätze schreiben. WIP nicht verwenden
         cache_api: Cache für API-Endpunkte aktivieren. Experimentell
         email_subjet_prefix: Zeichenfolge, die vor System-E-Mail-Betreffs eingefügt wird.
-        contact_email_to: Die E-Mail-Adresse, von der Systembenachrichtigungen gesendet werden. Eine zusätzliche Konfiguration ist erforderlich, um eine Adresse von anderen Domänen als der Domäne der Website hinzuzufügen
+        contact_email: Die E-Mail-Adresse, von der Systembenachrichtigungen gesendet werden. Eine zusätzliche Konfiguration ist erforderlich, um eine Adresse von anderen Domänen als der Domäne der Website hinzuzufügen
         geonames_username: Registrieren Sie sich unter http://www.geonames.org/manageaccount
         file_acl: Deaktivieren Sie dies, wenn Sie ein Dateisystem wie Samba oder NFS verwenden, das das Festlegen von Zugriffssteuerungslisten nicht unterstützt
         ssl_configured: Setzen Sie es auf wahr, wenn Sie https verwenden

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -20,7 +20,7 @@ en:
         google_oauth_private_key_path: The full path to your p12, key file. (You can use the private key value OR path; value takes precedence)
         google_oauth_private_key_secret: The secret provided when you created the p12 key
         google_oauth_client_email: OAuth Client email address
-        contact_email: The email address that messages submitted via the contact page are sent to
+        contact_email_to: The email address that messages submitted via the contact page are sent to
         weekly_email_list: List of email addresses to email the weekly report. Leave a single space between each email
         monthly_email_list: List of email addresses to email the monthly report. Leave a single space between each email
         yearly_email_list: List of email addresses to email the yearly report. Leave a single space between each email
@@ -36,7 +36,7 @@ en:
         doi_writer: Write DOIs for records. WIP do not use
         cache_api: Turns on cache for API endpoints. Experimental
         email_subjet_prefix: String to put in front of system email subjects.
-        contact_email_to: The email address that system notifications will be sent from. Additional configuration is required to add an address from domains other than the site's domain
+        contact_email: The email address that system notifications will be sent from. Additional configuration is required to add an address from domains other than the site's domain
         geonames_username: Register at http://www.geonames.org/manageaccount
         file_acl: Turn off if using a file system like samba or nfs that does not support setting access control lists
         ssl_configured: Set it true if using https

--- a/config/locales/simple_form.es.yml
+++ b/config/locales/simple_form.es.yml
@@ -20,7 +20,7 @@ es:
         google_oauth_private_key_path: La ruta completa a su archivo p12, archivo clave. (Puede usar el valor de la clave privada O el camino; el valor tiene prioridad)
         google_oauth_private_key_secret: El secreto proporcionado cuando creó la clave p12
         google_oauth_client_email: Dirección de correo electrónico del cliente OAuth
-        contact_email: La dirección de correo electrónico a la que se envían los mensajes enviados a través de la página de contacto
+        contact_email_to: La dirección de correo electrónico a la que se envían los mensajes enviados a través de la página de contacto
         weekly_email_list: Lista de direcciones de correo electrónico para enviar el informe semanal. Deje un espacio entre cada correo electrónico
         monthly_email_list: Lista de direcciones de correo electrónico para enviar el informe mensual. Deje un espacio entre cada correo electrónico
         yearly_email_list: Lista de direcciones de correo electrónico para enviar el informe anual. Deje un espacio entre cada correo electrónico
@@ -36,7 +36,7 @@ es:
         doi_writer: Escribir DOIs para registros. WIP no usar
         cache_api: Activa la caché para puntos finales de API. Experimental
         email_subjet_prefix: Cadena para poner al frente de los asuntos de correo electrónico del sistema.
-        contact_email_to: La dirección de correo electrónico desde la que se enviarán las notificaciones del sistema. Se requiere una configuración adicional para agregar una dirección de dominios distintos al dominio del sitio
+        contact_email: La dirección de correo electrónico desde la que se enviarán las notificaciones del sistema. Se requiere una configuración adicional para agregar una dirección de dominios distintos al dominio del sitio
         geonames_username: Regístrese en http://www.geonames.org/manageaccount
         file_acl: Desactívelo si usa un sistema de archivos como samba o nfs que no admite listas de control de acceso
         ssl_configured: Establézcalo como verdadero si está utilizando https

--- a/config/locales/simple_form.fr.yml
+++ b/config/locales/simple_form.fr.yml
@@ -20,7 +20,7 @@ fr:
         google_oauth_private_key_path: Le chemin complet vers votre fichier p12, fichier clé. (Vous pouvez utiliser la valeur de la clé privée OU le chemin ; la valeur prime)
         google_oauth_private_key_secret: Le secret fourni lorsque vous avez créé la clé p12
         google_oauth_client_email: Adresse e-mail du client OAuth
-        contact_email: L'adresse e-mail à laquelle les messages soumis via la page de contact sont envoyés
+        contact_email_to: L'adresse e-mail à laquelle les messages soumis via la page de contact sont envoyés
         weekly_email_list: Liste des adresses e-mail pour envoyer le rapport hebdomadaire. Laissez un espace entre chaque e-mail
         monthly_email_list: Liste des adresses e-mail pour envoyer le rapport mensuel. Laissez un espace entre chaque e-mail
         yearly_email_list: Liste des adresses e-mail pour envoyer le rapport annuel. Laissez un espace entre chaque e-mail
@@ -36,7 +36,7 @@ fr:
         doi_writer: Écrire des DOIs pour les enregistrements. WIP ne pas utiliser
         cache_api: Active le cache pour les points d'accès API. Expérimental
         email_subjet_prefix: Chaîne à mettre devant les sujets des e-mails système.
-        contact_email_to: L'adresse e-mail à partir de laquelle les notifications système seront envoyées. Une configuration supplémentaire est nécessaire pour ajouter une adresse provenant de domaines autres que le domaine du site
+        contact_email: L'adresse e-mail à partir de laquelle les notifications système seront envoyées. Une configuration supplémentaire est nécessaire pour ajouter une adresse provenant de domaines autres que le domaine du site
         geonames_username: Inscrivez-vous sur http://www.geonames.org/manageaccount
         file_acl: Désactivez si vous utilisez un système de fichiers comme samba ou nfs qui ne prend pas en charge les listes de contrôle d'accès
         ssl_configured: Mettez-le sur vrai si vous utilisez https

--- a/config/locales/simple_form.it.yml
+++ b/config/locales/simple_form.it.yml
@@ -20,7 +20,7 @@ it:
         google_oauth_private_key_path: Il percorso completo del tuo file p12, file chiave. (Puoi utilizzare il valore della chiave privata OPPURE il percorso; il valore ha la precedenza)
         google_oauth_private_key_secret: Il segreto fornito quando hai creato la chiave p12
         google_oauth_client_email: Indirizzo email del client OAuth
-        contact_email: L'indirizzo email al quale i messaggi inviati tramite la pagina di contatto sono inviati
+        contact_email_to: L'indirizzo email al quale i messaggi inviati tramite la pagina di contatto sono inviati
         weekly_email_list: Lista di indirizzi email ai quali inviare il rapporto settimanale. Lascia uno spazio tra ogni email
         monthly_email_list: Lista di indirizzi email ai quali inviare il rapporto mensile. Lascia uno spazio tra ogni email
         yearly_email_list: Lista di indirizzi email ai quali inviare il rapporto annuale. Lascia uno spazio tra ogni email
@@ -36,7 +36,7 @@ it:
         doi_writer: Scrivi DOI per i record. Lavoro in corso, non utilizzare
         cache_api: Abilita la cache per gli endpoint API. Sperimentale
         email_subjet_prefix: Stringa da mettere davanti agli oggetti delle email di sistema.
-        contact_email_to: L'indirizzo email da cui saranno inviate le notifiche di sistema. È richiesta una configurazione aggiuntiva per aggiungere un indirizzo da domini diversi dal dominio del sito
+        contact_email: L'indirizzo email da cui saranno inviate le notifiche di sistema. È richiesta una configurazione aggiuntiva per aggiungere un indirizzo da domini diversi dal dominio del sito
         geonames_username: Registrati su http://www.geonames.org/manageaccount
         file_acl: Disattiva se stai utilizzando un sistema di file come samba o nfs che non supporta le liste di controllo degli accessi
         ssl_configured: Impostalo su vero se stai utilizzando https

--- a/config/locales/simple_form.pt-BR.yml
+++ b/config/locales/simple_form.pt-BR.yml
@@ -20,7 +20,7 @@ pt-BR:
         google_oauth_private_key_path: O caminho completo para o seu arquivo p12, arquivo de chave. (Você pode usar o valor da chave privada OU o caminho; o valor tem precedência)
         google_oauth_private_key_secret: O segredo fornecido quando você criou a chave p12
         google_oauth_client_email: Endereço de e-mail do cliente OAuth
-        contact_email: O endereço de e-mail para o qual as mensagens enviadas via página de contato são enviadas
+        contact_email_to: O endereço de e-mail para o qual as mensagens enviadas via página de contato são enviadas
         weekly_email_list: Lista de endereços de e-mail para enviar o relatório semanal. Deixe um espaço único entre cada e-mail
         monthly_email_list: Lista de endereços de e-mail para enviar o relatório mensal. Deixe um espaço único entre cada e-mail
         yearly_email_list: Lista de endereços de e-mail para enviar o relatório anual. Deixe um espaço único entre cada e-mail
@@ -36,7 +36,7 @@ pt-BR:
         doi_writer: Escrever DOIs para registros. Em desenvolvimento, não use
         cache_api: Ativar cache para pontos finais de API. Experimental
         email_subjet_prefix: String para colocar na frente dos assuntos dos e-mails do sistema.
-        contact_email_to: O endereço de e-mail do qual as notificações do sistema serão enviadas. Uma configuração adicional é necessária para adicionar um endereço de domínios diferentes do domínio do site
+        contact_email: O endereço de e-mail do qual as notificações do sistema serão enviadas. Uma configuração adicional é necessária para adicionar um endereço de domínios diferentes do domínio do site
         geonames_username: Registre-se em http://www.geonames.org/manageaccount
         file_acl: Desative se estiver usando um sistema de arquivos como samba ou nfs que não suporta listas de controle de acesso
         ssl_configured: Defina como verdadeiro se estiver usando https

--- a/config/locales/simple_form.zh.yml
+++ b/config/locales/simple_form.zh.yml
@@ -20,7 +20,7 @@ zh:
         google_oauth_private_key_path: 您的p12密钥文件的完整路径。（您可以使用私钥值或路径；值优先）
         google_oauth_private_key_secret: 创建p12密钥时提供的秘密
         google_oauth_client_email: OAuth客户电子邮件地址
-        contact_email: 通过联系页面提交的消息发送到的电子邮件地址
+        contact_email_to: 通过联系页面提交的消息发送到的电子邮件地址
         weekly_email_list: 每周报告的电子邮件地址列表。每个电子邮件之间留一个空格
         monthly_email_list: 每月报告的电子邮件地址列表。每个电子邮件之间留一个空格
         yearly_email_list: 每年报告的电子邮件地址列表。每个电子邮件之间留一个空格
@@ -36,7 +36,7 @@ zh:
         doi_writer: 为记录编写DOIs。仍在进行中，请勿使用
         cache_api: 打开API端点的缓存。实验性
         email_subjet_prefix: 放在系统电子邮件主题前面的字符串。
-        contact_email_to: 系统通知将从其中发送的电子邮件地址。需要额外的配置才能从网站域以外的域添加地址
+        contact_email: 系统通知将从其中发送的电子邮件地址。需要额外的配置才能从网站域以外的域添加地址
         geonames_username: 在http://www.geonames.org/manageaccount上注册
         file_acl: 如果使用不支持设置访问控制列表的文件系统（如samba或nfs），请关闭它
         ssl_configured: 如果使用https，请将其设置为true


### PR DESCRIPTION
This commit will fix the text of the contact_email and contact_email_to because they were swapped.

Corrected hint text:

<img width="1281" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/19597776/9716cf0a-64b7-450f-91fd-d5429f037342">

This PR was branched off of the commit that was deployed to production on 19 OCT 23.