### PR TITLE
🐛 Handle "or" behavior for specified metric types

### DIFF
--- a/app/models/sushi/platform_report.rb
+++ b/app/models/sushi/platform_report.rb
@@ -120,7 +120,11 @@ module Sushi
     alias to_hash as_json
 
     def attribute_performance_for_resource_types
-      return [] if metric_type_in_params && metric_types.include?("Searches_Platform")
+      # We want to consider "or" behavior for multiple metric_types.  Namely if you specify any
+      # metric type (other than Searches_Platform) you're going to get results.
+      #
+      # See https://github.com/scientist-softserv/palni-palci/issues/686#issuecomment-1785326034
+      return [] if metric_type_in_params && (metric_types & (ALLOWED_METRIC_TYPES - ['Searches_Platform'])).count.zero?
 
       data_for_resource_types.map do |record|
         {

--- a/spec/models/sushi/platform_report_spec.rb
+++ b/spec/models/sushi/platform_report_spec.rb
@@ -33,6 +33,20 @@ RSpec.describe Sushi::PlatformReport do
       end
     end
 
+    context 'when given metric_types searches_platform AND total_item_requests' do
+      let(:params) do
+        {
+          begin_date: '2023-08',
+          end_date: '2023-09',
+          metric_type: 'total_item_requests|searches_platform'
+        }
+      end
+
+      it 'includes the platform data type and the article data type (which is the only data type within the date range' do
+        expect(subject.dig('Report_Items', 'Attribute_Performance').map { |ap| ap['Data_Type'] }.sort).to match_array(['Article', 'Platform'])
+      end
+    end
+
     context 'with additional params that are not required' do
       let(:params) do
         {


### PR DESCRIPTION
Prior to this commit, when you provided an explicit
`metric_type=total_item_requests` you would get back the various data
types that had been seeded in the database.

When you'd provide the `metric_type=searches_platform` you would see the
DataType for the `Platform` (and not the Article nor Book data types).

When you'd provide ``metric_type=searches_platform|total_item_requests`
you would only get the `Platform` data type.

The expected behavior is you would get the `Article`, `Book`, and
`Platform` data types.

This commit remedies that behavior.  Note, dear reader, that the test
case only has `article` in the given date range.

See the Sushi Docs:

- https://countermetrics.stoplight.io/docs/counter-sushi-api/e98e9f5cab5ed-pr-platform-report

<details>
<summary>Copied text from Issue</summary>

In https://pittir.commons-archive.org/api/sushi/r51/reports/pr?begin_date=2023-06&end_date=2023-07&metric_type=total_item_requests , the output includes:
```
      {
        "Data_Type": "article",
        "Access_Method": "Regular",
        "Performance": {
          "Total_Item_Requests": {
            "2023-06": 700,
            "2023-07": 740
          }
        }
      },
      {
        "Data_Type": "book",
        "Access_Method": "Regular",
        "Performance": {
          "Total_Item_Requests": {
            "2023-06": 175,
            "2023-07": 187
          }
        }
      }
```
The for the same timeframe, https://pittir.commons-archive.org/api/sushi/r51/reports/pr?begin_date=2023-06&end_date=2023-07&metric_type=Searches_Platform includes:
```
      {
        "Data_Type": "Platform",
        "Access_Method": "Regular",
        "Performance": {
          "Searches_Platform": {
            "2023-06": 806,
            "2023-07": 833
          }
        }
      }
```
so, an "OR" of the two parameters (`metric_type=Searches_Platform|total_item_requests`) should include both Metric Types (from any Data Types, since data_type is not filtered):
```
      {
        "Data_Type": "article",
        "Access_Method": "Regular",
        "Performance": {
          "Total_Item_Requests": {
            "2023-06": 700,
            "2023-07": 740
          }
        }
      },
      {
        "Data_Type": "book",
        "Access_Method": "Regular",
        "Performance": {
          "Total_Item_Requests": {
            "2023-06": 175,
            "2023-07": 187
          }
        }
      },
      {
        "Data_Type": "Platform",
        "Access_Method": "Regular",
        "Performance": {
          "Searches_Platform": {
            "2023-06": 806,
            "2023-07": 833
          }
        }
      }
```
instead, https://pittir.commons-archive.org/api/sushi/r51/reports/pr?begin_date=2023-06&end_date=2023-07&metric_type=Searches_Platform|total_item_requests only includes Searches Platform from the Platform Data Type:
```
  "Report_Items": {
    "Platform": "pittir.commons-archive.org",
    "Attribute_Performance": [
      {
        "Data_Type": "Platform",
        "Access_Method": "Regular",
        "Performance": {
          "Searches_Platform": {
            "2023-06": 806,
            "2023-07": 833
          }
        }
      }
    ]
  }
```

</details>

Related to:

- https://github.com/scientist-softserv/palni-palci/issues/686#issuecomment-1785326034

-------

# Story

Refs #issuenumber

# Expected Behavior Before Changes

# Expected Behavior After Changes

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes