### PR TITLE
i1051 Set :post as default Solr HTTP method

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -26,6 +26,9 @@ class CatalogController < ApplicationController
   include BlacklightIiifSearch::Controller
 
   configure_blacklight do |config|
+    # TODO: Replace with Hyrax.config.solr_default_method when upgrading to >= Hyrax v4.0.0
+    config.http_method = :post
+
     # IiifPrint index fields
     config.add_index_field 'all_text_tsimv', highlight: true, helper_method: :render_ocr_snippets
 


### PR DESCRIPTION
Ref:
- #1051 
- https://github.com/samvera/hyrax/pull/4728
- https://github.com/samvera/hyrax/pull/5937

# Story

`:post` has a higher character limit than the default (`:get`)

# Expected Behavior Before Changes

All pages that query which Collections a user has access to will throw a `RSolr::Error::Http - 414 Request-URI Too Long` error. These include (but may not be limited to):

- Dashboard "All Collections" view 
- Dashboard Collection show page 
  - "Add a subcollection" modal populates a list of accessible collections 
- Collection show page (if the user has manage permissions) 
  - "Add to collection" modal populates a list of accessible collections 

# Expected Behavior After Changes

All pages that query which Collections a user has access to will no longer throw a `RSolr::Error::Http - 414 Request-URI Too Long` error. 

# Notes

A hotfix for this has been applied to the running production pods 