### PR TITLE
🎁 Add admin dashboard data repair jobs menu

### DIFF
--- a/app/controllers/admin/roles_service_controller.rb
+++ b/app/controllers/admin/roles_service_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Admin
+  class RolesServiceController < ApplicationController
+    layout 'hyrax/dashboard'
+
+    def index
+      authorize! :update, RolesService
+      add_breadcrumb t(:'hyrax.controls.home'), root_path
+      add_breadcrumb t(:'hyrax.dashboard.breadcrumbs.admin'), hyrax.dashboard_path
+      add_breadcrumb t(:'hyrax.admin.sidebar.roles_service_jobs'), main_app.admin_roles_service_jobs_path
+    end
+
+    # post "admin/roles_service/:job_name_key
+    def update_roles
+      authorize! :update, RolesService
+      job = RolesService.valid_jobs.fetch(params[:job_name_key])
+
+      job.perform_later
+
+      respond_to do |wants|
+        wants.html { redirect_to main_app.admin_roles_service_jobs_path, notice: "#{job} has been submitted." }
+        wants.json { render json: { notice: "#{job} has been submitted." }, status: :ok }
+      end
+    end
+  end
+end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -57,6 +57,7 @@ class Ability
 
     super
     can [:manage], [Site, Role, User]
+    can [:update], RolesService
 
     can [:read, :update], Account do |account|
       account == Site.account

--- a/app/views/admin/roles_service/index.html.erb
+++ b/app/views/admin/roles_service/index.html.erb
@@ -1,0 +1,21 @@
+<% content_for :page_title, construct_page_title(t('hyrax.admin.roles_service_jobs.header'), t('hyku.admin.title')) %>
+<% provide :page_header do %>
+  <h1><span class="fa fa-wrench" aria-hidden="true"></span>
+  <%= t('hyrax.admin.roles_service_jobs.header') %></h1>
+<% end %>
+
+<div class='panel panel-default'>
+  <div class='panel-body'>
+    <div class='table-responsive'>
+      <table class='table table-striped datatable'>
+        <tbody>
+          <% RolesService.valid_jobs.each do |key, klass| %>
+            <tr>
+              <td><%= button_to t("hyrax.admin.roles_service_jobs.jobs.#{key}.label"), main_app.admin_update_roles_path(job_name_key: key), method: :post, class: 'btn btn-danger' %></td>
+              <td><%= t("hyrax.admin.roles_service_jobs.jobs.#{key}.description") %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+  </div>
+</div>

--- a/app/views/hyrax/dashboard/sidebar/_configuration.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_configuration.html.erb
@@ -53,4 +53,9 @@
     <% end # end of configuration block %>
     <%= render 'hyrax/dashboard/sidebar/menu_partials', menu: menu, section: :configuration %>
   <% end %>
+  <% if can?(:update, RolesService) %>
+    <%= menu.nav_link(main_app.admin_roles_service_jobs_path) do %>
+      <span class="fa fa-users" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.roles_service_jobs') %></span>
+    <% end %>
+  <% end %>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -246,12 +246,35 @@ en:
             favicon: Favicon
             fonts: "Fonts"
             themes: "Themes"
