### PR TITLE
🐛 sidekiq is so slow

### DIFF
--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -138,6 +138,8 @@ extraEnvVars: &envVars
     value: /app/fits/tools/mediainfo/linux
   - name: NEGATIVE_CAPTCHA_SECRET
     value: $NEGATIVE_CAPTCHA_SECRET
+  - name: OMP_THREAD_LIMIT
+    value: "1"
   - name: PASSENGER_APP_ENV
     value: production
   - name: RAILS_CACHE_STORE_URL


### PR DESCRIPTION
ReindexCollectionsJobs are taking hours to complete

## NOTES

"Slow Sidekiq? 
If sidekiq is performing at an extremely slow pace (several hours to complete + seems to be stuck on CreateDerivativesJob ie: hyku project), consider adding the following env variable to the project's rancher cluster.

OMP_THREAD_LIMIT: 1"

ref: https://playbook-staging.notch8.com/en/dev/workers/sidekiq/sidekiq-debugging-tips

