### PR TITLE
🧹 Remove "Research Repository" from institution label

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -51,7 +51,7 @@ class Site < ApplicationRecord
 
   def institution_label
     if Site.instance.institution_name.present?
-      "#{Site.instance.institution_name}"
+      Site.instance.institution_name.to_s
     else
       Site.instance&.account&.cname
     end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -51,7 +51,7 @@ class Site < ApplicationRecord
 
   def institution_label
     if Site.instance.institution_name.present?
-      "#{Site.instance.institution_name} Research Repository"
+      "#{Site.instance.institution_name}"
     else
       Site.instance&.account&.cname
     end

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -50,7 +50,7 @@ class Site < ApplicationRecord
   end
 
   def institution_label
-    if Site.instance.institution_name.present?
+    if Site.instance&.institution_name&.present?
       Site.instance.institution_name.to_s
     else
       Site.instance&.account&.cname


### PR DESCRIPTION
⚠️ Deploying this requires a reindex of works and collections! ⚠️

The client set an institution label for a tenant as "PVCC" and was surprised to see the display labeled as "PVCC Research Repository". Originally the client asked for feature parity with BL, so this was implemented they way they do it.

ref: https://assaydepot.slack.com/archives/C0313NKC08L/p1702649455056029?thread_ts=1702588480.326439&cid=C0313NKC08L

Issue:
- https://github.com/scientist-softserv/palni-palci/issues/915

<img width="952" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/10081604/a0a252a1-dcfb-4180-80f5-e53d84a85d73">


