### PR TITLE
🐛 Fix banner alt text require

### DIFF
--- a/app/views/hyrax/admin/appearances/_banner_image_form.html.erb
+++ b/app/views/hyrax/admin/appearances/_banner_image_form.html.erb
@@ -67,6 +67,17 @@
   });
 
 document.querySelector('.banner-submit').addEventListener('click', function(e) {
+  // Get all required fields
+  var requiredFields = document.querySelectorAll('input[required],textarea[required],select[required]');
+
+  // Check if all required fields are filled
+  for (var i = 0; i < requiredFields.length; i++) {
+    if (!requiredFields[i].value) {
+      // return early if not all required fields have been filled out
+      return;
+    }
+  }
+
   e.preventDefault();
 
   // Show the spinner


### PR DESCRIPTION
# Story

The banner crop javascript was doing a `e.preventDefault();` which then allowed the form being submitted without the alt text which is a required field.  This commit will add a check to see if all the required fields are filled in and if not then the function should not execute and therefore not preventDefault.

Ref:
  - https://github.com/scientist-softserv/palni-palci/issues/948

# Screenshots / Video


https://github.com/scientist-softserv/palni-palci/assets/19597776/48740425-8539-40bd-b4d9-676b63ef412e
