### PR TITLE
🐛 Call `CreateGroupAndAddMembersJob` only for CDL

### DIFF
--- a/app/jobs/iiif_print/create_relationships_job_decorator.rb
+++ b/app/jobs/iiif_print/create_relationships_job_decorator.rb
@@ -38,7 +38,7 @@ module IiifPrint
           end
 
           # OVERRIDE begin
-          CreateGroupAndAddMembersJob.set(wait: 2.minutes).perform_later(parent_id)
+          CreateGroupAndAddMembersJob.set(wait: 2.minutes).perform_later(parent_id) if parent_model == 'Cdl'
           # OVERRIDE end
         else
           # if we aren't ready yet, reschedule the job and end this one normally

--- a/spec/jobs/iiif_print/create_relationships_job_decorator_spec.rb
+++ b/spec/jobs/iiif_print/create_relationships_job_decorator_spec.rb
@@ -8,10 +8,22 @@ RSpec.describe IiifPrint::Jobs::CreateRelationshipsJobDecorator, type: :decorato
     let(:parent) { FactoryBot.create(:cdl) }
     let(:child) { FactoryBot.create(:generic_work) }
 
-    it 'calls CreateGroupAndAddMembersJob' do
-      expect(CreateGroupAndAddMembersJob).to receive(:set).with(wait: 2.minutes).and_return(CreateGroupAndAddMembersJob)
-
+    after do
       job.perform(parent_id: parent.id, parent_model: parent.class.to_s, child_model: child.class)
+    end
+
+    context 'when parent_model is Cdl' do
+      it 'calls CreateGroupAndAddMembersJob' do
+        expect(CreateGroupAndAddMembersJob).to receive(:set).with(wait: 2.minutes).and_return(CreateGroupAndAddMembersJob)
+      end
+    end
+
+    context 'when parent_model is not Cdl' do
+      let(:parent) { FactoryBot.create(:generic_work) }
+
+      it 'does not call CreateGroupAndAddMembersJob' do
+        expect(CreateGroupAndAddMembersJob).not_to receive(:set)
+      end
     end
   end
 end


### PR DESCRIPTION
Originally the `CreateGroupAndAddMembersJob` was keyed off the `Cdl` model but after the refactor, that was no longer the case.  This fix will add a conditinal for the `CreateGroupAndAddMembersJob` to only run if the resource is a `Cdl`.
