### PR TITLE
i852 Improve slow video processing speeds

### DIFF
--- a/app/jobs/create_derivatives_job_decorator.rb
+++ b/app/jobs/create_derivatives_job_decorator.rb
@@ -2,10 +2,10 @@
 
 module CreateDerivativesJobDecorator
   def perform(file_set, file_id, filepath = nil)
-    return super if self.is_a?(CreateLargeDerivativesJob)
+    return super if is_a?(CreateLargeDerivativesJob)
     return super unless file_set.video? || file_set.audio?
 
-    CreateLargeDerivativesJob.perform_later(*self.arguments)
+    CreateLargeDerivativesJob.perform_later(*arguments)
     true
   end
 end

--- a/app/jobs/create_derivatives_job_decorator.rb
+++ b/app/jobs/create_derivatives_job_decorator.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module CreateDerivativesJobDecorator
+  def self.prepended(base)
+    base.class_eval do
+      queue_as :resource_intensive
+    end
+  end
+end
+
+CreateDerivativesJob.prepend(CreateDerivativesJobDecorator)

--- a/app/jobs/create_derivatives_job_decorator.rb
+++ b/app/jobs/create_derivatives_job_decorator.rb
@@ -1,14 +1,12 @@
 # frozen_string_literal: true
 
 module CreateDerivativesJobDecorator
-  def self.prepended(base)
-    base.class_eval do
-      before_perform :reassign_queue, if: ->() { arguments.first.video? || arguments.first.audio? }
-    end
-  end
+  def perform(file_set, file_id, filepath = nil)
+    return super if self.is_a?(CreateLargeDerivativesJob)
+    return super unless file_set.video? || file_set.audio?
 
-  def reassign_queue
-    self.queue_name = 'resource_intensive'
+    CreateLargeDerivativesJob.perform_later(*self.arguments)
+    true
   end
 end
 

--- a/app/jobs/create_derivatives_job_decorator.rb
+++ b/app/jobs/create_derivatives_job_decorator.rb
@@ -3,8 +3,12 @@
 module CreateDerivativesJobDecorator
   def self.prepended(base)
     base.class_eval do
-      queue_as :resource_intensive
+      before_perform :reassign_queue, if: ->() { arguments.first.video? || arguments.first.audio? }
     end
+  end
+
+  def reassign_queue
+    self.queue_name = 'resource_intensive'
   end
 end
 

--- a/app/jobs/create_derivatives_job_decorator.rb
+++ b/app/jobs/create_derivatives_job_decorator.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
+# OVERRIDE Hyrax v3.6.0
+# @see CreateLargeDerivativesJob
 module CreateDerivativesJobDecorator
+  # OVERRIDE: Divert audio and video derivative
+  # creation to CreateLargeDerivativesJob.
   def perform(file_set, file_id, filepath = nil)
     return super if is_a?(CreateLargeDerivativesJob)
     return super unless file_set.video? || file_set.audio?

--- a/app/jobs/create_large_derivatives_job.rb
+++ b/app/jobs/create_large_derivatives_job.rb
@@ -1,5 +1,16 @@
 # frozen_string_literal: true
 
+# CreateLargeDerivativesJob is intended to be used for resource-intensive derivative
+# generation (e.g. video processing). It is functionally similar to CreateDerivativesJob,
+# except that it queues jobs in the :resource_intensive queue.
+#
+# The worker responsible for processing jobs in the :resource_intensive queue should be
+# configured to have more resources dedicated to it, especially CPU. Otherwise, the
+# `ffmpeg` commands that this job class eventually triggers could be throttled.
+#
+# @see CreateDerivativesJobDecorator
+# @see Hydra::Derivatives::Processors::Ffmpeg
+# @see https://github.com/scientist-softserv/palni-palci/issues/852
 class CreateLargeDerivativesJob < CreateDerivativesJob
   queue_as :resource_intensive
 end

--- a/app/jobs/create_large_derivatives_job.rb
+++ b/app/jobs/create_large_derivatives_job.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class CreateLargeDerivativesJob < CreateDerivativesJob
+  queue_as :resource_intensive
+  queue_with_priority 20 # TODO: necessary?
+end

--- a/app/jobs/create_large_derivatives_job.rb
+++ b/app/jobs/create_large_derivatives_job.rb
@@ -2,5 +2,4 @@
 
 class CreateLargeDerivativesJob < CreateDerivativesJob
   queue_as :resource_intensive
-  queue_with_priority 20 # TODO: necessary?
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,3 +3,4 @@
   - default
   - import
   - export
+  - resource_intensive

