### PR TITLE
i852 Revert temporary hacks that prevent video processing

### DIFF
--- a/app/presenters/concerns/hyrax/iiif_av/displays_content_decorator.rb
+++ b/app/presenters/concerns/hyrax/iiif_av/displays_content_decorator.rb
@@ -42,18 +42,11 @@ module Hyrax
           height = solr_document.height&.try(:to_i) || 240
           duration = conformed_duration_in_seconds
           IIIFManifest::V3::DisplayContent.new(
-            # Hyrax::IiifAv::Engine.routes.url_helpers.iiif_av_content_url(
-            #   solr_document.id,
-            #   label: label,
-            #   host: request.base_url
-            # ),
-            # TODO: This is a hack to pull the download url from hyrax as the video resource.
-            #       Ultimately we want to fix the processing times of the video derivatives so it doesn't take
-            #       hours to days to complete.  The draw back of doing it this way is that we're using the original
-            #       video file which is fine if it's already processed, but if it's a raw, then it is not ideal for
-            #       streaming purposes.  The good thing is that PALs seem to be processing the video derivatives out
-            #       of band first before ingesting so we shouldn't run into this issue.
-            Hyrax::Engine.routes.url_helpers.download_url(solr_document.id, host: request.base_url, protocol: 'https'),
+            Hyrax::IiifAv::Engine.routes.url_helpers.iiif_av_content_url(
+              solr_document.id,
+              label: label,
+              host: request.base_url
+            ),
             label: label,
             width: width,
             height: height,

--- a/config/initializers/file_set_derivatives_overrides.rb
+++ b/config/initializers/file_set_derivatives_overrides.rb
@@ -48,17 +48,12 @@ Hyrax::FileSetDerivativesService.class_eval do
     original_size = "#{width}x#{height}"
     size = width.nil? || height.nil? ? DEFAULT_VIDEO_SIZE : original_size
     Hydra::Derivatives::Processors::Video::Processor.config.size_attributes = size
-    # HACK: Commented out the non-thumbnail derivative generation as they are clogging the ecosystem.
-    # See https://github.com/scientist-softserv/palni-palci/issues/924
-    # rubocop:disable Style/TrailingCommaInHashLiteral
     Hydra::Derivatives::VideoDerivatives.create(filename,
                                                 outputs: [{ label: :thumbnail, format: 'jpg',
                                                             url: derivative_url('thumbnail') },
-                                                          # { label: 'webm', format: 'webm',
-                                                          #   url: derivative_url('webm') },
-                                                          # { label: 'mp4', format: 'mp4',
-                                                          #   url: derivative_url('mp4') }
-                                                         ])
-    # rubocop:enable Style/TrailingCommaInHashLiteral
+                                                          { label: 'webm', format: 'webm',
+                                                            url: derivative_url('webm') },
+                                                          { label: 'mp4', format: 'mp4',
+                                                            url: derivative_url('mp4') }])
   end
 end


### PR DESCRIPTION
## ON HOLD pending #955 being merged

# Story

Refs
- #852 
- #854 
- #925 

# Expected Behavior Before Changes

- `mp4` and `webm` derivative generation for videos is skipped 
- The UV serves the raw video file 

# Expected Behavior After Changes

- `mp4` and `webm` derivative generation for videos is **not** skipped 
- The UV serves the video file's derivative  
