### PR TITLE
Skip search_only tenants when calculating usage

### DIFF
--- a/lib/tasks/tenants.rake
+++ b/lib/tasks/tenants.rake
@@ -4,7 +4,7 @@ namespace :tenants do
   # how much space, works, files, per each tenant?
   task calculate_usage: :environment do
     @results = []
-    Account.find_each do |account|
+    Account.where(search_only: false).find_each do |account|
       if account.cname.present?
         AccountElevator.switch!(account.cname)
         puts "---------------#{account.cname}-------------------------"


### PR DESCRIPTION
When task reaches a search-only tenant, it hangs for awhile before exiting with a `Killed` error