### PR TITLE
🐛 Skip rendering badges on search_only tenants

### DIFF
--- a/app/presenters/hyrax/collection_presenter_decorator.rb
+++ b/app/presenters/hyrax/collection_presenter_decorator.rb
@@ -104,6 +104,25 @@ module Hyrax
       user_can_feature_collection? && solr_document.public?
     end
 
+    ##
+    # OVERRIDE to handle search_only tenant's not having access to the collection type badge from
+    # the document's home tenant.
+    #
+    # @return [String]
+    #
+    # @see https://github.com/scientist-softserv/palni-palci/issues/951
+    # @see https://github.com/samvera/hyku/issues/1815
+    def collection_type_badge
+      return "" unless Site.account&.present?
+      return "" if Site.account.search_only?
+
+      super
+    rescue ActiveRecord::RecordNotFound
+      # This is a fail-safe if we deleted the underlying Hyrax::CollectionType but have not yet
+      # cleaned up the SOLR records.
+      ""
+    end
+
     def display_feature_collection_link?
       collection_featurable? && FeaturedCollection.can_create_another? && !collection_featured?
     end

--- a/spec/features/admin_dashboard_spec.rb
+++ b/spec/features/admin_dashboard_spec.rb
@@ -46,11 +46,14 @@ RSpec.describe 'Admin Dashboard', type: :feature, js: true, clean: true do
         expect(page).to have_link('Available Work Types')
         click_link "Features"
       end
+      # TODO: I (Jeremy) commented out the code, because I find it hard to imagine that the
+      #       e12067c3ac367d4bb2798ab71fbb8660 is a durable value for tests.
+      #
       # the workflow roles button is only ever shown if the setting is turned on.
-      within("form[action='/admin/features/show_workflow_roles_menu_item_in_admin_dashboard_sidebar/strategies/e12067c3ac367d4bb2798ab71fbb8660?locale=en']") do
-        find("input[value='on']").click
-      end
-      expect(page).to have_link('Workflow Roles')
+      # within("form[action='/admin/features/show_workflow_roles_menu_item_in_admin_dashboard_sidebar/strategies/e12067c3ac367d4bb2798ab71fbb8660?locale=en']") do
+      #   find("input[value='on']").click
+      # end
+      # expect(page).to have_link('Workflow Roles')
     end
 
     it 'shows the status page' do

--- a/spec/features/admin_dashboard_spec.rb
+++ b/spec/features/admin_dashboard_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe 'Admin Dashboard', type: :feature, js: true, clean: true do
       login_as(user, scope: :user)
     end
 
-    skip 'TODO: This consistently fails the CI pipeline, but passes locally. https://github.com/scientist-softserv/palni-palci/issues/933'
     it 'shows the admin page' do # rubocop:disable RSpec/ExampleLength
       visit Hyrax::Engine.routes.url_helpers.dashboard_path
       within '.sidebar' do
@@ -46,13 +45,8 @@ RSpec.describe 'Admin Dashboard', type: :feature, js: true, clean: true do
         expect(page).to have_link('Available Work Types')
         click_link "Features"
       end
-      # TODO: I (Jeremy) commented out the code, because I find it hard to imagine that the
-      #       e12067c3ac367d4bb2798ab71fbb8660 is a durable value for tests.
-      #
       # the workflow roles button is only ever shown if the setting is turned on.
-      # within("form[action='/admin/features/show_workflow_roles_menu_item_in_admin_dashboard_sidebar/strategies/e12067c3ac367d4bb2798ab71fbb8660?locale=en']") do
-      #   find("input[value='on']").click
-      # end
+      # see before block for enabling the feature
       # expect(page).to have_link('Workflow Roles')
     end
 

--- a/spec/presenters/hyrax/collection_presenter_decorator_spec.rb
+++ b/spec/presenters/hyrax/collection_presenter_decorator_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Hyrax::CollectionPresenter do
+  describe '#collection_type_badge' do
+    subject { presenter.collection_type_badge }
+
+    # We're decorating an alternate base class so that we don't need the full pre-amble for testing
+    # our decoration.  In other words, let's trust Hyrax::CollectionPresenter's specs for the
+    # "super" method call.
+    let(:base_class) do
+      Class.new do
+        def collection_type_badge
+          "<span>"
+        end
+        prepend Hyrax::CollectionPresenterDecorator
+      end
+    end
+    let(:presenter) { base_class.new }
+
+    before { allow(Site).to receive(:account).and_return(account) }
+
+    context 'when the Site.account is nil' do
+      let(:account) { nil }
+
+      it { is_expected.to eq("") }
+    end
+
+    context 'when the Site.account is search_only' do
+      let(:account) { FactoryBot.build(:account, search_only: true) }
+
+      it { is_expected.to eq("") }
+    end
+
+    context 'when the Site.account is NOT search_only' do
+      let(:account) { FactoryBot.build(:account, search_only: false) }
+
+      it { is_expected.to start_with("<span") }
+    end
+
+    context 'super_method' do
+      subject { Hyrax::CollectionPresenter.instance_method(:collection_type_badge).super_method }
+
+      let(:account) { nil }
+
+      it 'is Hyrax::CollectionPresenter#collection_type_badge' do
+        expect(subject.source_location.first).to end_with("app/presenters/hyrax/collection_presenter.rb")
+      end
+    end
+  end
+end


### PR DESCRIPTION
*Background:* A search_only tenant renders SOLR documents that had home
tenants different than the search_only tenant.  Part of that rendering
includes the underlying Work's collection type.  The SOLR document
stores the `Hyrax::CollectionType`'s ID.

The search_only tenant might have the same ID for
`Hyrax::CollectionType` but it is not the same thing.  Further, the home
tenant might have an ID that is not in the search_only tenant, which
results in an `ActiveRecord::RecordNotFound` error.

Prior to this commit, we always attempted to render the badge.

With this commit, we add some guarding logic to avoid rendering the
badge when we're likely not rendering within the SOLR documents home
tenant.

Related to:

- https://github.com/scientist-softserv/palni-palci/issues/951
- https://github.com/samvera/hyku/issues/1815