### PR TITLE
🎁  Add video embed to Generic Work

### DIFF
--- a/RepoREADME.md
+++ b/RepoREADME.md
@@ -242,3 +242,13 @@ Multi-tenant mode:
 ```bash
 rake tenantize:task[workflow:setup]
 ```
+### Youtube/Vimeo Video Player For Works
+- Works will have the option to add a youtube or vimeo player via an embed link
+- This link must be a correctly formatted embed link from either youtube or vimeo.
+- To find this link:
+    - Navigate to the url of the video you would like to include.
+    - Click the "share" button
+    - You will see a link or a section called "Embed". View the embed code for the video
+    - Copy JUST the link. The link will be formatted as so for Youtube and Vimeo respectively:
+      - https://www.youtube.com/embed/Znf73dsFdC8
+      - https://player.vimeo.com/video/467264493?h=b089de0eab

--- a/app/assets/stylesheets/viewer.scss
+++ b/app/assets/stylesheets/viewer.scss
@@ -5,9 +5,6 @@
 .viewer {
   height: 100%;
   padding: 10px;
-  iframe {
-    // position: absolute;
-  }
 }
 
 #viewer-modal {
@@ -20,4 +17,9 @@
   button.close {
     margin-bottom: 10px;
   }
+}
+
+.video-embed-viewer {
+  aspect-ratio: 16 / 9;
+  width: 100%;
 }

--- a/app/forms/hyrax/generic_work_form.rb
+++ b/app/forms/hyrax/generic_work_form.rb
@@ -9,8 +9,12 @@ module Hyrax
     include HydraEditor::Form::Permissions
     include PdfFormBehavior
 
-    self.terms = [:admin_note] + self.terms # rubocop:disable Style/RedundantSelf
+    self.terms = [:admin_note, :video_embed] + terms
     self.terms += %i[resource_type additional_information bibliographic_citation]
     self.required_fields = %i[title creator keyword rights_statement resource_type]
+
+    def secondary_terms
+      super + %i[video_embed]
+    end
   end
 end

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -12,6 +12,16 @@ class GenericWork < ActiveFedora::Base
 
   validates :title, presence: { message: 'Your work must have a title.' }
 
+  # rubocop:disable Style/RegexpLiteral
+  validates :video_embed,
+            format: {
+              # regex matches only youtube & vimeo urls that are formatted as embed links.
+              with: /(http:\/\/|https:\/\/)(www\.)?(player\.vimeo\.com|youtube\.com\/embed)/,
+              message: "Error: must be a valid YouTube or Vimeo Embed URL."
+            },
+            if: :video_embed?
+  # rubocop:enable Style/RegexpLiteral
+
   property :additional_information, predicate: ::RDF::Vocab::DC.accessRights do |index|
     index.as :stored_searchable
   end
@@ -30,6 +40,14 @@ class GenericWork < ActiveFedora::Base
 
   property :date, predicate: ::RDF::URI("https://hykucommons.org/terms/date"), multiple: false do |index|
     index.as :stored_searchable, :facetable
+  end
+
+  property :video_embed, predicate: ::RDF::URI("https://atla.com/terms/video_embed"), multiple: false do |index|
+    index.as :stored_searchable
+  end
+
+  def video_embed?
+    video_embed.present?
   end
 
   include ::Hyrax::BasicMetadata

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -62,6 +62,7 @@ class SolrDocument
   attribute :library_catalog_identifier, Solr::String, 'library_catalog_identifier_tesim'
   attribute :chronology_note, Solr::String, 'chronology_note_tesim'
   attribute :based_near, Solr::Array, 'based_near_tesim'
