### PR TITLE
Add description to show page

### DIFF
--- a/app/views/themes/scholarly_show/hyrax/base/show.html.erb
+++ b/app/views/themes/scholarly_show/hyrax/base/show.html.erb
@@ -35,6 +35,11 @@
           <% elsif @presenter.show_pdf_viewer? %>
             <div class="col-sm-12">
               <%= render 'pdf_js', file_set_presenter: pdf_file_set_presenter(@presenter) %>
+            </div>           
+            <div class="col-sm-12">
+              <div class="image-show-description">
+                <%= render 'work_description', presenter: @presenter %>
+              </div>
             </div>
           <% else %>
             <div class="col-sm-3 mb-1">


### PR DESCRIPTION
# Story

Refs https://github.com/scientist-softserv/palni-palci/issues/958

# Expected Behavior Before Changes

A work showing the PDF.js viewer did not show the description when using Scholarly Show Page theme.

# Expected Behavior After Changes

Description shows for all themes and viewer options.

# Screenshots / Video

<details>
<summary></summary>

![Screenshot 2024-03-06 at 7 10 48 PM](https://github.com/scientist-softserv/palni-palci/assets/17851674/4fb707e8-48f1-43bd-9722-7d3b1a1d0789)

![Screenshot 2024-03-06 at 7 10 56 PM](https://github.com/scientist-softserv/palni-palci/assets/17851674/317a6583-0f69-4f0c-ba1a-3bfa1ebb1fc0)

</details>

# Notes
