### PR TITLE
i1066 Fix member pagination on OER show pages

### DIFF
--- a/app/views/hyrax/oers/_related_items.html.erb
+++ b/app/views/hyrax/oers/_related_items.html.erb
@@ -32,7 +32,7 @@
   <div class="row">
     <% if presenter.total_pages > 1 %>
         <div class="row record-padding col-md-9">
-          <%= paginate array_of_ids, outer_window: 2, theme: 'blacklight', param_name: :page, route_set: main_app %>
+          <%= paginate presenter.list_of_item_ids_to_display, outer_window: 2, theme: 'blacklight', param_name: :page, route_set: main_app %>
         </div><!-- /pager -->
     <% end %>
   </div>

--- a/app/views/themes/cultural_show/hyrax/oers/_related_items.html.erb
+++ b/app/views/themes/cultural_show/hyrax/oers/_related_items.html.erb
@@ -21,7 +21,7 @@
   <div class="row">
     <% if presenter.total_pages > 1 %>
         <div class="row record-padding col-md-9">
-          <%= paginate array_of_ids, outer_window: 2, theme: 'blacklight', param_name: :page, route_set: main_app %>
+          <%= paginate presenter.list_of_item_ids_to_display, outer_window: 2, theme: 'blacklight', param_name: :page, route_set: main_app %>
         </div><!-- /pager -->
     <% end %>
   </div>


### PR DESCRIPTION
Ref:
- #1066 

# Story

Pagination was attempting to act upon a local variable that didn't exist; it was removed in this commit:
- fbe9093

Replace it with the presenter method that Hyrax typically uses to display member presenters

# Expected Behavior Before Changes

Viewing the show page of an OER work that has 11+ members (e.g. FileSets) throws a 500 error 

# Expected Behavior After Changes

OER members display in a paginated list 

# Screenshots / Video

<details>
<summary>Paginated members</summary>

<img width="1193" alt="image" src="https://github.com/user-attachments/assets/d5255a95-cf17-4a1f-adc9-fb048d8bbc9b" />


</details>

# Notes

This change needs to be contributed back to Hyku:
- https://github.com/samvera/hyku/pull/2407