### PR TITLE
🧹 Tighten tenant GA ID logic

### DIFF
--- a/app/views/shared/_ga4.html.erb
+++ b/app/views/shared/_ga4.html.erb
@@ -1,6 +1,7 @@
 <%# OVERRIDE Hyrax 3.5.0 to handle multitenancy %>
 
-<% ids = [Settings.google_analytics_id, current_account.google_analytics_id].compact.reject(&:empty?).uniq %>
+<% tenant_ga_id = current_account.google_analytics_id if current_account.id %>
+<% ids = [Settings.google_analytics_id, tenant_ga_id].compact.reject(&:empty?).uniq %>
 <script async src="https://www.googletagmanager.com/gtag/js?id=<%= ids.first %>"></script>
 <script>
   window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
The `#current_account` method returns a tenant instance when on the proprietor page (not in a tenant subdomain). This then looks for a `HYKU_GOOGLE_ANALYTICS_ID` instead of the `GOOGLE_ANALYTICS_ID` env variable.  We want to only use the `GOOGLE_ANALYTICS_ID`.

Ref:
  - https://github.com/scientist-softserv/palni-palci/issues/910
