### PR TITLE
make sure you can see the metadata page even if saml is not yet configured

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -293,6 +293,7 @@ Devise.setup do |config|
   # setup for multiprovider SAML options
   dynamic_options_generator = lambda { |identity_provider_id, rack_env|
     identity_provider = IdentityProvider.find(identity_provider_id)
+    identity_provider.options = {} if identity_provider.options.blank? # Protect against nil or empty string
     identity_provider.parsed_options(rack_env)
   }
   identity_provider_id_regex = /\d+/

--- a/lib/omni_auth/strategies/saml_decorator.rb
+++ b/lib/omni_auth/strategies/saml_decorator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+# OVERRIDE OmniAuth v2.1.1
+
 # monkey patch to support metadata paths - hacked version of:
 #    https://github.com/salsify/omniauth-multi-provider/issues/4#issuecomment-366452170
 #


### PR DESCRIPTION
# Story

Pitt ran in to trouble with accessing metadata because their provider was blank. But they didn't have info for the provider because their metadata wasn't accessible. This created a chicken and egg problem.

# Expected Behavior Before Changes

Go to identity providers, create a new SAML item, save it w/o config. Try to click the metadata link. Dashboard will render with a warning

# Expected Behavior After Changes

Go to identity providers, create a new SAML item, save it w/o config. Try to click the metadata link. Metadata will render
