### PR TITLE
🐛 Omit DataType=Platform when provided DataType does not include Platform

### DIFF
--- a/app/models/sushi/platform_report.rb
+++ b/app/models/sushi/platform_report.rb
@@ -137,6 +137,7 @@ module Sushi
 
     def attribute_performance_for_platform
       return [] if metric_type_in_params && metric_types.exclude?("Searches_Platform")
+      return [] if data_type_in_params && !data_types.find { |dt| dt.casecmp("Platform").zero? }
 
       [{
         "Data_Type" => "Platform",

--- a/spec/models/sushi/platform_report_spec.rb
+++ b/spec/models/sushi/platform_report_spec.rb
@@ -46,6 +46,21 @@ RSpec.describe Sushi::PlatformReport do
         expect(subject.dig('Report_Items', 'Attribute_Performance').map { |ap| ap['Data_Type'] }.sort).to match_array(['Article', 'Platform'])
       end
     end
+    context 'when given a non-platform data_type and omit searches platform' do
+      let(:params) do
+        {
+          begin_date: '2023-08',
+          end_date: '2023-09',
+          data_type: 'article',
+          attributes_to_show: ['Access_Method', 'Fake_Value'],
+          granularity: 'totals'
+        }
+      end
+
+      it 'omits the platform data type' do
+        expect(subject.dig('Report_Items', 'Attribute_Performance').detect { |dt| dt['Data_Type']['Platform'] }).to be_nil
+      end
+    end
 
     context 'with additional params that are not required' do
       let(:params) do


### PR DESCRIPTION
Prior to this commit, if the query parameters included only non-platform data_type (e.g. article) then we would continue to show the platform data type node.

With this commit, we skip showing that element if we have been provided explicit data_type(s) and none of them are Platform.

Related to:

- https://github.com/scientist-softserv/palni-palci/issues/686#issuecomment-1785326034

