### PR TITLE
🐛 Rework ability logic for depositor

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -15,7 +15,6 @@ class Ability
     user_roles
     work_roles
     featured_collection_abilities
-    everyone_can_create_curation_concerns
   ]
   # If the Groups with Roles feature is disabled, allow registered users to create curation concerns
   # (Works, Collections, and FileSets). Otherwise, omit this ability logic as to not

--- a/app/models/concerns/hyrax/ability/work_ability.rb
+++ b/app/models/concerns/hyrax/ability/work_ability.rb
@@ -15,7 +15,7 @@ module Hyrax
             doc = permissions_doc(id)
             all_work_types_and_files.include?(doc.hydra_model)
           end
-        elsif work_depositor?
+        elsif work_depositor? || admin_set_with_deposit?
           can %i[create], all_work_types_and_files
         end
       end


### PR DESCRIPTION
# Story

Even though a user could not see the Add New Work or Collection button, they were still able to navigate to it via the routes.  This commit will rework the ability logic for depositor so that won't happen.

Ref:
  - https://github.com/scientist-softserv/palni-palci/issues/864
