### PR TITLE
🐛 Account for when result is not a string

### DIFF
--- a/app/models/concerns/bulkrax/has_matchers_decorator.rb
+++ b/app/models/concerns/bulkrax/has_matchers_decorator.rb
@@ -6,6 +6,8 @@ module Bulkrax
   module HasMatchersDecorator
     def matched_metadata(multiple, name, result, object_multiple)
       if name == 'based_near'
+        return result if result.blank?
+
         result = if result.start_with?('http')
                    Hyrax::ControlledVocabularies::Location.new(RDF::URI.new(result))
                  else

--- a/spec/models/concerns/bulkrax/has_matchers_decorator_spec.rb
+++ b/spec/models/concerns/bulkrax/has_matchers_decorator_spec.rb
@@ -69,5 +69,17 @@ RSpec.describe Bulkrax::HasMatchersDecorator, type: :decorator do
         expect(subject.first.full_label).to eq 'Faketown, Kali4nia, United Steaks'
       end
     end
+
+    results = [[], nil, '', ' ']
+    results.each do |result|
+      context "when given a blank value (#{result.inspect})" do
+        let(:result) { result }
+
+        it 'returns the original value' do
+          expect(entry).not_to receive(:geonames_lookup)
+          expect(subject).to eq result
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This commit will fix a bug where if the csv has a `location` header but no value.
