### PR TITLE
i1063-fix-tenants-rake

### DIFF
--- a/lib/tasks/tenants.rake
+++ b/lib/tasks/tenants.rake
@@ -5,7 +5,7 @@ namespace :tenants do
   task calculate_usage: :environment do
     @results = []
     Account.where(search_only: false).find_each do |account|
-      next unless account.cname.present? # Skip accounts without a cname
+      next if account.cname.blank?
 
       AccountElevator.switch!(account.cname)
       puts "---------------#{account.cname}-------------------------"

--- a/lib/tasks/tenants.rake
+++ b/lib/tasks/tenants.rake
@@ -1,55 +1,72 @@
 # frozen_string_literal: true
 
+# Temporarily disable Sentry for this task
+Raven.configure do |config|
+  config.silence_ready = true
+end
+
 namespace :tenants do
-  # how much space, works, files, per each tenant?
+  # How much space, works, files, per each tenant?
   task calculate_usage: :environment do
-    @results = []
-    Account.where(search_only: false).find_each do |account|
-      if account.cname.present?
+    begin
+      @results = []
+      Account.where(search_only: false).find_each do |account|
+        next unless account.cname.present? # Skip accounts without a cname
+
         AccountElevator.switch!(account.cname)
         puts "---------------#{account.cname}-------------------------"
+
         models = Hyrax.config.curation_concerns.map { |m| "\"#{m}\"" }
         works = ActiveFedora::SolrService.query("has_model_ssim:(#{models.join(' OR ')})", rows: 100_000)
+
         if works&.any?
           puts "#{works.count} works found"
-          @tenant_file_sizes = []
+          tenant_file_sizes = [] # Declare and initialize within the block
+
           works.each do |work|
-            document = SolrDocument.find(work.id)
-            files = document._source["file_set_ids_ssim"]
-            if files&.any?
-              file_sizes = []
-              files.each do |file|
-                f = SolrDocument.find(file.to_s)
-                if file
-                  file_sizes.push(f.to_h['file_size_lts']) unless f.to_h['file_size_lts'].nil?
-                else
-                  files_sizes.push(0)
-                 end
-              end
-              if file_sizes.any?
-                file_sizes_total_bytes = file_sizes.inject(0, :+)
-                file_size_total = (file_sizes_total_bytes / 1.0.megabyte).round(2)
+            begin
+              document = SolrDocument.find(work.id)
+              files = document._source["file_set_ids_ssim"] || []
+
+              if files.any?
+                file_sizes = files.map do |file|
+                  begin
+                    f = SolrDocument.find(file.to_s)
+                    f.to_h['file_size_lts'] || 0
+                  rescue Blacklight::Exceptions::RecordNotFound => e
+                    puts "Warning: File #{file} not found. Skipping. Error: #{e.message}"
+                    0
+                  end
+                end
+
+                total_file_size_bytes = file_sizes.inject(0, :+)
+                tenant_file_sizes << (total_file_size_bytes / 1.0.megabyte).round(2)
               else
-                file_size_total = 0
+                tenant_file_sizes << 0
               end
-              @tenant_file_sizes.push(file_size_total)
-            else
-              @tenant_file_sizes.push(0)
+            rescue Blacklight::Exceptions::RecordNotFound => e
+              puts "Warning: Work #{work.id} not found. Skipping. Error: #{e.message}"
+              tenant_file_sizes << 0
             end
           end
-          if @tenant_file_sizes
-            tenant_file_sizes_total_megabytes = @tenant_file_sizes.inject(0, :+)
-            @results.push("#{account.cname}: #{tenant_file_sizes_total_megabytes} Total MB / #{works.count} Works")
-          else
-            @results.push("#{account.cname}: 0 Total MB / #{works.count} Works")
-          end
+
+          total_mb = tenant_file_sizes.inject(0, :+)
+          @results << "#{account.cname}: #{total_mb} Total MB / #{works.count} Works"
         else
-          @results.push("#{account.cname}: 0 Total MB / 0 Works")
+          @results << "#{account.cname}: 0 Total MB / 0 Works"
         end
+
         puts "=================================================================="
-        @results.each do |result|
-          puts result
-        end
+      end
+
+      # Output results
+      @results.each do |result|
+        puts result
+      end
+    ensure
+      # Re-enable Sentry after the task
+      Raven.configure do |config|
+        config.silence_ready = false
       end
     end
   end

