### PR TITLE
i1053 update ruby-saml gem version to get security fix

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,6 +263,7 @@ GEM
     bagit (0.4.6)
       docopt (~> 0.5.0)
       validatable (~> 1.6)
+    base64 (0.2.0)
     bcp47 (0.3.3)
       i18n
     bcrypt (3.1.18)
@@ -898,7 +899,7 @@ GEM
     oj (3.13.21)
     oj_mimic_json (1.0.1)
     okcomputer (1.18.4)
-    omniauth (2.1.1)
+    omniauth (2.1.2)
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
       rack-protection
@@ -990,15 +991,16 @@ GEM
       rails (>= 5.0, < 7.1)
       rdf
     raabro (1.4.0)
-    racc (1.7.1)
-    rack (2.2.8)
+    racc (1.8.1)
+    rack (2.2.9)
     rack-oauth2 (1.21.3)
       activesupport
       attr_required
       httpclient
       json-jwt (>= 1.11.0)
       rack (>= 2.1.0)
-    rack-protection (3.1.0)
+    rack-protection (3.2.0)
+      base64 (>= 0.1.0)
       rack (~> 2.2, >= 2.2.4)
     rack-test (0.7.0)
       rack (>= 1.0, < 3)
@@ -1139,7 +1141,7 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     retriable (3.1.2)
-    rexml (3.2.6)
+    rexml (3.3.7)
     riiif (1.7.1)
       deprecation (>= 1.0.0)
       railties (>= 4.2, < 6)
@@ -1194,7 +1196,7 @@ GEM
       multipart-post
       oauth2
     ruby-progressbar (1.13.0)
-    ruby-saml (1.15.0)
+    ruby-saml (1.17.0)
       nokogiri (>= 1.13.10)
       rexml
     ruby2_keywords (0.0.5)


### PR DESCRIPTION
# Story

Ref:
- #1053 

This is in response to [CVE-2024-45409](https://nvd.nist.gov/vuln/detail/CVE-2024-45409)