+      roles_service_jobs:
+        header: Data Repair Jobs
+        jobs:
+          create_admin_set_accesses: 
+            label: Create Admin Set Accesses
+            description: "Creating a Hyrax::PermissionTemplateAccess record (combined with Ability#user_groups)
+            will allow Works in all AdminSets to show up in Blacklight / Solr queries."
+          create_collection_accesses: 
+            label: Create Collection Accesses
+            description: "Because each collection role has some level of access to every Collection within a tenant,
+            creating a Hyrax::PermissionTemplateAccess record (combined with Ability#user_groups)
+            means all Collections will show up in Blacklight / Solr queries."
+          create_collection_type_participants: 
+            label: Create Collection Type Participants
+            description: "Because some of the collection roles have access to every Collection within a tenant, create a
+            Hyrax::CollectionTypeParticipant record for them on every Hyrax::CollectionType (except the AdminSet)"
+          grant_workflow_roles_for_all_admin_sets:
+            label: Admin Set Workflow Roles
+            description: "Permissions to deposit Works are controlled by Workflow Roles on individual AdminSets.
+            In order for Hyrax::Group and User records who have either the 'Work Editor' or 'Work Depositor' Role
+            to have the correct permissions for Works, we grant them Workflow Roles for all AdminSets.
+            NOTE: All AdminSets must have a permission template or this will fail. Run 'Create Admin Set Accesses' first."      
       sidebar:
         accounts: Accounts
         activity_summary: Activity Summary
         labels: Labels
         manage_groups: Manage Groups
         system_status: System Status
+        roles_service_jobs: Data Repair
       users:
         activate:
           confirmation: Are you sure you want to activate the user "%{user}"?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -134,6 +134,8 @@ Rails.application.routes.draw do # rubocop:disable Metrics/BlockLength
       resources :users, only: %i[index create destroy], param: :user_id, controller: 'group_users'
       resources :roles, only: %i[index create destroy], param: :role_id, controller: 'group_roles'
     end
+    post "roles_service/:job_name_key", to: "roles_service#update_roles", as: :update_roles
+    get "roles_service", to: "roles_service#index", as: :roles_service_jobs
   end
 
   # OVERRIDE here to add featured collection routes

--- a/spec/controllers/admin/roles_service_controller_spec.rb
+++ b/spec/controllers/admin/roles_service_controller_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.describe Admin::RolesServiceController, type: :controller do
+  context 'as an anonymous user' do
+    describe 'GET #index' do
+      subject { get :index }
+
+      it { is_expected.to redirect_to new_user_session_path }
+    end
+  end
+
+  context 'as an admin user' do
+    before { sign_in create(:admin) }
+
+    describe 'GET #index' do
+      subject { get :index }
+
+      it { is_expected.to render_template('layouts/hyrax/dashboard') }
+      it { is_expected.to render_template('admin/roles_service/index') }
+    end
+  end
+
+  context 'as an admin user' do
+    before { sign_in create(:admin) }
+
+    describe 'GET #index' do
+      subject { get :index }
+
+      it { is_expected.to render_template('layouts/hyrax/dashboard') }
+      it { is_expected.to render_template('admin/roles_service/index') }
+    end
+
+    describe 'POST #update_roles' do
+      it 'submits a job when it receives a valid job name' do
+        expect(RolesService::CreateCollectionAccessesJob).to receive(:perform_later)
+        post :update_roles, params: { job_name_key: :create_collection_accesses }
+      end
+    end
+  end
+end

--- a/spec/routing/admin/roles_service_routing_spec.rb
+++ b/spec/routing/admin/roles_service_routing_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+RSpec.describe Admin::RolesServiceController, type: :routing do
+  describe "routing" do
+    it "routes to #index" do
+      expect(get: "/admin/roles_service").to route_to("admin/roles_service#index")
+    end
+
+    it "routes to #update_roles via POST" do
+      expect(post: "/admin/roles_service/create_collection_accesses").to route_to("admin/roles_service#update_roles", job_name_key: 'create_collection_accesses')
+    end
+  end
+end


### PR DESCRIPTION
# Story
Adds a new menu, `Data Repair`, which contains buttons to submit RolesService repair tasks as jobs.

Jobs included are:
* CreateCollectionAccessesJob,
* CreateAdminSetAccessesJob,
* CreateCollectionTypeParticipantsJob,
* GrantWorkflowRolesForAllAdminSetsJob

Refs: https://github.com/scientist-softserv/palni-palci/issues/844

# Expected Behavior Before Changes

# Expected Behavior After Changes

- Data Repair menu appears at the bottom of admin dashboard sidebar.
- Data Repair menu has buttons with descriptive text to submit 4 commonly requested jobs.
- When a button is activated, a confirmation message appears to indicate that the job was submitted.

# Screenshots / Video

<details>
<summary></summary>

![Screenshot 2023-12-07 at 7 24 58 PM](https://github.com/scientist-softserv/palni-palci/assets/17851674/1ac7a677-5864-4706-ad06-84f194cdfd2d)

![Screenshot 2023-12-07 at 7 24 50 PM](https://github.com/scientist-softserv/palni-palci/assets/17851674/53c17432-30ad-43ca-b0fe-6848714da774)

![Screenshot 2023-12-07 at 7 25 12 PM](https://github.com/scientist-softserv/palni-palci/assets/17851674/12a8272a-3115-48a0-ad48-4954998590ba)

</details>

# Notes
Requires translations to run. https://github.com/scientist-softserv/palni-palci/issues/940