### PR TITLE
🎁 Add video embed to OER Work Type

### DIFF
--- a/app/forms/hyrax/oer_form.rb
+++ b/app/forms/hyrax/oer_form.rb
@@ -16,15 +16,16 @@ module Hyrax
                     newer_version_id previous_version_id alternate_version_id related_item_id keyword
                     date_created files visibility_during_embargo embargo_release_date visibility_after_embargo
                     visibility_during_lease lease_expiration_date visibility_after_lease visibility
-                    ordered_member_ids in_works_ids member_of_collection_ids admin_set_id abstract video_embed]
+                    ordered_member_ids in_works_ids member_of_collection_ids admin_set_id abstract]
     self.terms -=%i[previous_version_id newer_version_id alternate_version_id related_item_id]
     self.required_fields = %i[title creator resource_type date_created audience education_level learning_resource_type
                               discipline rights_statement]
 
     delegate :related_members_attributes=, :previous_version, :newer_version, :alternate_version, :related_item, to: :model
+    include VideoEmbedFormBehavior
 
     def secondary_terms
-      super - [:rendering_ids] + [:video_embed]
+      super - [:rendering_ids]
     end
 
     def self.build_permitted_params

--- a/app/forms/hyrax/oer_form.rb
+++ b/app/forms/hyrax/oer_form.rb
@@ -16,7 +16,7 @@ module Hyrax
                     newer_version_id previous_version_id alternate_version_id related_item_id keyword
                     date_created files visibility_during_embargo embargo_release_date visibility_after_embargo
                     visibility_during_lease lease_expiration_date visibility_after_lease visibility
-                    ordered_member_ids in_works_ids member_of_collection_ids admin_set_id abstract]
+                    ordered_member_ids in_works_ids member_of_collection_ids admin_set_id abstract video_embed]
     self.terms -=%i[previous_version_id newer_version_id alternate_version_id related_item_id]
     self.required_fields = %i[title creator resource_type date_created audience education_level learning_resource_type
                               discipline rights_statement]
@@ -24,7 +24,7 @@ module Hyrax
     delegate :related_members_attributes=, :previous_version, :newer_version, :alternate_version, :related_item, to: :model
 
     def secondary_terms
-      super - [:rendering_ids]
+      super - [:rendering_ids] + [:video_embed]
     end
 
     def self.build_permitted_params

--- a/app/forms/video_embed_form_behavior.rb
+++ b/app/forms/video_embed_form_behavior.rb
@@ -7,7 +7,7 @@ module VideoEmbedFormBehavior
     self.terms += %i[video_embed]
   end
 
-  def secondary_terms
+  def primary_terms
     super + %i[video_embed]
   end
 end

--- a/app/models/concerns/video_embed_behavior.rb
+++ b/app/models/concerns/video_embed_behavior.rb
@@ -7,9 +7,9 @@ module VideoEmbedBehavior
     validates :video_embed,
               format: {
                 with: %r{(http://|https://)(www\.)?(player\.vimeo\.com|youtube\.com/embed)},
-                message: ->(object, data) do
+                message: lambda do |_object, _data|
                   I18n.t('errors.messages.valid_embed_url', default: 'must be a valid YouTube or Vimeo Embed URL.')
-                end 
+                end
               },
               if: :video_embed?
 

--- a/app/models/concerns/video_embed_behavior.rb
+++ b/app/models/concerns/video_embed_behavior.rb
@@ -6,7 +6,7 @@ module VideoEmbedBehavior
   included do
     validates :video_embed,
               format: {
-                with: /(http:\/\/|https:\/\/)(www\.)?(player\.vimeo\.com|youtube\.com\/embed)/,
+                with: %r{(http://|https://)(www\.)?(player\.vimeo\.com|youtube\.com/embed)},
                 message: "Error: must be a valid YouTube or Vimeo Embed URL."
               },
               if: :video_embed?

--- a/app/models/concerns/video_embed_behavior.rb
+++ b/app/models/concerns/video_embed_behavior.rb
@@ -7,7 +7,9 @@ module VideoEmbedBehavior
     validates :video_embed,
               format: {
                 with: %r{(http://|https://)(www\.)?(player\.vimeo\.com|youtube\.com/embed)},
-                message: "Error: must be a valid YouTube or Vimeo Embed URL."
+                message: ->(object, data) do
+                  I18n.t('errors.messages.valid_embed_url', default: 'must be a valid YouTube or Vimeo Embed URL.')
+                end 
               },
               if: :video_embed?
 

--- a/app/models/oer.rb
+++ b/app/models/oer.rb
@@ -12,6 +12,7 @@ class Oer < ActiveFedora::Base
     pdf_splitter_service: IiifPrint::TenantConfig::PdfSplitter
   )
   include PdfBehavior
+  include VideoEmbedBehavior
 
   self.indexer = OerIndexer
   # Change this to restrict which works can be added as a child.
@@ -22,15 +23,6 @@ class Oer < ActiveFedora::Base
   validates :learning_resource_type, presence: { message: 'You must select a learning resource type.' }
   validates :resource_type, presence: { message: 'You must select a resource type.' }
   validates :discipline, presence: { message: 'You must select a discipline.' }
-  # rubocop:disable Style/RegexpLiteral
-  validates :video_embed,
-            format: {
-              # regex matches only youtube & vimeo urls that are formatted as embed links.
-              with: /(http:\/\/|https:\/\/)(www\.)?(player\.vimeo\.com|youtube\.com\/embed)/,
-              message: "Error: must be a valid YouTube or Vimeo Embed URL."
-            },
-            if: :video_embed?
-  # rubocop:enable Style/RegexpLiteral
 
   property :audience, predicate: ::RDF::Vocab::SCHEMA.EducationalAudience do |index|
     index.as :stored_searchable, :facetable
@@ -114,14 +106,6 @@ class Oer < ActiveFedora::Base
 
   property :date, predicate: ::RDF::URI("https://hykucommons.org/terms/date"), multiple: false do |index|
     index.as :stored_searchable, :facetable
-  end
-
-  property :video_embed, predicate: ::RDF::URI("https://atla.com/terms/video_embed"), multiple: false do |index|
-    index.as :stored_searchable
-  end
-
-  def video_embed?
-    video_embed.present?
   end
 
   # This must be included at the end, because it finalizes the metadata

--- a/app/models/oer.rb
+++ b/app/models/oer.rb
@@ -22,6 +22,15 @@ class Oer < ActiveFedora::Base
   validates :learning_resource_type, presence: { message: 'You must select a learning resource type.' }
   validates :resource_type, presence: { message: 'You must select a resource type.' }
   validates :discipline, presence: { message: 'You must select a discipline.' }
+  # rubocop:disable Style/RegexpLiteral
+  validates :video_embed,
+            format: {
+              # regex matches only youtube & vimeo urls that are formatted as embed links.
+              with: /(http:\/\/|https:\/\/)(www\.)?(player\.vimeo\.com|youtube\.com\/embed)/,
+              message: "Error: must be a valid YouTube or Vimeo Embed URL."
+            },
+            if: :video_embed?
+  # rubocop:enable Style/RegexpLiteral
 
   property :audience, predicate: ::RDF::Vocab::SCHEMA.EducationalAudience do |index|
     index.as :stored_searchable, :facetable
@@ -105,6 +114,14 @@ class Oer < ActiveFedora::Base
 
   property :date, predicate: ::RDF::URI("https://hykucommons.org/terms/date"), multiple: false do |index|
     index.as :stored_searchable, :facetable
+  end
+
+  property :video_embed, predicate: ::RDF::URI("https://atla.com/terms/video_embed"), multiple: false do |index|
+    index.as :stored_searchable
+  end
+
+  def video_embed?
+    video_embed.present?
   end
 
   # This must be included at the end, because it finalizes the metadata

--- a/app/views/themes/cultural_show/hyrax/base/show.html.erb
+++ b/app/views/themes/cultural_show/hyrax/base/show.html.erb
@@ -21,7 +21,7 @@
               <div class="col-sm-12 centered-media">
                 <%= render 'representative_media', presenter: @presenter, viewer: true %>
               </div>
-            <% elsif @presenter.pdf_viewer? %>
+            <% elsif @presenter.show_pdf_viewer? %>
               <div class="col-sm-12">
                 <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter) %>
               </div>

--- a/app/views/themes/scholarly_show/hyrax/base/show.html.erb
+++ b/app/views/themes/scholarly_show/hyrax/base/show.html.erb
@@ -32,7 +32,7 @@
                 <% render 'work_description', presenter: @presenter %>
               </div>
             </div>
-          <% elsif @presenter.pdf_viewer? %>
+          <% elsif @presenter.show_pdf_viewer? %>
             <div class="col-sm-12">
               <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter) %>
             </div>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,5 +1,8 @@
 ---
 de:
+  errors:
+    messages:
+      valid_embed_url: "muss eine gültige YouTube- oder Vimeo-Einbettungs-URL sein."
   activefedora:
     models:
       cdl: CDL

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,8 @@
 ---
 en:
+  errors:
+    messages:
+      valid_embed_url: "must be a valid YouTube or Vimeo Embed URL."
   single_signon:
    index:
      sign_in_with_provider: Sign in with %{provider}

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,5 +1,8 @@
 ---
 es:
+  errors:
+    messages:
+      valid_embed_url: "debe ser una URL de incrustación válida de YouTube o Vimeo."
   activefedora:
     models:
       cdl: CDL

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,5 +1,8 @@
 ---
 fr:
+  errors:
+    messages:
+      valid_embed_url: "doit être une URL d'incorporation valide de YouTube ou Vimeo."
   activefedora:
     models:
       cdl: CDL

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,5 +1,8 @@
 ---
 it:
+  errors:
+    messages:
+      valid_embed_url: "deve essere un URL di incorporamento valido di YouTube o Vimeo."
   activefedora:
     models:
       cdl: CDL

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,5 +1,8 @@
 ---
 pt-BR:
+  errors:
+    messages:
+      valid_embed_url: "deve ser uma URL de incorporação válida do YouTube ou Vimeo."
   activefedora:
     models:
       cdl: CDL

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1,5 +1,8 @@
 ---
 zh:
+  errors:
+    messages:
+      valid_embed_url: "必须是有效的YouTube或Vimeo嵌入URL。"
   activefedora:
     models:
       cdl: CDL


### PR DESCRIPTION
This PR manually adds video embed to oer model, form files, and show partial.

It also includes translations. 

Issue:
- https://github.com/scientist-softserv/palni-palci/issues/911

# OER show page (OER does not use the base/show.html.erb like the other model types)

Vimeo example: https://player.vimeo.com/video/467264493?h=b089de0eab

![image](https://github.com/scientist-softserv/palni-palci/assets/10081604/4cd2b711-773c-4984-8fac-de2a6edb21a0)



