### PR TITLE
🎁 Add admin_note to bulkrax.rb

### DIFF
--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -55,6 +55,7 @@ Bulkrax.setup do |config|
     'accessibility_hazard' => { from: ['accessibility_hazard'], split: '\|' },
     'accessibility_summary' => { from: ['accessibility_summary'] },
     'additional_information' => { from: ['additional_information'], split: '\|', generated: true },
+    'admin_note' => { from: ['admin_note'] },
     'admin_set_id' => { from: ['admin_set_id'], generated: true },
     'alternate_version' => { from: ['alternate_version'], split: '\|' },
     'alternative_title' => { from: ['alternative_title'], split: '\|', generated: true },


### PR DESCRIPTION
# Story

Ref:
  - https://github.com/scientist-softserv/palni-palci/issues/990


# Expected Behavior Before Changes
The `admin_note` property was not mapped to Bulkrax

# Expected Behavior After Changes
Now it is.

# Screenshots / Video
![image](https://github.com/scientist-softserv/palni-palci/assets/19597776/a3bf8536-e4c7-4095-a45a-5f4c991faf91)