--- a/spec/jobs/create_derivatives_job_spec.rb
+++ b/spec/jobs/create_derivatives_job_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+RSpec.describe CreateDerivativesJob do
+  around do |example|
+    ffmpeg_enabled = Hyrax.config.enable_ffmpeg
+    Hyrax.config.enable_ffmpeg = true
+    example.run
+    Hyrax.config.enable_ffmpeg = ffmpeg_enabled
+  end
+
+  describe 'recreating self as a CreateLargeDerivativesJob' do
+    let(:id)       { '123' }
+    let(:file_set) { FileSet.new }
+    let(:file) do
+      Hydra::PCDM::File.new.tap do |f|
+        f.content = 'foo'
+        f.original_name = filename
+        f.save!
+      end
+    end
+
+    before do
+      allow(FileSet).to receive(:find).with(id).and_return(file_set)
+      allow(file_set).to receive(:mime_type).and_return(mime_type)
+      allow(file_set).to receive(:id).and_return(id)
+      # Short-circuit irrelevant logic
+      allow(file_set).to receive(:reload)
+      allow(file_set).to receive(:update_index)
+    end
+
+    context 'with an image file' do
+      let(:mime_type) { 'image/jpeg' }
+      let(:filename) { 'picture.jpg' }
+
+      before do
+        # Short-circuit irrelevant logic
+        allow(Hydra::Derivatives::ImageDerivatives).to receive(:create)
+      end
+
+      it 'does not recreate as a CreateLargeDerivativesJob' do
+        expect(CreateLargeDerivativesJob).not_to receive(:perform_later)
+
+        described_class.perform_now(file_set, file.id)
+      end
+    end
+
+    context 'with an video file' do
+      let(:mime_type) { 'video/mp4' }
+      let(:filename) { 'video.mp4' }
+
+      before do
+        # Short-circuit irrelevant logic
+        allow(Hydra::Derivatives::VideoDerivatives).to receive(:create)
+      end
+
+      it 'recreates as a CreateLargeDerivativesJob' do
+        expect(CreateLargeDerivativesJob).to receive(:perform_later)
+
+        described_class.perform_now(file_set, file.id)
+      end
+    end
+
+    context 'with an audio file' do
+      let(:mime_type) { 'audio/x-wav' }
+      let(:filename) { 'audio.wav' }
+
+      before do
+        # Short-circuit irrelevant logic
+        allow(Hydra::Derivatives::AudioDerivatives).to receive(:create)
+      end
+
+      it 'recreates as a CreateLargeDerivativesJob' do
+        expect(CreateLargeDerivativesJob).to receive(:perform_later)
+
+        described_class.perform_now(file_set, file.id)
+      end
+    end
+  end
+end

--- a/spec/jobs/create_large_derivatives_job_spec.rb
+++ b/spec/jobs/create_large_derivatives_job_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+RSpec.describe CreateLargeDerivativesJob, type: :job do
+  let(:id)       { '123' }
+  let(:file_set) { FileSet.new }
+  let(:file) do
+    Hydra::PCDM::File.new.tap do |f|
+      f.content = 'foo'
+      f.original_name = 'video.mp4'
+      f.save!
+    end
+  end
+
+  before do
+    allow(FileSet).to receive(:find).with(id).and_return(file_set)
+    allow(file_set).to receive(:id).and_return(id)
+    # Short-circuit irrelevant logic
+    allow(file_set).to receive(:reload)
+    allow(file_set).to receive(:update_index)
+  end
+
+  it 'runs in the :resource_intensive queue' do
+    expect { described_class.perform_later(file_set, file.id) }
+      .to have_enqueued_job(described_class)
+      .on_queue('resource_intensive')
+  end
+
+  # @see CreateDerivativesJobDecorator#perform
+  it "doesn't schedule itself infinitly" do
+    expect(described_class).not_to receive(:perform_later)
+
+    described_class.perform_now(file_set, file.id)
+  end
+
+  it 'successfully calls the logic in CreateDerivativesJob' do
+    allow(file_set).to receive(:mime_type).and_return('video/mp4')
+    expect(Hydra::Derivatives::VideoDerivatives).to receive(:create)
+
+    described_class.perform_now(file_set, file.id)
+  end
+end


### PR DESCRIPTION
# Story

Refs
- #852 

@orangewolf and I determined that the slowness identified in #852 is due to insufficient CPU resources; `ffmpeg` commands run on large files were being throttled and thus running extremely slowly. 

To solve this, we decided that when an audio or video derivative job is triggered, we should put in into a separate Sidekiq queue (i.e. `:resource_intensive`). We'll have the default worker(s) run all queues other than `:resource_intensive`. We'll also have a new, separate worker that runs all the other queues plus the `:resource_intensive` queue. The new worker will have 4x the CPU resources that the default workers have, but only 1 thread.

This effectively creates a powerful "slow lane". `:resource_intensive` jobs will slow down the separate worker while they're running, but they won't bog down all the jobs since the other workers are still running.

## Part 1

This PR implements the first part of the solution described above. Specifically, it: 

- Adds the new `:resource_intensive` Sidekiq queue 
- Builds out the logic that diverts only audio and video files on the `:resource_intensive` queue 

# Expected Behavior Before Changes

Video and audio files get processed by the `CreateDerivativesJob` in the `:default` Sidekiq queue 

# Expected Behavior After Changes

Video and audio files get processed by the `CreateLargeDerivativesJob` in the `:resource_intensive` Sidekiq queue 

# Screenshots / Video

![image](https://github.com/scientist-softserv/palni-palci/assets/32469930/9cd1f604-79a5-465e-ade4-7fb1db1f9ce7)

# Notes

## Flow of logic introduced in this PR

```mermaid
flowchart TD
    0([CreateDerivativesJob#perform_later]) -->
    S[CreateDerivativesJob#perform]
    V{Is audio or video?}
    D[CreateDerivativesJobDecorator]
    L{Is CreateLargeDerivativesJob?}
    H([Hyrax logic])
    J[Spawn CreateLargeDerivativesJob]
    S --> D
    D --> L
    L --> |No|V
    L --> |Yes|H
    V --> |No|H
    V --> |Yes|J
    J --> |#super|S
    style H stroke:#f66,stroke-width:2px
    style V stroke:yellow
    style L stroke:yellow
    style 0 stroke:#0f0,stroke-width:2px
```