### PR TITLE
🎁 Add search form to splash page

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -128,3 +128,8 @@ Metrics/BlockLength:
     - 'spec/**/*.rb'
     - 'lib/tasks/*.rake'
     - 'app/controllers/catalog_controller.rb'
+
+RSpec/FilePath:
+  Exclude:
+    - 'spec/config/application_spec.rb'
+    - 'spec/services/discipline_service_spec.rb'

--- a/app/views/splash/_search_form.html.erb
+++ b/app/views/splash/_search_form.html.erb
@@ -1,0 +1,19 @@
+<%# OVERRIDE Copied from app/views/catalog/_search_form.html.erb
+Used for rendering the home URL. %>
+<%= form_tag Hyku::Application.cross_tenant_search_url, target: "_blank", method: :get, class: "form-horizontal search-form", id: "search-form-header", role: "search" do %>
+  <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:q, :search_field, :qt, :page, :utf8)) %>
+  <%= hidden_field_tag :search_field, 'all_fields' %>
+  <div class="form-group">
+    <label class="control-label col-sm-3" for="search-field-header">
+      <%= t("hyku.splash.form.q.label", application_name: application_name) %>
+    </label>
+    <div class="input-group">
+      <%= text_field_tag :q, current_search_parameters , class: "q form-control", id: "search-field-header", placeholder: t("hyrax.search.form.q.placeholder") %>
+      <div class="input-group-btn">
+        <button type="submit" class="btn btn-primary" id="search-submit-header">
+          <%= t('hyrax.search.button.html') %>
+        </button>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/splash/index.html.erb
+++ b/app/views/splash/index.html.erb
@@ -17,9 +17,9 @@
   </div>
 </section>
 
-
-
 <section class="product-features">
+  <%# SEARCH BAR FOR HOME PAGE %>
+  <%= render partial: 'splash/search_form' %>
   <h2>Browse our partner repositories:</h2>
   <div class="row grid-row accounts-row">
     <% @accounts.each_with_index do |account, i| %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,29 @@ Bundler.require(*groups)
 
 module Hyku
   class Application < Rails::Application
+    ##
+    # @return [String] the URL to use for searching across all tenants.
+    #
+    # @see .cross_tenant_search_host
+    # @see https://github.com/scientist-softserv/palni-palci/issues/947
+    def self.cross_tenant_search_url
+      # Do not include the scheme (e.g. http or https) but instead let the browser apply the correct
+      # scheme.
+      "//#{cross_tenant_search_host}/catalog"
+    end
+
+    ##
+    # @api private
+    #
+    # @return [String] the host (e.g. "search.hykucommons.org") for cross-tenant search.
+    def self.cross_tenant_search_host
+      # I'm providing quite a few fallbacks, as this URL is used on the first page you'll see in a
+      # new Hyku instance.
+      ENV["HYKU_CROSS_TENANT_SEARCH_HOST"].presence ||
+      Account.where(search_only: true).limit(1).pluck(:cname)&.first ||
+        "search.hykucommons.org"
+    end
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -190,6 +190,9 @@ en:
       left_text: Works for institutions large and small, from museums to university libraries. Get started in minutes.
       right_heading: Flexible
       right_text: Customize the user interface to match your institution's brand identity. Tailor workflows to match how your staff likes to work.
+      form:
+        q:
+          label: Search across all repositories
     toolbar:
       profile:
         edit_registration: Change password

--- a/ops/demo-deploy.tmpl.yaml
+++ b/ops/demo-deploy.tmpl.yaml
@@ -106,6 +106,8 @@ extraEnvVars: &envVars
     value: "true"
   - name: HYKU_ROOT_HOST
     value: commons-archive.org
+  - name: HYKU_CROSS_TENANT_SEARCH_HOST
+    value: search.commons-archive.org
   - name: HYKU_USER_DEFAULT_PASSWORD
     value: password
   - name: HYRAX_USE_SOLR_GRAPH_NESTING

--- a/ops/production-deploy.tmpl.yaml
+++ b/ops/production-deploy.tmpl.yaml
@@ -120,6 +120,8 @@ extraEnvVars: &envVars
     value: "true"
   - name: HYKU_ROOT_HOST
     value: hykucommons.org
+  - NAME: HYKU_CROSS_TENANT_SEARCH_HOST
+    value: search.commons-archive.org
   - name: HYKU_USER_DEFAULT_PASSWORD
     value: password
   - name: HYRAX_USE_SOLR_GRAPH_NESTING

--- a/spec/config/application_spec.rb
+++ b/spec/config/application_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Hyku::Application do
+  describe ".cross_tenant_search_url" do
+    subject { described_class.cross_tenant_search_url }
+
+    it { is_expected.to start_with("//") }
+  end
+
+  describe ".cross_tenant_search_host" do
+    subject { described_class.cross_tenant_search_host }
+
+    it { is_expected.to be_present }
+    it { is_expected.to be_a(String) }
+  end
+end


### PR DESCRIPTION
This feature introduces a search on the proprietor's home page (e.g. the
root host of the Hyku instance).

That form will then submit a search against the configured host for
cross-tenant searching.

In the case of "commonsarchive.org", that will be
"//search.commonsarchive.org/catalog" (as demonstrated in the hard-coded value).

Related to:

- https://github.com/scientist-softserv/palni-palci/issues/947