### PR TITLE
🧹 Restore <%= render...

### DIFF
--- a/app/views/themes/cultural_show/hyrax/base/show.html.erb
+++ b/app/views/themes/cultural_show/hyrax/base/show.html.erb
@@ -31,7 +31,7 @@
               </div>
             <% end %>
           <% end %>
-          <div class="<%= @presenter.viewer? ? 'col-sm-8' : 'col-sm-8' %>">
+          <div class="col-sm-8">
             <%= render 'work_description', presenter: @presenter %>
             <%= render 'metadata', presenter: @presenter %>
           </div>

--- a/app/views/themes/scholarly_show/hyrax/base/show.html.erb
+++ b/app/views/themes/scholarly_show/hyrax/base/show.html.erb
@@ -20,7 +20,7 @@
             <%= render 'video_embed_viewer', presenter: @presenter %>
             <div class="col-sm-12">
               <div class="image-show-description">
-                <% render 'work_description', presenter: @presenter %>
+                <%= render 'work_description', presenter: @presenter %>
               </div>
             </div>
           <% elsif @presenter.iiif_viewer? %>
@@ -29,7 +29,7 @@
             </div>
             <div class="col-sm-12">
               <div class="image-show-description">
-                <% render 'work_description', presenter: @presenter %>
+                <%= render 'work_description', presenter: @presenter %>
               </div>
             </div>
           <% elsif @presenter.show_pdf_viewer? %>
@@ -41,7 +41,7 @@
               <%= render 'representative_media', presenter: @presenter, viewer: false %>
             </div>
             <div class="col-sm-9">
-              <% render 'work_description', presenter: @presenter %>
+              <%= render 'work_description', presenter: @presenter %>
             </div>
           <% end %>
         </div>


### PR DESCRIPTION
Prior to this commit, we had a case where `<% render` was called.  The result would be that we would in fact not render the results.

In the [file from PR 930][1] the render moved from `<%= render` to `<% render`

With this commit, we restore that rendering.

Related to:

- https://github.com/scientist-softserv/palni-palci/pull/930
- https://github.com/scientist-softserv/palni-palci/issues/911

[1]: https://github.com/scientist-softserv/palni-palci/pull/930/files#diff-521d4c52bd51d0f13962e2d0b09d2740a257187d4fbf7b1fd8cff53e36b1362e

