### PR TITLE
🐛 Fix top level collections

### DIFF
--- a/app/controllers/hyrax/homepage_controller.rb
+++ b/app/controllers/hyrax/homepage_controller.rb
@@ -90,7 +90,7 @@ module Hyrax
       end
 
       def load_top_level_collections(colls)
-        colls.select{ |c| c['member_of_collection_ids_ssim'] == nil }
+        colls.select{ |c| c['member_of_collection_ids_ssim'].nil? }
       end
 
       # Return 6 collections

--- a/app/controllers/hyrax/homepage_controller.rb
+++ b/app/controllers/hyrax/homepage_controller.rb
@@ -33,18 +33,13 @@ module Hyrax
 
     # override hyrax v2.9.0 added @home_text - Adding Themes
     def index
-      @presenter = presenter_class.new(current_ability, collections)
       @featured_researcher = ContentBlock.for(:researcher)
-      @marketing_text = ContentBlock.for(:marketing)
       @home_text = ContentBlock.for(:home_text)
       @featured_work_list = FeaturedWorkList.new
       # OVERRIDE here to add featured collection list
       @featured_collection_list = FeaturedCollectionList.new
-      @announcement_text = ContentBlock.for(:announcement)
+      load_shared_info
       recent
-      ir_counts if home_page_theme == 'institutional_repository'
-      @top_level_collections = collections(rows: 100_000).select{ |c| c['nesting_collection__deepest_nested_depth_isi'] == 1 }[0..5] if home_page_theme == 'institutional_repository'
-
       # override hyrax v2.9.0 added for facets on homepage - Adding Themes
       (@response, @document_list) = search_results(params)
 
@@ -66,11 +61,7 @@ module Hyrax
     def browserconfig; end
 
     def all_collections
-      @presenter = presenter_class.new(current_ability, collections)
-      @marketing_text = ContentBlock.for(:marketing)
-      @announcement_text = ContentBlock.for(:announcement)
-      @collections = collections(rows: 100_000)
-      ir_counts if home_page_theme == 'institutional_repository'
+      load_shared_info
     end
 
     # Added from Blacklight 6.23.0 to change url for facets on home page
@@ -85,6 +76,22 @@ module Hyrax
       end
 
     private
+
+      # shared methods for index and all_collections routes
+      def load_shared_info
+        @presenter = presenter_class.new(current_ability, collections)
+        @marketing_text = ContentBlock.for(:marketing)
+        @announcement_text = ContentBlock.for(:announcement)
+        @collections = collections(rows: 100_000)
+        if home_page_theme == 'institutional_repository'
+          ir_counts
+          @top_level_collections ||= load_top_level_collections(@collections)
+        end
+      end
+
+      def load_top_level_collections(colls)
+        colls.select{ |c| c['member_of_collection_ids_ssim'] == nil }
+      end
 
       # Return 6 collections
       def collections(rows: 6)

--- a/app/views/themes/institutional_repository/hyrax/homepage/all_collections.html.erb
+++ b/app/views/themes/institutional_repository/hyrax/homepage/all_collections.html.erb
@@ -1,6 +1,6 @@
 <h2>Browse by Collection</h2>
-<% top_level_collections = @collections.select{ |c| c['nesting_collection__deepest_nested_depth_isi'] == 1 }%>
-<% top_level_collections.each do |collection| %>
+
+<% @top_level_collections.each do |collection| %>
   <div class="col-sm-12">
     <div>
       <ul class="all-collection-list">


### PR DESCRIPTION
# Story

Fixing the app to use the graph indexer means that the query for top level collections will not work. It relied on an index field, `nesting_collection__deepest_nested_depth_isi` which was added by the nesting indexer. With the use of the graph indexer, this term no longer exists. 

This is a minor issue, as it ONLY affects the `all_collections` route for the homepage when using the `institutional_repository` theme, and this route is not linked anywhere. Without this change, the list of collections on this path would have been empty once collections are reindexed, as the queried term would no longer exist.

A simpler solution is to identify a top level collection as one which is not a member of any other collection. Along with this change, come code duplication is also being cleaned up.

Refs
- https://github.com/scientist-softserv/palni-palci/issues/901

# Expected Behavior Before Changes

Once a collection is reindexed, it would no longer be identified as a top level collection.

# Expected Behavior After Changes

Collections at the `all_collections` route will include all collections which do not belong to another collection, and will no longer rely on the obsolete nesting indexer term to determine this inclusion.

# Screenshots / Video

<details>
<summary></summary>

Collection appears in all_documents view
![Screenshot 2023-11-01 at 4 11 59 PM](https://github.com/scientist-softserv/palni-palci/assets/17851674/73b528eb-9c0b-4d26-b4e4-e6cd78cea8ee)

## Solr document does not include the nesting indexer terms
![Screenshot 2023-11-01 at 4 12 31 PM](https://github.com/scientist-softserv/palni-palci/assets/17851674/f5d982bb-b9c7-43c0-b7c5-31d793907c46)


</details>

# Notes
