### PR TITLE
🐛 Fix OER display of PDFs

### DIFF
--- a/app/views/hyrax/oers/show.html.erb
+++ b/app/views/hyrax/oers/show.html.erb
@@ -23,9 +23,13 @@
             <div class="col-sm-12">
               <%= render 'representative_media', presenter: @presenter, viewer: true %>
             </div>
+          <% elsif @presenter.show_pdf_viewer? %>
+            <div class="col-sm-12">
+              <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter) %>
+            </div>
           <% end %>
           <div class="col-sm-3 text-center">
-            <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.iiif_viewer? %>
+            <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.iiif_viewer? || @presenter.show_pdf_viewer? %>
             <%= render 'citations', presenter: @presenter %>
             <!-- analytics_button is disabled until future fix -->
             <%#= render 'analytics_button', presenter: @presenter %>


### PR DESCRIPTION
# Story

This commit will adjust the OER show page so it will properly show PDFs

# Screenshots / Video

## Before:

![image](https://github.com/scientist-softserv/palni-palci/assets/19597776/4c0e794e-fecd-47d0-854e-ecb25f0ae2a9)


## After:

![image](https://github.com/scientist-softserv/palni-palci/assets/19597776/f3f8a69c-7cf9-40f3-a1d7-77ad476fcd74)
