### PR TITLE
🐛 Render show_actions on OER show

### DIFF
--- a/app/views/hyrax/oers/show.html.erb
+++ b/app/views/hyrax/oers/show.html.erb
@@ -15,6 +15,7 @@
     <div class="panel panel-default">
       <div class="panel-heading">
         <%= render 'work_title', presenter: @presenter %>
+        <%= render 'show_actions', presenter: @presenter %> 
       </div>
       <div class="panel-body">
         <div class="row">


### PR DESCRIPTION
# Story
This commit will render the show_actions partial on the OER show page.

Ref:
  - https://github.com/scientist-softserv/palni-palci/issues/888

# Screenshots / Video
<img width="678" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/19597776/f4c2db04-7215-4f88-ae08-cb0a7d18819e">
