### PR TITLE
🎁 Make headers with spaces acceptable

### DIFF
--- a/app/parsers/bulkrax/csv_parser_decorator.rb
+++ b/app/parsers/bulkrax/csv_parser_decorator.rb
@@ -29,7 +29,7 @@ module Bulkrax
           # any parser_mappings fields terms from `config/initializers/bulkrax.rb`
           # or any keys that has sequential numbers like creator_1
           (record[field] ||
-            mapped_from(field).map { |f| record[f] }.first ||
+            mapped_from(field).map { |f| record[f] }.any? ||
             handle_keys_with_numbers(field, record)).blank?
         end
       end

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -2,6 +2,7 @@
 
 require 'bagit'
 
+# rubocop:disable Metrics/BlockLength
 Bulkrax.setup do |config|
   # Add or remove local parsers
   config.parsers -= [
@@ -114,12 +115,18 @@ Bulkrax.setup do |config|
     'subject' => { from: ['subject'], split: '\|' },
     'table_of_contents' => { from: ['table_of_contents'], split: '\|' },
     'title' => { from: ['title'], split: '\|' },
+    'video_embed' => { from: ['video_embed'] }
   }
 
+  # currently Bulkrax does not support headers with spaces
+  # here we add the key but with the underscore turned into a space to accommodate
+  parser_mappings.each do |key, value|
+    value[:from] += ([key.tr('_', ' ')] + value[:from].map { |f| f.tr('_', ' ') })
+    value[:from].uniq!
+  end
+
   config.field_mappings['Bulkrax::BagitParser'] = parser_mappings
-  config.field_mappings['Bulkrax::CsvParser'] = parser_mappings.merge(
-    {'video_embed' => { from: ['video_embed'] }}
-    )
+  config.field_mappings['Bulkrax::CsvParser'] = parser_mappings
 
   # Add to, or change existing mappings as follows
   #   e.g. to exclude date
@@ -137,3 +144,4 @@ Bulkrax.setup do |config|
     Hyrax::DashboardController.sidebar_partials[:repository_content] << "hyrax/dashboard/sidebar/bulkrax_sidebar_additions"
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/parsers/bulkrax/csv_parser_decorator_spec.rb
+++ b/spec/parsers/bulkrax/csv_parser_decorator_spec.rb
@@ -194,6 +194,17 @@ RSpec.describe Bulkrax::CsvParserDecorator, type: :decorator do
       end
     end
 
+    context 'when the csv headers do not have underscores' do
+      let(:generic_work_record_with_no_underscores) do
+        generic_work_record.transform_keys { |key| key.to_s.tr('_', ' ') }
+      end
+      let(:records) { [generic_work_record_with_no_underscores] }
+
+      it 'still returns true' do
+        expect(subject.valid_import?).to be true
+      end
+    end
+
     context 'when the csv header is the parser_mappings value' do
       let(:generic_work_record_with_type_instead_of_resource_type) do
         generic_work_record.transform_keys! { |key| key == :resource_type ? :type : key }


### PR DESCRIPTION
# Story

This commit will adjust the Bulkrax csv parser fields to allow spaces in the csv headers.  Previously, if you had `rights statement`, this header was not accepted.  With this commit it will be.

Ref:
  - https://github.com/scientist-softserv/palni-palci/issues/436

