### PR TITLE
Do not order location attribute

### DIFF
--- a/app/models/concerns/order_metadata_values.rb
+++ b/app/models/concerns/order_metadata_values.rb
@@ -7,7 +7,7 @@ module OrderMetadataValues
     def self.multi_valued_properties_for_ordering
       properties.collect do |prop_name, node_config|
         # Only concerned with properties displayed to end users
-        next if %w[head tail].include?(prop_name)
+        next if %w[head tail based_near].include?(prop_name)
 
         prop_name.to_sym if node_config.instance_variable_get(:@opts)&.dig(:multiple)
       end.compact


### PR DESCRIPTION
# Story

Ordering based_near causes several issues:
- adding a work to a collection fails
- adding a work outside of the actor stack turned the attribute into a string.

Refs:
- https://github.com/scientist-softserv/palni-palci/issues/892
- https://github.com/scientist-softserv/palni-palci/issues/964

# Expected Behavior Before Changes

Adding a work with a location value to a collection fails.

# Expected Behavior After Changes

Adding a work with a location value to a collection succeeds
The location term is not ordered.

# Notes