--- a/lib/tasks/tenants.rake
+++ b/lib/tasks/tenants.rake
@@ -1,73 +1,61 @@
 # frozen_string_literal: true
 
-# Temporarily disable Sentry for this task
-Raven.configure do |config|
-  config.silence_ready = true
-end
-
 namespace :tenants do
   # How much space, works, files, per each tenant?
   task calculate_usage: :environment do
-    begin
-      @results = []
-      Account.where(search_only: false).find_each do |account|
-        next unless account.cname.present? # Skip accounts without a cname
+    @results = []
+    Account.where(search_only: false).find_each do |account|
+      next unless account.cname.present? # Skip accounts without a cname
 
-        AccountElevator.switch!(account.cname)
-        puts "---------------#{account.cname}-------------------------"
+      AccountElevator.switch!(account.cname)
+      puts "---------------#{account.cname}-------------------------"
 
-        models = Hyrax.config.curation_concerns.map { |m| "\"#{m}\"" }
-        works = ActiveFedora::SolrService.query("has_model_ssim:(#{models.join(' OR ')})", rows: 100_000)
+      models = Hyrax.config.curation_concerns.map { |m| "\"#{m}\"" }
+      works = ActiveFedora::SolrService.query("has_model_ssim:(#{models.join(' OR ')})", rows: 100_000)
 
-        if works&.any?
-          puts "#{works.count} works found"
-          tenant_file_sizes = [] # Declare and initialize within the block
+      if works&.any?
+        puts "#{works.count} works found"
+        tenant_file_sizes = [] # Declare and initialize within the block
 
-          works.each do |work|
-            begin
-              document = SolrDocument.find(work.id)
-              files = document._source["file_set_ids_ssim"] || []
+        works.each do |work|
+          begin
+            document = SolrDocument.find(work.id)
+            files = document._source["file_set_ids_ssim"] || []
 
-              if files.any?
-                file_sizes = files.map do |file|
-                  begin
-                    f = SolrDocument.find(file.to_s)
-                    f.to_h['file_size_lts'] || 0
-                  rescue Blacklight::Exceptions::RecordNotFound => e
-                    puts "Warning: File #{file} not found. Skipping. Error: #{e.message}"
-                    0
-                  end
+            if files.any?
+              file_sizes = files.map do |file|
+                begin
+                  f = SolrDocument.find(file.to_s)
+                  f.to_h['file_size_lts'] || 0
+                rescue Blacklight::Exceptions::RecordNotFound => e
+                  puts "Warning: File #{file} not found. Skipping. Error: #{e.message}"
+                  0
                 end
-
-                total_file_size_bytes = file_sizes.inject(0, :+)
-                tenant_file_sizes << (total_file_size_bytes / 1.0.megabyte).round(2)
-              else
-                tenant_file_sizes << 0
               end
-            rescue Blacklight::Exceptions::RecordNotFound => e
-              puts "Warning: Work #{work.id} not found. Skipping. Error: #{e.message}"
+
+              total_file_size_bytes = file_sizes.inject(0, :+)
+              tenant_file_sizes << (total_file_size_bytes / 1.0.megabyte).round(2)
+            else
               tenant_file_sizes << 0
             end
+          rescue Blacklight::Exceptions::RecordNotFound => e
+            puts "Warning: Work #{work.id} not found. Skipping. Error: #{e.message}"
+            tenant_file_sizes << 0
           end
-
-          total_mb = tenant_file_sizes.inject(0, :+)
-          @results << "#{account.cname}: #{total_mb} Total MB / #{works.count} Works"
-        else
-          @results << "#{account.cname}: 0 Total MB / 0 Works"
         end
 
-        puts "=================================================================="
+        total_mb = tenant_file_sizes.inject(0, :+)
+        @results << "#{account.cname}: #{total_mb} Total MB / #{works.count} Works"
+      else
+        @results << "#{account.cname}: 0 Total MB / 0 Works"
       end
 
-      # Output results
-      @results.each do |result|
-        puts result
-      end
-    ensure
-      # Re-enable Sentry after the task
-      Raven.configure do |config|
-        config.silence_ready = false
-      end
+      puts "=================================================================="
+    end
+
+    # Output results
+    @results.each do |result|
+      puts result
     end
   end
 end


### PR DESCRIPTION
#1063 

Updates the tenants.rake to:
- turn off sentry reporting during the task and then re-enables at the end
- add graceful error handling in order to get the tenants data for client
 