### PR TITLE
🧹 Hide custom Hyku Commons workflow

### DIFF
--- a/app/views/hyrax/admin/admin_sets/_form_workflow.erb
+++ b/app/views/hyrax/admin/admin_sets/_form_workflow.erb
@@ -1,0 +1,30 @@
+<%# OVERRIDE Hyrax v3.6.0 to hide custom mediated workflow for Hyku Commons %>
+
+<div id="workflow" class="tab-pane">
+  <div class="panel panel-default labels">
+    <%= simple_form_for collection_permission_template_form_for(form: @form),
+      url: [hyrax, :admin, @form, :permission_template],
+      html: { id: 'form_workflows', class: 'nav-safety' } do |f| %>
+      <% if f.object.available_workflows.any? %>
+        <div class="panel-body">
+          <p><%= t('.page_description') %></p>
+            <%# OVERRIDE begin %>
+            <% available_workflows = f.object.available_workflows.select { |wf| wf.name != 'hyku_commons_mediated_deposit' } %>
+            <%= f.collection_radio_buttons :workflow_id, available_workflows, :id, :label, item_wrapper_tag: :div, item_wrapper_class: "radio" do |b| %>
+            <%# OVERRIDE end %>
+              <span><%= b.radio_button + b.object.label %></span>
+              <p><%= b.object.description %></p>
+            <% end %>
+        </div>
+        <div class="panel-footer">
+          <%= link_to t('.cancel'), hyrax.admin_admin_sets_path, class: 'btn btn-default pull-right'%>
+          <%= f.button :submit, class: 'btn btn-primary pull-right'%>
+        </div>
+      <% else %>
+        <div class="panel-body">
+          <p><%= t('.no_workflows') %></p>
+        </div>
+      <% end %>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
# Story

This commit will hide the custom Hyku Commons workflow from the admin workflow form.  This is a temporary measure to ensure that the option is not going to show up in the admin interface to reduce confusion.  The long-term fix will be to create a script and delete the custom workflow from the database from each tenant, however it was warned that working with Siptiy::Workflow might be a little tricky.

Ref:
  - https://github.com/scientist-softserv/palni-palci/issues/448

# Screenshots / Video

<img width="1069" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/19597776/bbfc94d5-f9ef-4ccb-83fd-0ff0818cf37a">

<img width="801" alt="image" src="https://github.com/scientist-softserv/palni-palci/assets/19597776/046a5509-8ef4-42f4-b4d6-ffc9209c490c">