```rb
Bulkrax.config.field_mappings['Bulkrax::CsvParser'] =>
{"abstract"=>{:from=>["abstract"], :split=>"\\|", :generated=>true},
 "accessibility_feature"=>
  {:from=>["accessibility_feature", "accessibility feature"], :split=>"\\|"},
 "accessibility_hazard"=>
  {:from=>["accessibility_hazard", "accessibility hazard"], :split=>"\\|"},
 "accessibility_summary"=>
  {:from=>["accessibility_summary", "accessibility summary"]},
 "additional_information"=>
  {:from=>["additional_information", "additional information"],
   :split=>"\\|",
   :generated=>true},
 "admin_note"=>{:from=>["admin_note", "admin note"]},
 "admin_set_id"=>{:from=>["admin_set_id", "admin set id"], :generated=>true},
 "alternate_version"=>
  {:from=>["alternate_version", "alternate version"], :split=>"\\|"},
 "alternative_title"=>
  {:from=>["alternative_title", "alternative title"],
   :split=>"\\|",
   :generated=>true},
 "arkivo_checksum"=>
  {:from=>["arkivo_checksum", "arkivo checksum"],
   :split=>"\\|",
   :generated=>true},
 "audience"=>{:from=>["audience"], :split=>"\\|"},
 "based_near"=>{:from=>["location", "based near"], :split=>"\\|"},
 "bibliographic_citation"=>
  {:from=>["bibliographic_citation", "bibliographic citation"],
   :split=>"\\|",
   :generated=>true},
 "bulkrax_identifier"=>
  {:from=>["source_identifier", "bulkrax identifier", "source identifier"],
   :source_identifier=>true,
   :generated=>true},
 "children"=>
  {:from=>["children"],
   :split=>/\s*[;|]\s*/,
   :related_children_field_mapping=>true},
 "chronology_note"=>
  {:from=>["chronology_note", "chronology note"], :split=>"\\|"},
 "committee_member"=>
  {:from=>["committee_member", "committee member"], :split=>"\\|"},
 "contributing_library"=>
  {:from=>["contributing_library", "contributing library"], :split=>"\\|"},
 "contributor"=>{:from=>["contributor"], :split=>"\\|"},
 "creator"=>{:from=>["author", "creator"], :split=>"\\|"},
 "date_created"=>
  {:from=>["date", "date_created", "date created"], :split=>"\\|"},
 "date_uploaded"=>
  {:from=>["date_uploaded", "date uploaded"], :generated=>true},
 "date"=>{:from=>["date"], :split=>"\\|"},
 "degree_discipline"=>
  {:from=>["discipline", "degree discipline"], :split=>"\\|"},
 "degree_grantor"=>{:from=>["grantor", "degree grantor"], :split=>"\\|"},
 "degree_level"=>{:from=>["level", "degree level"], :split=>"\\|"},
 "degree_name"=>{:from=>["degree", "degree name"], :split=>"\\|"},
 "depositor"=>{:from=>["depositor"], :split=>"\\|", :generated=>true},
 "description"=>{:from=>["description"], :split=>"\\|"},
 "discipline"=>{:from=>["discipline"], :split=>"\\|"},
 "education_level"=>
  {:from=>["education_level", "education level"], :split=>"\\|"},
 "embargo_id"=>{:from=>["embargo_id", "embargo id"], :generated=>true},
 "file"=>{:from=>["item", "file"], :split=>"\\|"},
 "identifier"=>{:from=>["identifier"], :split=>"\\|"},
 "import_url"=>
  {:from=>["import_url", "import url"], :split=>"\\|", :generated=>true},
 "keyword"=>{:from=>["keyword"], :split=>"\\|"},
 "label"=>{:from=>["label"], :generated=>true},
 "language"=>{:from=>["language"], :split=>"\\|"},
 "learning_resource_type"=>
  {:from=>["learning_resource_type", "learning resource type"], :split=>"\\|"},
 "lease_id"=>{:from=>["lease_id", "lease id"], :generated=>true},
 "library_catalog_identifier"=>
  {:from=>["library_catalog_identifier", "library catalog identifier"],
   :split=>"\\|"},
 "license"=>{:from=>["license"], :split=>"\\|"},
 "newer_version"=>{:from=>["newer_version", "newer version"], :split=>"\\|"},
 "oer_size"=>{:from=>["oer_size", "oer size"], :split=>"\\|"},
 "on_behalf_of"=>{:from=>["on_behalf_of", "on behalf of"], :generated=>true},
 "owner"=>{:from=>["owner"], :generated=>true},
 "parents"=>
  {:from=>["parents"],
   :split=>/\s*[;|]\s*/,
   :related_parents_field_mapping=>true},
 "previous_version"=>
  {:from=>["previous_version", "previous version"], :split=>"\\|"},
 "proxy_depositor"=>
  {:from=>["proxy_depositor", "proxy depositor"], :generated=>true},
 "publisher"=>{:from=>["publisher"], :split=>"\\|"},
 "related_item"=>{:from=>["related_item", "related item"], :split=>"\\|"},
 "related_url"=>
  {:from=>["related_url", "relation", "related url"], :split=>"\\|"},
 "relative_path"=>
  {:from=>["relative_path", "relative path"], :split=>"\\|", :generated=>true},
 "rendering_ids"=>
  {:from=>["rendering_ids", "rendering ids"], :split=>"\\|", :generated=>true},
 "representative_id"=>
  {:from=>["representative_id", "representative id"], :generated=>true},
 "resource_type"=>{:from=>["type", "resource type"], :split=>"\\|"},
 "rights_holder"=>{:from=>["rights_holder", "rights holder"], :split=>"\\|"},
 "rights_notes"=>
  {:from=>["rights_notes", "rights notes"], :split=>"\\|", :generated=>true},
 "rights_statement"=>
  {:from=>["rights", "rights_statement", "rights statement"],
   :split=>"\\|",
   :generated=>true},
 "source"=>{:from=>["source"], :split=>"\\|", :generated=>true},
 "state"=>{:from=>["state"], :generated=>true},
 "subject"=>{:from=>["subject"], :split=>"\\|"},
 "table_of_contents"=>
  {:from=>["table_of_contents", "table of contents"], :split=>"\\|"},
 "title"=>{:from=>["title"], :split=>"\\|"},
 "video_embed"=>{:from=>["video_embed", "video embed"]}}
```