### PR TITLE
i1040 Propagate locale between group form tabs

### DIFF
--- a/app/presenters/hyku/admin/group/navigation_presenter.rb
+++ b/app/presenters/hyku/admin/group/navigation_presenter.rb
@@ -27,7 +27,7 @@ module Hyku
               name: I18n.t('hyku.admin.groups.nav.attributes'),
               controller: 'admin/groups',
               action: 'edit',
-              path: Rails.application.routes.url_helpers.edit_admin_group_path(group_id),
+              path: Rails.application.routes.url_helpers.edit_admin_group_path(group_id, locale: I18n.locale),
               context: params
             )
           end
@@ -37,7 +37,7 @@ module Hyku
               name: I18n.t('hyku.admin.groups.nav.members'),
               controller: 'admin/group_users',
               action: 'index',
-              path: Rails.application.routes.url_helpers.admin_group_users_path(group_id),
+              path: Rails.application.routes.url_helpers.admin_group_users_path(group_id, locale: I18n.locale),
               context: params
             )
           end
@@ -47,7 +47,7 @@ module Hyku
               name: I18n.t('hyku.admin.groups.nav.roles'),
               controller: 'admin/group_roles',
               action: 'index',
-              path: Rails.application.routes.url_helpers.admin_group_roles_path(group_id),
+              path: Rails.application.routes.url_helpers.admin_group_roles_path(group_id, locale: I18n.locale),
               context: params
             )
           end
@@ -57,7 +57,7 @@ module Hyku
               name: I18n.t('hyku.admin.groups.nav.delete'),
               controller: 'admin/groups',
               action: 'remove',
-              path: Rails.application.routes.url_helpers.remove_admin_group_path(group_id),
+              path: Rails.application.routes.url_helpers.remove_admin_group_path(group_id, locale: I18n.locale),
               context: params
             )
           end


### PR DESCRIPTION
# Story

Ref:
- #1040 

This is a UX improvement. However, it also fixes a bug where some users were getting an error message on these pages for the locale param being an empty string (`?locale=`). Strangely, this only appeared to be affecting users using Windows, but that may not be causation.

# Expected Behavior Before Changes

The `locale` URL param is lost when clicking any of the tabs on the Group form. This was causing errors for some users who were somehow getting `?locale=` 

# Expected Behavior After Changes

The `locale` URL param is persisted when clicking any of the tabs on the Group form. Errors related to `locale` being empty should now be impossible 

# Screenshots / Video

![Edit Group Administration Hyku Commons 2024-06-27 at 5 21 28 PM](https://github.com/scientist-softserv/palni-palci/assets/32469930/8174c361-1e11-4bf1-b0b9-c2e6639a2692)
