### PR TITLE
🐛 Fix audio mime type for IIIF manifest

### DIFF
--- a/app/presenters/concerns/hyrax/iiif_av/displays_content_decorator.rb
+++ b/app/presenters/concerns/hyrax/iiif_av/displays_content_decorator.rb
@@ -63,6 +63,17 @@ module Hyrax
           )
         end
 
+        def audio_content
+          streams = stream_urls
+          if streams.present?
+            streams.collect { |label, url| audio_display_content(url, label) }
+          else
+            # OVERRIDE, because we're hard coding `audio/mpeg`, it doesn't make sense to support `ogg`
+            # See: https://github.com/samvera-labs/hyrax-iiif_av/blob/6273f90016c153d2add33f85cc24285d51a25382/app/presenters/concerns/hyrax/iiif_av/displays_content.rb#L118
+            audio_display_content(download_path('mp3'), 'mp3')
+          end
+        end
+
         def audio_display_content(_url, label = '')
           duration = conformed_duration_in_seconds
           IIIFManifest::V3::DisplayContent.new(
@@ -74,7 +85,9 @@ module Hyrax
             label: label,
             duration: duration,
             type: 'Sound',
-            format: solr_document.mime_type
+            # instead of relying on the mime type of the original file, we hard code it to `audio/mpeg`
+            # because this is pointing to the mp3 derivative, also UV doesn't support specifically `audio/x-wave`
+            format: 'audio/mpeg'
           )
         end
 


### PR DESCRIPTION
# Story

This commit will use `audio/mpeg` as the mime type for mp3 resources in the IIIF manifest instead of relying on the characterized mime type of the original file.  This is a problem when our file is a wav file and it gets characterized as `audio/x-wave` which doesn't work with Universal Viewer.  Instead, since we are serving up the mp3 derivative in the manifest, we should use `audio/mpeg` as the mime type.  We also remove the ogg format because it is not being used and having that hard coded as `audio/mpeg` as well feels incorrect.  This however doesn't solve the bigger problem of the File Set not gettig the original file in the first place but that is a separate issue and would need some investigation.

Ref:
  - https://github.com/scientist-softserv/palni-palci/issues/887

# Screenshots / Video

<img width="1201" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/19597776/a56aeba6-07e7-4584-9638-86a2fdf76e5d">

<details><summary>Manifest:</summary>

```json
{
  "@context": [
    "http://www.w3.org/ns/anno.jsonld",
    "http://iiif.io/api/presentation/3/context.json"
  ],
  "type": "Manifest",
  "id": "https://dev.hyku.test/concern/generic_works/6f05a539-bfc3-4a0c-b173-47d427c5b59f/manifest",
  "label": {
    "none": [
      "audio test"
    ]
  },
  "rights": "http://rightsstatements.org/vocab/InC-OW-EU/1.0/",
  "metadata": [
    {
      "label": {
        "en": [
          "Title"
        ]
      },
      "value": {
        "none": [
          "audio test"
        ]
      }
    },
    {
      "label": {
        "en": [
          "Date modified"
        ]
      },
      "value": {
        "none": [
          "12/07/2023"
        ]
      }
    },
    {
      "label": {
        "en": [
          "Creator"
        ]
      },
      "value": {
        "none": [
          "<a href='https://dev.hyku.test/catalog?f%5Bcreator_sim%5D%5B%5D=Wang%2C+Kirk&locale=en'>Wang, Kirk</a>"
        ]
      }
    },
    {
      "label": {
        "en": [
          "Keyword"
        ]
      },
      "value": {
        "none": [
          "<a href='https://dev.hyku.test/catalog?f%5Bkeyword_sim%5D%5B%5D=test&locale=en'>test</a>"
        ]
      }
    },
    {
      "label": {
        "en": [
          "Resource type"
        ]
      },
      "value": {
        "none": [
          "<a href='https://dev.hyku.test/catalog?f%5Bresource_type_sim%5D%5B%5D=Audio&locale=en'>Audio</a>"
        ]
      }
    },
    {
      "label": {
        "en": [
          "Rights statement"
        ]
      },
      "value": {
        "none": [
          "<a href='http://rightsstatements.org/vocab/InC-OW-EU/1.0/'>In Copyright - EU Orphan Work</a>"
        ]
      }
    }
  ],
  "service": [
    {
      "@context": "http://iiif.io/api/search/1/context.json",
      "profile": "http://iiif.io/api/search/1/search",
      "label": "Search within this manifest",
      "type": "SearchService1",
      "id": "https://dev.hyku.test/catalog/6f05a539-bfc3-4a0c-b173-47d427c5b59f/iiif_search"
    }
  ],
  "items": [
    {
      "type": "Canvas",
      "id": "https://dev.hyku.test/concern/generic_works/6f05a539-bfc3-4a0c-b173-47d427c5b59f/manifest/canvas/c625a441-46d9-4647-b430-53386902656b",
      "label": {
        "none": [
          "file_example_WAV_1MG.wav"
        ]
      },
      "items": [
        {
          "type": "AnnotationPage",
          "id": "https://dev.hyku.test/concern/generic_works/6f05a539-bfc3-4a0c-b173-47d427c5b59f/manifest/canvas/c625a441-46d9-4647-b430-53386902656b/annotation_page/e9a765a5-eb70-4583-b6c8-17266c0aad70",
          "items": [
            {
              "type": "Annotation",
              "motivation": "painting",
              "body": {
                "id": "http://dev.hyku.test/iiif_av/content/c625a441-46d9-4647-b430-53386902656b/mp3",
                "type": "Sound",
                "duration": 5.94,
                "format": "audio/mpeg",
                "label": {
                  "none": [
                    "mp3"
                  ]
                }
              },
              "id": "https://dev.hyku.test/concern/generic_works/6f05a539-bfc3-4a0c-b173-47d427c5b59f/manifest/canvas/c625a441-46d9-4647-b430-53386902656b/annotation_page/e9a765a5-eb70-4583-b6c8-17266c0aad70/annotation/5b7e8f13-e820-4949-926a-3d3b007ec86c",
              "target": "https://dev.hyku.test/concern/generic_works/6f05a539-bfc3-4a0c-b173-47d427c5b59f/manifest/canvas/c625a441-46d9-4647-b430-53386902656b"
            }
          ]
        }
      ],
      "thumbnail": [],
      "duration": 5.94
    }
  ],
  "viewingHint": "paged"
}
```
</details>