### PR TITLE
:bug: Revert change to deploy action to remove sudo command - deploy fix

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   deploy:
-    uses: scientist-softserv/actions/.github/workflows/deploy.yaml@remove-sudo-from-setup-env
+    uses: scientist-softserv/actions/.github/workflows/deploy.yaml@v0.0.15
     secrets: inherit

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,5 +20,5 @@ on:
 
 jobs:
   deploy:
-    uses: scientist-softserv/actions/.github/workflows/deploy.yaml@v0.0.21
+    uses: scientist-softserv/actions/.github/workflows/deploy.yaml@remove-sudo-from-setup-env
     secrets: inherit


### PR DESCRIPTION
This was causing an error when deploying pals.

```ruby
"Run sudo rm -rf /usr/share/dotnet && sudo rm -rf /opt/ghc && sudo rm -rf "/usr/local/share/boost" && sudo rm -rf "$AGENT_TOOLSDIRECTORY" /__w/_temp/f7307c65-f24c-404d-a4a2-8e327e69ce19.sh: line 1: sudo: command not found"
```

ref:
- https://github.com/scientist-softserv/palni-palci/actions/runs/8840191966/job/24275038076
- https://github.com/scientist-softserv/actions/compare/remove-sudo-from-setup-env?expand=1

# Story

Refs #issuenumber

# Expected Behavior Before Changes

# Expected Behavior After Changes

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes
