### PR TITLE
🐛 Refactor ReindexCollectionsJob to use GlobalID for object serializa…

### DIFF
--- a/app/jobs/reindex_collections_job.rb
+++ b/app/jobs/reindex_collections_job.rb
@@ -1,9 +1,10 @@
 # frozen_string_literal: true
 
 class ReindexCollectionsJob < ApplicationJob
-  def perform(collection = nil)
-    if collection.present?
-      collection.update_index
+  def perform(collection_id = nil)
+    if collection_id.present?
+      collection = Collection.find(collection_id)
+      collection&.update_index
     else
       Collection.find_each do |collection|
         collection.try(:reindex_extent=, Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX)

--- a/lib/tasks/index.rake
+++ b/lib/tasks/index.rake
@@ -31,7 +31,7 @@ namespace :hyku do
       progressbar = ProgressBar.create(total: Collection.count, title: title, format: "%t %c of %C %a %B %p%%")
       begin
         Collection.find_each do |collection|
-          ReindexCollectionsJob.perform_later(collection)
+          ReindexCollectionsJob.perform_later(collection.id)
           progressbar.increment
         end
       rescue => e


### PR DESCRIPTION


Prior to this commit we were unable to run the reindex rake task for Collections. It resolved the error: ActiveJob::SerializationError: Unsupported argument type: Collection

# Expected Behavior After Changes

I can successfully run the rake task and see jobs get enqueued. 

# Screenshots / Video

<img width="1293" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/10081604/73480e46-3695-43a8-90d1-56a8c2f16c31">

