### PR TITLE
:fire: Hotfix - allow for ids to be empty in #admin_set_with_deposit?

### DIFF
--- a/app/models/concerns/hyrax/ability/work_ability.rb
+++ b/app/models/concerns/hyrax/ability/work_ability.rb
@@ -19,6 +19,21 @@ module Hyrax
           can %i[create], all_work_types_and_files
         end
       end
+
+      # OVERRIDE HYRAX 3.6.0 to return false if no ids are found
+      # @return [Boolean] true if the user has at least one admin set they can deposit into.
+      def admin_set_with_deposit?
+        ids = PermissionTemplateAccess.for_user(ability: self,
+                                                access: ['deposit', 'manage'])
+                                      .joins(:permission_template)
+                                      .select(:source_id)
+                                      .distinct
+                                      .pluck(:source_id)
+
+        return false if ids.empty?
+
+        Hyrax.custom_queries.find_ids_by_model(model: Hyrax::AdministrativeSet, ids: ids).any?
+      end
     end
   end
 end


### PR DESCRIPTION
The client reported 500 errors in production. Locally, it displayed as a 404 because no users were found in the solr query it performed. We are overriding the method to rescue the case for nil ids.

ref: https://assaydepot.slack.com/archives/C0313NKC08L/p1698080533392449


# Expected Behavior Before Changes

Navigating to https://hykucommons.org/proprietor/users?locale=en and https://hykucommons.org/proprietor/accounts?locale=en resulted  in 500 errors

![Screenshot 2023-10-23 at 10-41-20 We're sorry but something went wrong (500)](https://github.com/scientist-softserv/palni-palci/assets/10081604/dedc0182-f821-42bc-b1c9-366f076b0833)


# Expected Behavior After Changes

A user can successfully navigate to https://hykucommons.org/proprietor/users?locale=en and https://hykucommons.org/proprietor/accounts?locale=en without error. 

![image](https://github.com/scientist-softserv/palni-palci/assets/10081604/ce1cd920-90d0-4bc5-9e45-8d851e2e04de)

