### PR TITLE
i1046-admin-can-deposit-works-into-collections-to-main

### DIFF
--- a/app/controllers/hyrax/my/works_controller_decorator.rb
+++ b/app/controllers/hyrax/my/works_controller_decorator.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 # OVERRIDE Hyrax 3.6.0 to add custom sort fields while in the dashboard for works
+# OVERRIDE Hyrax 3.5.0 to update collections_service method to remove all params
 
 module Hyrax
   module My
-    module WorksControllerDecorator
+    module WorksControllerClassDecorator
       def configure_facets
         configure_blacklight do |config|
           # clear facets copied from the CatalogController
@@ -22,8 +23,20 @@ module Hyrax
         end
       end
     end
+
+    module WorksControllerDecorator
+      # OVERRIDE FROM HYRAX: CAN REMOVE AT 4.0
+      # https://github.com/samvera/hyrax/pull/5972
+      def collections_service
+        cloned = clone
+        cloned.params = {}
+        Hyrax::CollectionsService.new(cloned)
+      end
+    end
   end
 end
 
-Hyrax::My::WorksController.singleton_class.send(:prepend, Hyrax::My::WorksControllerDecorator)
+Hyrax::My::WorksController.singleton_class.send(:prepend, Hyrax::My::WorksControllerClassDecorator)
 Hyrax::My::WorksController.configure_facets
+
+Hyrax::My::WorksController.prepend(Hyrax::My::WorksControllerDecorator)


### PR DESCRIPTION
update the works controller decorator to remove params in collections_service method

# Story
https://assaydepot.slack.com/archives/C0313NKC08L/p1721066260232569

A user is reporting an issue depositing works into collections they should have access to (as an admin).

This is on [wabash.hykucommons.org](http://wabash.hykucommons.org/)

Refs #1046 

# Expected Behavior Before Changes
An admin could not add a work that they searched to a collection from the collection "Adds existing works to collection"
An admin could not add a work they searched for in the my/works page through the "Add to Collection button"

# Expected Behavior After Changes
An admin can add a work that they searched to a collection from the collection "Adds existing works to collection"
An admin can add a work they searched for in the my/works page through the "Add to Collection button"

# Screenshots / Video
Video of local demo of fix: https://share.zight.com/eDuKOD28

<details>
<summary>Click for BEFORE FIX Screenshots</summary>
Before:
<img width="1221" alt="Screenshot 2024-07-22 at 15 09 19" src="https://github.com/user-attachments/assets/bcea43e7-187c-439a-a8f4-39e0f8ce41ef">
<img width="1222" alt="Screenshot 2024-07-22 at 15 10 29" src="https://github.com/user-attachments/assets/dfba9024-1fc1-4293-975a-ac6bb019f676">

</details>
