### PR TITLE
🐛 Fix cropped banner images being overwritten

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -30,7 +30,7 @@ module Users
         # where we want a JS-based redirect to go.
         render 'complete', locals: { redirect_to_url: url || hyrax.dashboard_path }
       else
-        redirect_to root_path, flash: {error: 'Not able to log in user. #{@user.errors.full_messages}'}
+        redirect_to root_path, flash: { error: "Not able to log in user. #{@user.errors.full_messages}" }
       end
     end
     alias cas callback
@@ -42,7 +42,7 @@ module Users
     end
 
     def failure
-      redirect_to root_path, flash: {error: 'Authentication Failed. Something is wrong with the SSO configuration.'}
+      redirect_to root_path, flash: { error: 'Authentication Failed. Something is wrong with the SSO configuration.' }
     end
   end
 end

--- a/app/views/hyrax/admin/appearances/_banner_image_form.html.erb
+++ b/app/views/hyrax/admin/appearances/_banner_image_form.html.erb
@@ -75,7 +75,8 @@ document.querySelector('.banner-submit').addEventListener('click', function(e) {
   if (cropper) {
     cropper.getCroppedCanvas().toBlob(function(blob) {
       var formData = new FormData(document.querySelector('form'));
-      formData.append('admin_appearance[banner_image]', blob, 'cropped.jpg');
+      var currentAccountName = "<%= current_account.name %>";
+      formData.append('admin_appearance[banner_image]', blob, `${currentAccountName}-cropped.jpg`);
 
       $.ajax('/admin/appearance', {
         method: 'POST',


### PR DESCRIPTION
When cropper.js intercepts an updated banner image file and crops it, the original filename gets changed to cropped.jpg which gets saved to disk.  When another tenant crops their banner image, it also gets saved as cropped.jpg and overwrites the previous tenant's banner image.  In this commit, we prepend the tenant name so it would look something like `shared-cropped.jpg` and `uindy-cropped.jpg` instead and avoids the files from being overwritten.

Ref:
  - https://github.com/scientist-softserv/palni-palci/issues/948
  - https://github.com/scientist-softserv/palni-palci/issues/746

# Expected Behavior Before Changes

Banner images were being overwritten.

# Expected Behavior After Changes

Banner images have unique names based off the tenant so overwriting the name shouldn't be possible.

# Screenshots / Video

## Before
UIndy tenant has the banner image with filename being `cropped.jpg`
<img width="1708" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/19597776/c5b8549b-e606-4c14-80be-bbe8dadd9194">

Search tenant also has the same filename of `cropped.jpg`
<img width="1713" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/19597776/23dd22c3-f8ec-4e4f-8fac-61bc5537efea">

## After
The tenant is prepended to the filename
<img width="1712" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/19597776/98e56e3d-96e6-4527-85c4-a095f1f2f710">

Another example
<img width="1713" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/19597776/6a178a4e-51a2-48ed-ae2a-5fd3093fb331">
