### PR TITLE
Update reindex_collections_job.rb

### DIFF
--- a/app/jobs/reindex_collections_job.rb
+++ b/app/jobs/reindex_collections_job.rb
@@ -3,13 +3,16 @@
 class ReindexCollectionsJob < ApplicationJob
   def perform(collection_id = nil)
     if collection_id.present?
-      collection = Collection.find(collection_id)
-      collection&.update_index
+      update_collection_index(Collection.find(collection_id))
     else
-      Collection.find_each do |collection|
-        collection.try(:reindex_extent=, Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX)
-        collection.update_index
-      end
+      Collection.find_each { |collection| update_collection_index(collection) }
     end
+  end
+
+  private
+
+  def update_collection_index(collection)
+    collection.try(:reindex_extent=, Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX)
+    collection&.update_index
   end
 end

--- a/app/jobs/reindex_collections_job.rb
+++ b/app/jobs/reindex_collections_job.rb
@@ -11,8 +11,8 @@ class ReindexCollectionsJob < ApplicationJob
 
   private
 
-  def update_collection_index(collection)
-    collection.try(:reindex_extent=, Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX)
-    collection&.update_index
-  end
+    def update_collection_index(collection)
+      collection.try(:reindex_extent=, Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX)
+      collection&.update_index
+    end
 end

--- a/spec/jobs/reindex_collections_job_spec.rb
+++ b/spec/jobs/reindex_collections_job_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe ReindexCollectionsJob, type: :job do
+  describe '#perform' do
+    context 'when collection_id is present' do
+      it 'updates the index of the specified collection' do
+        collection = create(:collection)
+        allow_any_instance_of(Collection).to receive(:update_index)
+        described_class.perform_now(collection.id)
+      end
+    end
+
+    context 'when collection_id is not present' do
+      it 'updates the index of all collections' do
+        create_list(:collection, 3)
+        allow_any_instance_of(Collection).to receive(:update_index)
+        described_class.perform_now
+      end
+    end
+  end
+end

--- a/spec/jobs/reindex_collections_job_spec.rb
+++ b/spec/jobs/reindex_collections_job_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.describe ReindexCollectionsJob, type: :job do
   describe '#perform' do
     context 'when collection_id is present' do


### PR DESCRIPTION
# Notes

Is the reindex rake task creating slow jobs because it's missing this line? It's taking hours to complete a single job.

`collection.try(:reindex_extent=, Hyrax::Adapters::NestingIndexAdapter::LIMITED_REINDEX)`

as seen here: 



https://github.com/scientist-softserv/palni-palci/blob/main/app/jobs/reindex_collections_job.rb#L10


<img width="1298" alt="Screenshot 2023-11-01 at 11 14 25 AM" src="https://github.com/scientist-softserv/palni-palci/assets/10081604/291eaa00-eac5-4e46-ba09-b456fe055255">

ref: https://github.com/scientist-softserv/palni-palci/issues/901