+  attribute :video_embed, Solr::String, 'video_embed_tesim'
 
   field_semantics.merge!(
     contributor: 'contributor_tesim',

--- a/app/presenters/hyku/work_show_presenter.rb
+++ b/app/presenters/hyku/work_show_presenter.rb
@@ -111,7 +111,7 @@ module Hyku
     private
 
       def extract_video_embed_presence
-        solr_document[:video_embed_tesim].present?
+        solr_document[:video_embed_tesim]&.first&.present?
       end
 
       def extract_from_identifier(rgx)

--- a/app/presenters/hyku/work_show_presenter.rb
+++ b/app/presenters/hyku/work_show_presenter.rb
@@ -104,8 +104,15 @@ module Hyku
       end
     end
     
+    def video_embed_viewer?
+      extract_video_embed_presence
+    end
 
     private
+
+      def extract_video_embed_presence
+        solr_document[:video_embed_tesim].present?
+      end
 
       def extract_from_identifier(rgx)
         if solr_document['identifier_tesim'].present?

--- a/app/views/hyrax/base/_form.html.erb
+++ b/app/views/hyrax/base/_form.html.erb
@@ -1,0 +1,24 @@
+<%# OVERRIDE Hyrax 3.6.0 to remove the broken error alerts from form validations %>
+
+<%= simple_form_for [main_app, @form],
+                    html: {
+                      data: { behavior: 'work-form',
+                              'param-key' => @form.model_name.param_key },
+                      multipart: true
+                    } do |f| %>
+  <%# OVERRIDE Here to remove broken error alert from form validation %>
+  <% if Flipflop.batch_upload? && !f.object.persisted? %>
+    <% provide :metadata_tab do %>
+      <p class="switch-upload-type"><%= t('.batch_upload_hint') %> <%= link_to t('.batch_link'), hyrax.new_batch_upload_path(payload_concern: @form.model.class) %></p>
+    <% end %>
+  <% end %>
+  <%= render 'hyrax/base/guts4form', f: f, tabs: form_tabs_for(form: f.object) %>
+<% end %>
+
+<script type="text/javascript">
+  Blacklight.onLoad(function() {
+    <%# This causes the page to switch back to the default template if they've
+        previously visited the batch download page in this Turbolinks session %>
+    $("#fileupload").fileupload('option', 'downloadTemplateId', 'template-download')
+  });
+</script>

--- a/app/views/hyrax/base/_video_embed_viewer.html.erb
+++ b/app/views/hyrax/base/_video_embed_viewer.html.erb
@@ -1,0 +1,3 @@
+<div class="col-sm-12">
+  <iframe class='video-embed-viewer' src="<%="#{@presenter.solr_document[:video_embed_tesim].first}"%>" title="Video Player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -19,7 +19,9 @@
       <div class="panel-body">
         <div class="row">
           <%= render 'workflow_actions_widget', presenter: @presenter %>
-          <% if @presenter.iiif_viewer? %>
+          <% if @presenter.video_embed_viewer? %>
+            <%= render 'video_embed_viewer', presenter: @presenter %>
+          <% elsif @presenter.iiif_viewer? %>
             <div class="col-sm-12">
               <%= render 'representative_media', presenter: @presenter, viewer: true %>
             </div>

--- a/app/views/layouts/hyrax/dashboard.html.erb
+++ b/app/views/layouts/hyrax/dashboard.html.erb
@@ -1,0 +1,41 @@
+<%# OVERRIDE from Hyrax 3.6.0 to hide broken flash messages on the dashboard edit work pages %>
+
+<!DOCTYPE html>
+<html lang="<%= I18n.locale.to_s %>" prefix="og:http://ogp.me/ns#">
+  <head>
+    <%= render partial: 'layouts/head_tag_content' %>
+    <%= content_for(:head) %>
+  </head>
+
+  <body class="dashboard">
+    <div class="skip-to-content">
+      <%= link_to "Skip to Content", "#skip-to-content" %>
+    </div>
+    <%= render '/masthead' %>
+    <%= content_for(:navbar) %>
+    <div id="content-wrapper" role="main">
+      <div class="sidebar maximized">
+        <%= render 'hyrax/dashboard/sidebar' %>
+      </div>
+      <div class="main-content maximized">
+        <%# OVERRIDE here to hide broken flash messages on the dashboard edit work pages. %>
+        <%# regex includes only the paths for works since this is the only known place flash messages are broken. %>
+          <%= render '/flash_msg' %>
+        <%= render_breadcrumbs builder: Hyrax::BootstrapBreadcrumbsBuilder %>
+        <% if content_for?(:page_header) %>
+          <div class="row">
+            <div class="col-xs-12 main-header">
+              <%= yield(:page_header) %>
+            </div>
+          </div>
+        <% end %>
+
+          <a name="skip-to-content" id="skip-to-content"></a>
+          <%= content_for?(:content) ? yield(:content) : yield %>
+
+      </div>
+
+    </div><!-- /#content-wrapper -->
+    <%= render 'shared/ajax_modal' %>
+  </body>
+</html>

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -116,7 +116,9 @@ Bulkrax.setup do |config|
   }
 
   config.field_mappings['Bulkrax::BagitParser'] = parser_mappings
-  config.field_mappings['Bulkrax::CsvParser'] = parser_mappings
+  config.field_mappings['Bulkrax::CsvParser'] = parser_mappings.merge(
+    {'video_embed' => { from: ['video_embed'] }}
+    )
 
   # Add to, or change existing mappings as follows
   #   e.g. to exclude date

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1150,6 +1150,7 @@ en:
         resource_type: Pre-defined categories to describe the type of content being uploaded, such as &quot;article&quot; or &quot;dataset.&quot;  More than one type may be selected.
         subject: Headings or index terms describing what the work is about; these do need to conform to an existing vocabulary.
         title: A name to aid in identifying a work.
+        video_embed: "If you enter an embed link for a video, it must be a properly formatted url beginning with 'http://' or 'https://'. It also needs to contain a valid link to a hosted video that can appear in an iframe. <br /><br /><i>Examples:<br/>https://player.vimeo.com/video/467264493?h=b089de0eab<br/>https://www.youtube.com/embed/Znf73dsFdC8</i>"
     labels:
       collection:
         size: Size


### PR DESCRIPTION
This commit allows videos to be embedded into a Generic Work. When the value is present, an embedded video should display.

related:
- https://github.com/scientist-softserv/atla-hyku/pull/34/files

Issue:
- https://github.com/scientist-softserv/palni-palci/issues/911

# TODO

This PR is already large. I may create sub task for the tickets in attempts to keep this epic of work small. This PR only handles embedding the video for Generic Works, base theme, and in English only.

- [ ] Run translations
- [ ] Add video embed options to other work types
- [ ] Add embedded video to other theme's show pages

# Expected Behavior Before Changes

This feature previously did not exist.

# Expected Behavior After Changes

A user can create a Generic Work and embed a video. If the value exists, the embedded video will display in the iframe of the show page and the user is able to play it. 

![Screenshot 2023-12-05 at 15-39-30 embed](https://github.com/scientist-softserv/palni-palci/assets/10081604/6c6967cb-8c46-45a4-8fec-3c4f0e22df49)

When there is an error on the form (ie: an invalid embed link), messages appear to say so: 


![Screenshot 2023-12-05 at 16-17-09 embed __ Work fb7583b6-bf66-478a-b0c9-dad657fd60d4 __ Dev](https://github.com/scientist-softserv/palni-palci/assets/10081604/f311a0de-ea4e-4a2b-baba-45c6dfe93c74)
![Screenshot 2023-12-05 at 16-17-59 embed __ Work fb7583b6-bf66-478a-b0c9-dad657fd60d4 __ Dev](https://github.com/scientist-softserv/palni-palci/assets/10081604/475dc290-9c82-44ae-8e68-9d2f7c04919c)


# Notes
